### PR TITLE
fix(embeddings): retry-once wrapper for HF Inference API aborts/5xx/429

### DIFF
--- a/backend/utils/ai/embeddings.ts
+++ b/backend/utils/ai/embeddings.ts
@@ -36,6 +36,7 @@ import {
   FeatureExtractionPipeline,
   env as transformersEnv,
 } from '@huggingface/transformers';
+import { logger } from '../http/logger.js';
 
 export const MODEL_SLUG = 'mixedbread-ai/mxbai-embed-large-v1';
 export const EMBEDDING_DIM = 1024;
@@ -76,67 +77,135 @@ function shouldUseHfApi(): boolean {
  *
  * We detect the shape and either normalize the pooled result
  * or do CLS pooling + normalize the hidden states.
+ *
+ * v1.70 — Retry wrapper for transient failures.
+ *
+ * The HF Inference API occasionally aborts mid-request during
+ * concurrent-burst conditions (cron startup fires categoryCluster +
+ * faqAudit + autoAnswer + popularity simultaneously, easily
+ * exceeding the free-tier per-minute rate limit). Node's undici
+ * surfaces those as AbortError (err.code === 20, err.name ===
+ * 'AbortError', message === 'This operation was aborted'). The
+ * 30s timeout here is the upper bound, NOT the abort cause —
+ * warm HF calls complete in ~0.3s.
+ *
+ * We retry once on transient failures with 500ms backoff:
+ *   - AbortError (network/keep-alive/rate-limit-disconnect)
+ *   - HTTP 429 (rate-limited — worth backing off and retrying)
+ *   - HTTP 5xx (transient server error)
+ * We do NOT retry:
+ *   - HTTP 4xx other than 429 (real bug — surface it)
+ *   - JSON parse errors (model returned garbage — surface it)
+ *
+ * The retry budget is intentionally small: 1 extra attempt. If HF
+ * is genuinely down, callers fall through to their existing
+ * graceful-degradation paths (empty results, keyword fallback).
+ * Bumping retries higher would just add latency to the failure path.
  */
+const HF_MAX_RETRIES = 2;          // first attempt + 1 retry
+const HF_TIMEOUT_MS  = 30_000;     // per-attempt ceiling
+const HF_RETRY_DELAY_MS = 500;     // backoff between attempts
+
 async function callHfApiEmbedding(text: string): Promise<number[]> {
   const apiKey = getHfApiKey();
   if (!apiKey) {
     throw new Error('HUGGINGFACE_API_KEY is not set');
   }
   const url = `${HF_API_BASE}/${MODEL_SLUG}`;
-  const controller = new AbortController();
-  const t = setTimeout(() => controller.abort(), 30_000);  // 30s timeout
-  try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        inputs: text,
-        options: { wait_for_model: true, use_cache: true },
-      }),
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      const errText = await res.text();
-      throw new Error(`HF Inference API ${res.status}: ${errText}`);
-    }
-    const data = await res.json();
-    // v1.68.1 — the new router endpoint returns a FLAT
-    // 1D array of 1024 numbers (not a 2D nested array).
-    // Three valid response shapes from various HF
-    // endpoints/versions:
-    //
-    //   (1) 2D: [batch, dim]                  → [[0.06, 0.29, ...]]
-    //       E.g. some legacy endpoints, mxbai hidden states
-    //   (2) 1D: [dim]                         → [0.06, 0.29, ...]
-    //       E.g. the new router endpoint, fully pooled
-    //   (3) 3D: [batch, seq, dim]             → [[[0.06, ...]]]
-    //       E.g. mxbai hidden states without CLS pooling
-    //
-    // The previous code assumed shape (3) and tried to
-    // take data[0][0] as the vector — that returned a
-    // single number for the new endpoint, and normalizeL2
-    // threw "vec is not iterable" trying to for-loop over
-    // it. Now we probe the shape first.
-    if (!Array.isArray(data) || data.length === 0) {
-      throw new Error(`HF Inference API returned unexpected shape: ${JSON.stringify(data).slice(0, 200)}`);
-    }
-    const first = data[0];
-    if (Array.isArray(first)) {
-      if (Array.isArray(first[0])) {
-        // shape (3): 3D — take CLS token (first token of first sequence)
-        return normalizeL2(first[0] as number[]);
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= HF_MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), HF_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          inputs: text,
+          options: { wait_for_model: true, use_cache: true },
+        }),
+        signal: controller.signal,
+      });
+      clearTimeout(t);
+
+      if (!res.ok) {
+        const errText = await res.text().catch(() => '<body unreadable>');
+        const err = new Error(`HF Inference API ${res.status}: ${errText}`);
+        // 429 (rate-limited) and 5xx are worth one retry; other 4xx are real bugs.
+        const retryable = res.status === 429 || res.status >= 500;
+        if (retryable && attempt < HF_MAX_RETRIES) {
+          lastError = err;
+          logger.warn(`[embeddings] HF API ${res.status} (attempt ${attempt}/${HF_MAX_RETRIES}) — retrying in ${HF_RETRY_DELAY_MS}ms`);
+          await new Promise((r) => setTimeout(r, HF_RETRY_DELAY_MS));
+          continue;
+        }
+        throw err;
       }
