### PR TITLE
fix: wire unused Zod validation schemas into reputation and moderation routes

### DIFF
--- a/backend/routes/moderation.ts
+++ b/backend/routes/moderation.ts
@@ -1,17 +1,18 @@
 import { Router } from 'express';
 import { adminOnly } from '../middleware/admin.js';
 import { banUser, unbanUser, suspendUser, unsuspendUser, warnUser, softDeleteUser, getModerationLogs, getModerationQueue } from '../controllers/moderationController.js';
+import { validateBody, banUserSchema, suspendUserSchema, warnUserSchema, softDeleteSchema } from '../utils/validation.js';
 
 const router = Router();
 router.use(adminOnly);
 
 router.get('/queue', getModerationQueue);
 router.get('/logs', getModerationLogs);
-router.post('/ban', banUser);
-router.post('/unban', unbanUser);
-router.post('/suspend', suspendUser);
-router.post('/unsuspend', unsuspendUser);
-router.post('/warn', warnUser);
-router.post('/soft-delete', softDeleteUser);
+router.post('/ban', validateBody(banUserSchema), banUser);
+router.post('/unban', validateBody(banUserSchema), unbanUser);
+router.post('/suspend', validateBody(suspendUserSchema), suspendUser);
+router.post('/unsuspend', validateBody(softDeleteSchema), unsuspendUser);
+router.post('/warn', validateBody(warnUserSchema), warnUser);
+router.post('/soft-delete', validateBody(softDeleteSchema), softDeleteUser);
 
 export default router;

--- a/backend/routes/reputation.ts
+++ b/backend/routes/reputation.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { adminOnly } from '../middleware/admin.js';
 import { awardPoints, getUserReputation, issueBadge, revokeBadge, getLeaderboard } from '../controllers/reputationController.js';
+import { validateBody, awardPointsSchema, issueBadgeSchema } from '../utils/validation.js';
 
 const router = Router();
 
@@ -10,8 +11,8 @@ router.get('/leaderboard', getLeaderboard);
 router.use(adminOnly);
 
 router.get('/user/:userId', getUserReputation);
-router.post('/points', awardPoints);
-router.post('/badge/issue', issueBadge);
-router.post('/badge/revoke', revokeBadge);
+router.post('/points', validateBody(awardPointsSchema), awardPoints);
+router.post('/badge/issue', validateBody(issueBadgeSchema), issueBadge);
+router.post('/badge/revoke', validateBody(issueBadgeSchema), revokeBadge);
 
 export default router;


### PR DESCRIPTION
## Summary

Import and apply `validateBody()` middleware with the corresponding Zod schemas on all POST routes in `backend/routes/reputation.ts` and `backend/routes/moderation.ts`.

## Problem

The Zod validation schemas (`awardPointsSchema`, `issueBadgeSchema`, `banUserSchema`, `suspendUserSchema`, `warnUserSchema`, `softDeleteSchema`) were defined in `utils/validation.ts` but never imported or used in the reputation and moderation route files. This meant request bodies for these admin endpoints were unvalidated, allowing malformed or malicious payloads through.

## Changes

### `backend/routes/reputation.ts`
- Added `validateBody(awardPointsSchema)` to POST /points
- Added `validateBody(issueBadgeSchema)` to POST /badge/issue
- Added `validateBody(issueBadgeSchema)` to POST /badge/revoke

### `backend/routes/moderation.ts`
- Added `validateBody(banUserSchema)` to POST /ban and POST /unban
- Added `validateBody(suspendUserSchema)` to POST /suspend
- Added `validateBody(softDeleteSchema)` to POST /unsuspend and POST /soft-delete
- Added `validateBody(warnUserSchema)` to POST /warn

Closes #19
