### PR TITLE
fix: remove broken unique index on upvotes array preventing multi-post voting (#13)

### DIFF
--- a/backend/models/CommunityPost.ts
+++ b/backend/models/CommunityPost.ts
@@ -305,8 +305,8 @@ communityPostSchema.index({ title: 'text', body: 'text' });
 // Time-Trial activation scheduler
 communityPostSchema.index({ status: 1, timeTrialStatus: 1, createdAt: 1 });
 communityPostSchema.index({ status: 1, aiAnswerStatus: 1, createdAt: 1 });
-// Prevent duplicate upvotes: each user can only appear once in the upvotes array
-communityPostSchema.index({ upvotes: 1 }, { unique: true, sparse: true });
+// Index for upvote queries (uniqueness per-post is enforced by $addToSet in controller)
+communityPostSchema.index({ upvotes: 1 }, { sparse: true });
 // Promotion query indexes
 communityPostSchema.index({ eligibleForPromotion: 1, promotionPendingAt: 1 });
 communityPostSchema.index({ status: 1, eligibleForPromotion: 1 });

--- a/backend/scripts/drop-upvotes-unique-index.ts
+++ b/backend/scripts/drop-upvotes-unique-index.ts
@@ -1,0 +1,50 @@
+/**
+ * Migration: Drop the broken unique index on the `upvotes` array field.
+ *
+ * Issue #13 — the unique constraint on a multikey (array) index prevents
+ * a user from upvoting more than one post across the entire collection.
+ * The schema definition has been fixed, but any existing MongoDB deployment
+ * will still have the old unique index in place until it is explicitly
+ * dropped.  This script does that.
+ *
+ * Usage:
+ *   npx tsx scripts/drop-upvotes-unique-index.ts
+ */
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const COLLECTION = 'yaksha_faq_communityposts';
+
+async function run() {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/cs15';
+  await mongoose.connect(uri);
+  console.log(`Connected to ${uri}`);
+
+  const db = mongoose.connection.db!;
+  const col = db.collection(COLLECTION);
+
+  // List current indexes
+  const indexes = await col.indexes();
+  const upvoteIdx = indexes.find(
+    (idx) =>
+      idx.key && 'upvotes' in idx.key && idx.unique === true
+  );
+
+  if (!upvoteIdx) {
+    console.log('✔  No unique index on upvotes found — nothing to do.');
+  } else {
+    console.log(`Found unique index "${upvoteIdx.name}" — dropping…`);
+    await col.dropIndex(upvoteIdx.name!);
+    console.log('✔  Unique index dropped successfully.');
+  }
+
+  await mongoose.disconnect();
+  console.log('Done.');
+}
+
+run().catch((err) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description
Fixes #13
This PR fixes a critical bug where users were unable to upvote more than one community post. The root cause was a `unique: true` constraint on the `upvotes` array in the `CommunityPost` model. Because MongoDB enforces uniqueness globally across a multikey index, a user's ID could only exist in the `upvotes` array of *one single post* across the entire database, throwing a duplicate key error on subsequent votes.
## Changes Made
- **`backend/models/CommunityPost.ts`**: Removed the `unique: true` constraint from the `upvotes` index. The `$addToSet` operator in the controller already guarantees per-post upvote uniqueness at the application level.
- **`backend/scripts/drop-upvotes-unique-index.ts`**: Added a dedicated migration script to safely drop the existing broken index from any deployed database, since changing the Mongoose schema does not automatically drop existing unique indexes.
## Deployment Notes
After deploying this code, you **must** run the following script against the production database to drop the stale index:
```bash
npx tsx scripts/drop-upvotes-unique-index.ts