-      // shape (1): 2D already-pooled, single vector in the batch
-      return normalizeL2(first as number[]);
+
+      const data = await res.json();
+      // v1.68.1 — the new router endpoint returns a FLAT
+      // 1D array of 1024 numbers (not a 2D nested array).
+      // Three valid response shapes from various HF
+      // endpoints/versions:
+      //
+      //   (1) 2D: [batch, dim]                  → [[0.06, 0.29, ...]]
+      //       E.g. some legacy endpoints, mxbai hidden states
+      //   (2) 1D: [dim]                         → [0.06, 0.29, ...]
+      //       E.g. the new router endpoint, fully pooled
+      //   (3) 3D: [batch, seq, dim]             → [[[0.06, ...]]]
+      //       E.g. mxbai hidden states without CLS pooling
+      //
+      // The previous code assumed shape (3) and tried to
+      // take data[0][0] as the vector — that returned a
+      // single number for the new endpoint, and normalizeL2
+      // threw "vec is not iterable" trying to for-loop over
+      // it. Now we probe the shape first.
+      if (!Array.isArray(data) || data.length === 0) {
+        throw new Error(`HF Inference API returned unexpected shape: ${JSON.stringify(data).slice(0, 200)}`);
+      }
+      const first = data[0];
+      if (Array.isArray(first)) {
+        if (Array.isArray(first[0])) {
+          // shape (3): 3D — take CLS token (first token of first sequence)
+          return normalizeL2(first[0] as number[]);
+        }
+        // shape (1): 2D already-pooled, single vector in the batch
+        return normalizeL2(first as number[]);
+      }
+      // shape (2): 1D — data itself is the vector
+      return normalizeL2(data as number[]);
+    } catch (err) {
+      clearTimeout(t);
+      const e = err as Error & { code?: number; name?: string };
+      // AbortError from undici: err.name === 'AbortError',
+      // err.code === 20 (DOMException code for AbortError),
+      // err.message === 'This operation was aborted'. The 30s
+      // timeout above is one possible trigger, but during cron
+      // bursts at server boot the abort typically fires much
+      // sooner — undici resets the connection when HF closes it
+      // mid-request (rate-limit, transient upstream error).
+      // We can't easily distinguish the two from inside the
+      // catch, so the retry treats them identically.
+      const isAbort = e?.name === 'AbortError' || e?.code === 20;
+      if (isAbort && attempt < HF_MAX_RETRIES) {
+        lastError = e;
+        logger.warn(`[embeddings] HF API call aborted (attempt ${attempt}/${HF_MAX_RETRIES}) — retrying in ${HF_RETRY_DELAY_MS}ms`);
+        await new Promise((r) => setTimeout(r, HF_RETRY_DELAY_MS));
+        continue;
+      }
+      // Non-retryable error (or final attempt failed) — bubble up.
+      // Don't wrap: callers pattern-match on the error message and
+      // a wrapped AbortError would still match `name === 'AbortError'`.
+      throw err;
     }
-    // shape (2): 1D — data itself is the vector
-    return normalizeL2(data as number[]);
-  } finally {
-    clearTimeout(t);
   }
+  // Should be unreachable — the loop either returns, throws, or
+  // continues. Throw the last error to satisfy TS control flow.
+  throw lastError ?? new Error('HF embedding failed after retries');
 }
 
 function normalizeL2(vec: number[]): number[] {


### PR DESCRIPTION
## What

Wraps the HuggingFace Inference API embedding call in a 'for (attempt 1..2)' retry loop with 500ms backoff. Previously a single transient abort (AbortError, 429, or 5xx) would propagate to the caller and silently degrade the user-visible feature.

## Why

Server boot triggers 4 crons (categoryCluster, faqAudit, autoAnswer, initial popularity recompute) within ~30s of startup, easily exceeding HF's free-tier per-minute rate limit. undici surfaces the rate-limit-disconnect as `AbortError` (err.name === 'AbortError', err.code === 20, err.message === 'This operation was aborted'), not as HTTP 429. The previous single-attempt code would propagate the abort and callers would degrade to empty results.

## Changes

- **`backend/utils/ai/embeddings.ts`** (+120/-51)
  - Wrap `callHfApiEmbedding` in retry loop
  - Retry on AbortError, HTTP 429, HTTP 5xx
  - No retry on HTTP 4xx (other than 429), JSON parse errors
  - 30s timeout unchanged (was upper bound, not the cause)
  - Add `logger.warn` on each retry attempt

## Caller behavior

Unchanged. All existing call sites already handle the existing failure modes:
- `duplicateDetector`: `queryEmb` null → fall back to no candidates
- `knowledgeBase`: `qEmb` null → return `[]`
- `categoryClusterer`: serial loop, one failure → category skipped, continues

## Verification

- `tsc --noEmit` exits 0
- Real HF smoke: `generateEmbedding` returns 1024-dim L2-normalized vector
- Code review of retry loop (AbortError code 20, 429/5xx backoff, 4xx pass-through)
- Related doc: `docs/token_usage.md` (separate PR) adds a v1.70 footnote on the ~5-10% retry overhead

## Out of scope

- No retry count tuning — 1 retry is enough for the burst case; tune later if HF stays flaky
- No circuit breaker — premature optimization; the rate limiter is the real bottleneck
- No structured metric on retry rate — `logger.warn` is grep-able; add to Prometheus later if needed