### PR TITLE
fix: return 403 for authorization failures

### DIFF
--- a/backend/__tests__/authorize.test.ts
+++ b/backend/__tests__/authorize.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import { authorize, type AuthedRequest } from '../middleware/authShared.js';
+
+function createResponse() {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { response: { status } as unknown as Response, status, json };
+}
+
+describe('authorize', () => {
+  it('returns 403 without calling next when the user lacks an allowed role', () => {
+    const req = { user: { role: 'user' } } as unknown as AuthedRequest;
+    const { response, status, json } = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    authorize('admin', 'moderator')(req as Request, response, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({ message: 'Insufficient permissions.' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next without writing a response when the user has an allowed role', () => {
+    const req = { user: { role: 'moderator' } } as unknown as AuthedRequest;
+    const { response, status, json } = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    authorize('admin', 'moderator')(req as Request, response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/backend/middleware/authShared.ts
+++ b/backend/middleware/authShared.ts
@@ -65,14 +65,13 @@ export async function verifyAndLoadUser(
 }
 
 /**
- * Standalone role guard — used by `authorize(...roles)`. Throws on failure
- * so the global error handler can format the response.
+ * Standalone role guard used by `authorize(...roles)`.
  */
-export function authorize(...allowedRoles: UserRole[]): (req: Request, _res: Response, next: NextFunction) => void {
-  return (req: Request, _res: Response, next: NextFunction): void => {
+export function authorize(...allowedRoles: UserRole[]): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction): void => {
     const role = (req as AuthedRequest).user?.role as UserRole | undefined;
     if (!role || !allowedRoles.includes(role)) {
-      next(new Error('Insufficient permissions.'));
+      res.status(403).json({ message: 'Insufficient permissions.' });
       return;
     }
     next();


### PR DESCRIPTION
Fixes #31

Authorization failures now return HTTP 403 Forbidden instead of HTTP 500 Internal Server Error.

Changes:

* Updated authorization middleware to return 403 directly.
* Added regression tests covering authorized and unauthorized roles.

Verification:

* Backend tests passed.
* TypeScript build passed.

