### PR TITLE
fix: block banned suspended and deleted users

### DIFF
--- a/backend/middleware/authShared.ts
+++ b/backend/middleware/authShared.ts
@@ -59,6 +59,21 @@ export async function verifyAndLoadUser(
     return null;
   }
 
+  if (user.isBanned) {
+    res.status(403).json({ message: 'Account is banned.' });
+    return null;
+  }
+
+  if (user.isDeleted) {
+    res.status(403).json({ message: 'Account has been deleted.' });
+    return null;
+  }
+
+  if (user.suspendedUntil && user.suspendedUntil > new Date()) {
+    res.status(403).json({ message: `Account is suspended until ${user.suspendedUntil.toISOString()}.` });
+    return null;
+  }
+
   req.user = user as IUser;
   req.auth = decoded;
   return user as IUser;


### PR DESCRIPTION
Fixes #26

Added account status checks in verifyAndLoadUser().

Changes:
- Return 403 for banned users
- Return 403 for deleted users
- Return 403 for users with active suspensions

This prevents moderated accounts from continuing to access protected APIs using previously issued JWTs.