### PR TITLE
fix: add missing comment edit/delete routes

### DIFF
--- a/backend/routes/community.ts
+++ b/backend/routes/community.ts
@@ -65,6 +65,8 @@ router.post('/:id/comments/:commentId/upvote', protect, toggleCommentUpvote);
 router.post('/:id/comments/:commentId/downvote', protect, toggleCommentDownvote);
 router.patch('/:id/comments/:commentId/verify', protect, authorize('admin', 'moderator'), verifyComment);
 router.patch('/:id/comments/:commentId/accept-answer', protect, acceptCommentAnswer);
+router.patch('/:id/comments/:commentId', protect, updateComment);
+router.delete('/:id/comments/:commentId', protect, deleteComment);
 router.patch('/:id/comments/:commentId/dna', protect, authorize('admin', 'moderator'), setCommentDNA);
 router.delete('/:id/comments/:commentId/dna', protect, authorize('admin', 'moderator'), clearCommentDNA);
 router.patch('/:id/resolve', protect, validateBody(resolvePostSchema), resolvePost);


### PR DESCRIPTION
Fixes #42

Added the missing comment edit and delete routes in backend/routes/community.ts.

Changes:

Registered PATCH /api/community/:id/comments/:commentId
Registered DELETE /api/community/:id/comments/:commentId
Both routes use the existing protect middleware

This enables the frontend comment edit and delete actions to reach the existing controller implementations instead of returning 404.