### PR TITLE
fix: replace dynamic require('mongoose') with imported Types to fix ESM crash (#15)

### DIFF
--- a/backend/controllers/autoAnswerController.ts
+++ b/backend/controllers/autoAnswerController.ts
@@ -227,7 +227,7 @@ async function processPost(post: InstanceType<typeof CommunityPost>): Promise<vo
               {
                 from: post.lifecycle?.status ?? 'open',
                 to: 'answered',
-                changedBy: new (require('mongoose').Types.ObjectId)('000000000000000000000000'),
+                changedBy: new Types.ObjectId('000000000000000000000000'),
                 changedAt: new Date(),
                 note: `AI auto-answered from ${source}`,
               },


### PR DESCRIPTION
## Summary

The auto-approval workflow in `autoAnswerController.ts` used a dynamic
CommonJS `require('mongoose')` call to construct a sentinel ObjectId.
Under native ESM (`type: module`) this throws:

```
ReferenceError: require is not defined
```

The file already had `Types` imported from `mongoose` at line 25.
This PR replaces the `require` call with the already-imported `Types.ObjectId`.

## Changes

- `backend/controllers/autoAnswerController.ts` — one-line replacement:
  `require('mongoose').Types.ObjectId` → `Types.ObjectId`

## Constraints honored

- ❌ No database schemas modified
- ❌ No models modified
- ❌ No migrations modified
- ❌ No ObjectId values changed
- ❌ No business logic altered
- ❌ No new dependencies added
- ✅ Minimal, maintainable fix

Closes #15