### PR TITLE
fix: surface last synced timestamp on zoom connection card (#9)

### DIFF
--- a/backend/controllers/zoomAuthController.ts
+++ b/backend/controllers/zoomAuthController.ts
@@ -187,10 +187,27 @@ export async function zoomStatus(req: Request, res: Response): Promise<void> {
 
   const hasCredentials = !!(process.env.ZOOM_CLIENT_ID && process.env.ZOOM_CLIENT_SECRET);
 
+  // Query the latest successfully completed ZoomMeeting for this user
+  // to surface "Last synced" on the frontend connection card (issue #9).
+  let lastSyncedAt: Date | null = null;
+  if (user?.zoomConnected) {
+    const latestMeeting = await ZoomMeeting.findOne(
+      { userId: user._id, status: 'completed' },
+      { processingCompletedAt: 1, updatedAt: 1 },
+    )
+      .sort({ processingCompletedAt: -1 })
+      .lean();
+
+    lastSyncedAt = latestMeeting?.processingCompletedAt
+      ?? (latestMeeting as any)?.updatedAt
+      ?? null;
+  }
+
   res.json({
-    connected:   user?.zoomConnected ?? false,
-    connectedAt: user?.zoomConnectedAt,
-    zoomUserId:  user?.zoomUserId,
+    connected:    user?.zoomConnected ?? false,
+    connectedAt:  user?.zoomConnectedAt,
+    zoomUserId:   user?.zoomUserId,
+    lastSyncedAt,
     hasCredentials,
   });
 }

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -13,6 +13,7 @@ interface ZoomStatus {
   connected: boolean;
   connectedAt?: string;
   zoomUserId?: string;
+  lastSyncedAt?: string;
 }
 
 export default function AccountPage() {
@@ -314,6 +315,23 @@ export default function AccountPage() {
     ? new Date(zoomStatus.connectedAt).toLocaleDateString()
     : null;
 
+  // Relative time label for last sync (issue #9)
+  const formatRelativeTime = (dateStr?: string): string | null => {
+    if (!dateStr) return null;
+    const diff = Date.now() - new Date(dateStr).getTime();
+    if (diff < 0) return 'just now';
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return new Date(dateStr).toLocaleDateString();
+  };
+  const lastSyncedLabel = formatRelativeTime(zoomStatus?.lastSyncedAt);
+
   return (
     <div className="min-h-screen bg-bg">
       <Navbar />
@@ -545,6 +563,14 @@ export default function AccountPage() {
                       ? `Connected · since ${zoomConnectedAt}`
                       : 'Connect to auto-import meeting transcripts'}
                   </p>
+                  {zoomStatus?.connected && lastSyncedLabel && (
+                    <p className="text-[11px] text-ink-faint mt-0.5 flex items-center gap-1">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-emerald-500 shrink-0">
+                        <polyline points="20 6 9 17 4 12"/>
+                      </svg>
+                      Last synced: {lastSyncedLabel}
+                    </p>
+                  )}
                 </div>
               </div>
 


### PR DESCRIPTION
## Description
Fixes #9 
This PR addresses the missing "Last synced" timestamp on the Zoom integration connection card within the admin dashboard (`AccountPage.tsx`). Previously, admins could only see when the Zoom account was initially connected, making it difficult to confirm if automated transcript ingestion was actively running and succeeding.
## Changes Made
- **Backend** (`zoomAuthController.ts`): Updated the `GET /api/zoom/auth/status` endpoint to additionally query for the most recent successfully completed `ZoomMeeting` for the authenticated user. Surfaces this timestamp as `lastSyncedAt`.
- **Frontend** (`AccountPage.tsx`): 
  - Added `lastSyncedAt` to the `ZoomStatus` interface.
  - Implemented a `formatRelativeTime` helper to convert timestamps into human-readable relative formats (e.g., "just now", "3m ago", "2h ago").
  - Updated the UI on the Zoom connection card to display the "Last synced" time below the connection status when applicable.
## Verification
- Compiled cleanly via `tsc` on both frontend and backend workspaces.
- Logic verified via local DB queries to ensure correct lookup of the latest completed `ZoomMeeting`.
- Passed the existing `zoom.spec.ts` end-to-end Playwright tests confirming no regressions to the manual ingestion pipeline.