### PR TITLE
feat(auth): v1.70 controlled registration via admin invite link

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -53,6 +53,11 @@ interface UserResponse {
 }
 
 // POST /api/auth/register
+// v1.70 — The controlled-registration gate is enforced by the
+// `registrationGate` middleware mounted in routes/auth.ts, BEFORE
+// validateBody. By the time this handler runs, the request has
+// either been 403'd (closed/no-token/bad-token) or it's a real
+// registration attempt. We just validate + create.
 export const register = async (req: Request, res: Response): Promise<void> => {
   try {
     const parsed = registerSchema.safeParse(req.body);

--- a/backend/controllers/registrationControlController.ts
+++ b/backend/controllers/registrationControlController.ts
@@ -1,0 +1,185 @@
+/**
+ * registrationControlController.ts — admin endpoints for the
+ * v1.70 controlled-registration feature.
+ *
+ * Endpoints (mounted under /api/admin/registration-config):
+ *   GET    /                       → current config (no plaintext token)
+ *   PATCH  /                       → toggle enabled (body: { enabled })
+ *   POST   /regenerate-token       → generate fresh token, return plaintext once
+ *
+ * Role gate: `admin` only (per v1.70 spec — closest existing match
+ * to "super-admin" since UserRole has no super-admin). Moderators
+ * cannot toggle registration — that's an admin-level concern.
+ *
+ * Audit: every state change writes an AdminLog entry with
+ * action='settings_update' and targetType='system', so the existing
+ * /admin/audit log captures who flipped the toggle and when.
+ */
+
+import { Request, Response } from 'express';
+import { Types } from 'mongoose';
+import RegistrationConfig, {
+  ensureRegistrationConfig,
+  generateInviteToken,
+} from '../models/RegistrationConfig.js';
+import AdminLog from '../models/AdminLog.js';
+import User from '../models/User.js';
+import { adminLog } from '../utils/http/logger.js';
+
+/**
+ * Pull the admin id off the request. Routes mounted with
+ * `protect + authorize('admin')` guarantee `req.user` exists.
+ */
+function adminIdFromReq(req: Request): Types.ObjectId | null {
+  const u = (req as Request & { user?: { _id?: Types.ObjectId | string } }).user;
+  if (!u?._id) return null;
+  return typeof u._id === 'string' ? new Types.ObjectId(u._id) : u._id;
+}
+
+/**
+ * Build the full invite-link URL for display. Uses PUBLIC_BASE_URL
+ * if set (recommended for production), falls back to the request's
+ * own host header so the admin always sees a usable URL even in dev.
+ */
+function buildInviteLink(req: Request, token: string): string {
+  const configured = (process.env.PUBLIC_BASE_URL ?? '').trim().replace(/\/$/, '');
+  if (configured) return `${configured}/?token=${token}`;
+  // Fallback: derive from the request so the admin gets a working link
+  // in dev without needing to configure PUBLIC_BASE_URL.
+  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'http';
+  const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost';
+  return `${proto}://${host}/?token=${token}`;
+}
+
+/**
+ * GET /api/admin/registration-config
+ * Returns the current config — INCLUDING the current invite link,
+ * built from the stored plaintext token. The link is only exposed
+ * to admin-role callers; public callers see only `enabled`.
+ */
+export async function adminGetRegistrationConfig(req: Request, res: Response): Promise<void> {
+  try {
+    const doc = await ensureRegistrationConfig();
+    const lastToggledBy = doc.lastToggledBy
+      ? await User.findById(doc.lastToggledBy).select('name email').lean()
+      : null;
+    res.json({
+      enabled: doc.registrationEnabled,
+      inviteLink: buildInviteLink(req, doc.inviteToken),
+      tokenGeneratedAt: doc.tokenGeneratedAt,
+      lastToggledBy: lastToggledBy
+        ? {
+            id: String(lastToggledBy._id),
+            name: (lastToggledBy as { name?: string }).name ?? null,
+            email: (lastToggledBy as { email?: string }).email ?? null,
+          }
+        : null,
+      lastToggledAt: doc.lastToggledAt,
+    });
+  } catch (err) {
+    adminLog.error(`[registrationControl] get failed: ${(err as Error).message}`);
+    res.status(500).json({ message: 'Failed to load registration config.' });
+  }
+}
+
+/**
+ * PATCH /api/admin/registration-config
+ * Body: { enabled: boolean }
+ * Toggles the registration gate. Audit-logged.
+ */
+export async function adminUpdateRegistrationConfig(req: Request, res: Response): Promise<void> {
+  try {
+    const body = (req.body ?? {}) as { enabled?: unknown };
+    if (typeof body.enabled !== 'boolean') {
+      res.status(400).json({ message: '`enabled` (boolean) is required.' });
+      return;
+    }
+    const adminId = adminIdFromReq(req);
+    if (!adminId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+    // Ensure singleton exists before updating so the upsert doesn't
+    // require an inviteToken that wasn't generated yet.
+    await ensureRegistrationConfig();
+    const doc = await RegistrationConfig.findByIdAndUpdate(
+      'singleton',
+      {
+        $set: {
+          registrationEnabled: body.enabled,
+          lastToggledBy: adminId,
+          lastToggledAt: new Date(),
+        },
+      },
+      { new: true },
+    );
+    // Audit log — reuses the existing 'settings_update' action.
+    // Best-effort: don't block the response on log failure.
+    AdminLog.create({
+      adminId,
+      action: 'settings_update',
+      targetType: 'system',
+      details: `Registration ${body.enabled ? 'enabled' : 'disabled'}`,
+    }).catch((err) => {
+      adminLog.warn(`[registrationControl] audit log write failed: ${(err as Error).message}`);
+    });
+    res.json({
+      enabled: doc?.registrationEnabled ?? body.enabled,
+      lastToggledAt: doc?.lastToggledAt,
+    });
+  } catch (err) {
+    adminLog.error(`[registrationControl] update failed: ${(err as Error).message}`);
+    res.status(500).json({ message: 'Failed to update registration config.' });
+  }
+}
+
+/**
+ * POST /api/admin/registration-config/regenerate-token
+ * Generates a new random token, replaces the stored one atomically.
+ * Returns the new plaintext token AND the full invite link in the
+ * response — the admin must copy it now; the DB only retains the
+ * plaintext for future GETs (and the same plaintext for verify).
+ *
+ * This is the ONLY endpoint that returns a usable invite link
+ * without the admin having to read the DB directly. Treat the
+ * response body as secret.
+ */
+export async function adminRegenerateInviteToken(req: Request, res: Response): Promise<void> {
+  try {
+    const adminId = adminIdFromReq(req);
+    if (!adminId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+    const newToken = generateInviteToken();
+    const doc = await RegistrationConfig.findByIdAndUpdate(
+      'singleton',
+      {
+        $set: {
+          inviteToken: newToken,
+          tokenGeneratedAt: new Date(),
+          lastToggledBy: adminId,
+          lastToggledAt: new Date(),
+        },
+      },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    );
+    AdminLog.create({
+      adminId,
+      action: 'settings_update',
+      targetType: 'system',
+      details: 'Registration invite token regenerated',
+    }).catch((err) => {
+      adminLog.warn(`[registrationControl] audit log write failed: ${(err as Error).message}`);
+    });
+    res.json({
+      // plaintext — admin needs this to share the link. Returned ONCE.
+      token: newToken,
+      inviteLink: buildInviteLink(req, newToken),
+      tokenGeneratedAt: doc?.tokenGeneratedAt,
+    });
+  } catch (err) {
+    adminLog.error(`[registrationControl] regenerate failed: ${(err as Error).message}`);
+    res.status(500).json({ message: 'Failed to regenerate invite token.' });
+  }
+}

--- a/backend/models/RegistrationConfig.ts
+++ b/backend/models/RegistrationConfig.ts
@@ -1,0 +1,103 @@
+/**
+ * RegistrationConfig — singleton document controlling whether
+ * public self-registration is allowed.
+ *
+ * Defaults to CLOSED. New users can only register when:
+ *   (1) `registrationEnabled === true`, AND
+ *   (2) The caller supplies the `inviteToken` from the admin's
+ *       currently-active invite link. Tokens are compared using
+ *       `crypto.timingSafeEqual` against this document's stored
+ *       `inviteToken` field (plaintext — see security note below).
+ *
+ * Why plaintext: the admin dashboard needs to RENDER the current
+ * invite link so they can copy it (per the v1.70 spec). Hashing
+ * the token would force the admin to regenerate before every share,
+ * which breaks the spec's "Display current invite link URL (copyable)"
+ * requirement. The DB is the trust boundary; the token can be
+ * regenerated atomically if it's ever leaked.
+ *
+ * Singleton pattern (mirrors AppSetting): a single document with
+ * `_id: 'singleton'`. Use `ensureRegistrationConfig()` to read or
+ * lazily-create on first access — call it from server boot so the
+ * doc always exists.
+ */
+
+import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
+import crypto from 'node:crypto';
+
+export interface IRegistrationConfig extends Document<string> {
+  /** Always 'singleton' — one document, ever. */
+  _id: 'singleton';
+  /** When false, all `/api/auth/register` calls return 403. */
+  registrationEnabled: boolean;
+  /** Plaintext invite token. Compare with `crypto.timingSafeEqual`. */
+  inviteToken: string;
+  /** When the current `inviteToken` was last generated. */
+  tokenGeneratedAt: Date;
+  /** Last admin who toggled the flag or regenerated the token. */
+  lastToggledBy: Types.ObjectId | null;
+  /** When the toggle or token was last changed. */
+  lastToggledAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const registrationConfigSchema = new MongooseSchema<IRegistrationConfig>(
+  {
+    _id: { type: String, default: 'singleton' },
+    registrationEnabled: { type: Boolean, default: false },
+    inviteToken: { type: String, required: true },
+    tokenGeneratedAt: { type: Date, required: true },
+    lastToggledBy: {
+      type: MongooseSchema.Types.ObjectId,
+      ref: 'User',
+      default: null,
+    },
+    lastToggledAt: { type: Date, default: () => new Date() },
+  },
+  { timestamps: true }
+);
+
+const RegistrationConfigModel = mongoose.model<IRegistrationConfig>(
+  'RegistrationConfig',
+  registrationConfigSchema,
+  'yaksha_faq_registration_config'
+);
+
+export default RegistrationConfigModel;
+
+/**
+ * Generate a fresh invite token: 32 random bytes → base64url (~43 chars).
+ * Exported so the controller and the seed script share one source of truth.
+ */
+export function generateInviteToken(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Read the singleton, creating it with a fresh token if missing.
+ * Returns the live document (not lean) so callers can $set on it.
+ *
+ * Safe to call repeatedly — only creates on the first call.
+ * Logs the initial plaintext token to stderr so operators can copy
+ * it on first deploy. Subsequent reads do NOT log the token.
+ */
+export async function ensureRegistrationConfig(): Promise<IRegistrationConfig> {
+  let doc = await RegistrationConfigModel.findById('singleton');
+  if (!doc) {
+    const token = generateInviteToken();
+    doc = await RegistrationConfigModel.create({
+      _id: 'singleton',
+      registrationEnabled: false,
+      inviteToken: token,
+      tokenGeneratedAt: new Date(),
+      lastToggledBy: null,
+      lastToggledAt: new Date(),
+    });
+    // eslint-disable-next-line no-console
+    console.warn(
+      `\n[registrationConfig] First-time init — invite token (copy now, won't be shown again):\n${token}\n`
+    );
+  }
+  return doc;
+}

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -3,11 +3,14 @@ import { login, register, getMe, getAllUsers, updateUserRole, deleteUser, update
 import { protect, authorize } from '../middleware/auth.js';
 import { loginLimiter, registerLimiter, passwordChangeLimiter } from '../utils/auth/rateLimit.js';
 import { validateBody, registerSchema, loginSchema, updateProfileSchema, changePasswordSchema } from '../utils/auth/validation.js';
+// v1.70 — Controlled-registration gate. Mounted BEFORE validateBody so
+// closed/invalid-token requests 403 before the Zod schema runs.
+import { registrationGate } from '../utils/auth/registrationGate.js';
 
 const router = Router();
 
-// POST /api/auth/register (Public) — rate-limited, validated
-router.post('/register', registerLimiter, validateBody(registerSchema), register);
+// POST /api/auth/register (Public) — rate-limited, gated, validated
+router.post('/register', registerLimiter, registrationGate, validateBody(registerSchema), register);
 
 // POST /api/auth/login (Public) — rate-limited, validated
 router.post('/login', loginLimiter, validateBody(loginSchema), login);

--- a/backend/routes/registrationControl.ts
+++ b/backend/routes/registrationControl.ts
@@ -1,0 +1,25 @@
+/**
+ * routes/registrationControl.ts — admin endpoints for the v1.70
+ * controlled-registration feature. Mounted at /api/admin/registration-config.
+ *
+ * Role gate: `admin` only — not moderator, not ai_moderator.
+ * Per spec ("Only super-admin role can change it"), `admin` is the
+ * closest existing role in the UserRole enum.
+ */
+
+import { Router } from 'express';
+import { protect, authorize } from '../middleware/auth.js';
+import {
+  adminGetRegistrationConfig,
+  adminUpdateRegistrationConfig,
+  adminRegenerateInviteToken,
+} from '../controllers/registrationControlController.js';
+
+const router = Router();
+
+router.use(protect);
+router.get('/',           authorize('admin'), adminGetRegistrationConfig);
+router.patch('/',         authorize('admin'), adminUpdateRegistrationConfig);
+router.post('/regenerate-token', authorize('admin'), adminRegenerateInviteToken);
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -41,6 +41,8 @@ import adminWelcomeRoutes from './routes/adminWelcomeRoutes.js';
 import adminMentorRoutes from './routes/adminMentorRoutes.js';
 import adminTimelineRoutes from './routes/adminTimelineRoutes.js';
 import { adminRouter as appSettingsAdminRouter, publicRouter as appSettingsPublicRouter } from './routes/appSettings.js';
+// v1.70 — Controlled-registration admin endpoints (toggle + token regenerate).
+import registrationControlRoutes from './routes/registrationControl.js';
 import adminCategoryClusterRoutes from './routes/adminCategoryCluster.js';
 import publicCategoryClusterRoutes from './routes/publicCategoryCluster.js';
 import healthRoutes from './routes/health.js';
@@ -237,6 +239,11 @@ app.use('/api/admin/timeline-steps', adminTimelineRoutes);
 app.use('/api/admin/settings',  appSettingsAdminRouter);
 app.use('/api/public/settings', appSettingsPublicRouter);
 
+// v1.70 — Controlled registration admin endpoints (toggle + token regenerate).
+// Mounted separately from appSettings because the surface is small
+// and the endpoints have a different RBAC story (admin-only, not moderator).
+app.use('/api/admin/registration-config', registrationControlRoutes);
+
 // 6. Health Check Endpoint
 // Useful for deployment platforms (like Vercel/AWS) to verify the server is alive
 app.get('/api/health', async (req: Request, res: Response) => {
@@ -407,6 +414,20 @@ if (process.env.NODE_ENV !== 'production') {
       await migrateZoomSettingsToSessions();
     } catch (e) {
       startupLog.error('startup DB connect failed', { error: (e as Error).message });
+    }
+
+    // v1.70 — Lazy-init the RegistrationConfig singleton. On first
+    // boot this creates the doc with a fresh token + logs the
+    // plaintext to stderr so the operator can copy it. Subsequent
+    // boots are a no-op (findById hits cache after first call).
+    // Best-effort: a DB failure here shouldn't stop the server,
+    // since the gate helper also calls ensureRegistrationConfig
+    // on every /register request and on every admin GET.
+    try {
+      const { ensureRegistrationConfig } = await import('./models/RegistrationConfig.js');
+      await ensureRegistrationConfig();
+    } catch (e) {
+      startupLog.warn(`[registrationConfig] ensure failed at startup: ${(e as Error).message}`);
     }
 
     startEscalationScheduler();

--- a/backend/utils/auth/registrationGate.ts
+++ b/backend/utils/auth/registrationGate.ts
@@ -1,0 +1,120 @@
+/**
+ * registrationGate.ts — server-side gate for /api/auth/register.
+ *
+ * Two exports:
+ *   - `checkRegistrationAllowed(token)`: pure helper that returns a
+ *     discriminated-union decision. Used by `registrationGate` below
+ *     and exposed for callers that want the decision without
+ *     terminating the request (e.g. tests).
+ *   - `registrationGate`: Express middleware that runs `checkRegistrationAllowed`,
+ *     terminates with 403 on failure, otherwise calls next().
+ *
+ * Enforces the v1.70 controlled-registration spec:
+ *   - registrationEnabled must be true (admin toggle)
+ *   - the caller must supply the current inviteToken
+ *
+ * Token comparison uses `crypto.timingSafeEqual` against the stored
+ * plaintext token. The plaintext storage is intentional — see the
+ * doc-comment on `models/RegistrationConfig.ts`.
+ */
+import crypto from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import RegistrationConfig from '../../models/RegistrationConfig.js';
+import { authLog } from '../http/logger.js';
+
+export type RegistrationDecision =
+  | { ok: true }
+  | { ok: false; reason: 'disabled' | 'missing_token' | 'invalid_token' };
+
+/**
+ * Constant-time string comparison. Returns false if lengths differ
+ * (but still runs a comparison against a zero buffer of the same
+ * length to keep wall-clock time independent of the mismatch cause).
+ */
+function safeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) {
+    crypto.timingSafeEqual(ab, Buffer.alloc(ab.length));
+    return false;
+  }
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/**
+ * Decide whether a /api/auth/register call may proceed.
+ *
+ * Reads the RegistrationConfig singleton on every call so an admin
+ * toggle change takes effect immediately (no cache lag, per spec).
+ * The query is a single `findById('singleton').lean()` — small
+ * enough that even at 1k registrations/day the overhead is
+ * negligible.
+ */
+export async function checkRegistrationAllowed(
+  providedToken: string | undefined,
+): Promise<RegistrationDecision> {
+  // Defensive: if the singleton was never created (e.g. seed skipped),
+  // deny rather than allow by default.
+  const config = await RegistrationConfig.findById('singleton')
+    .select('registrationEnabled inviteToken')
+    .lean();
+  if (!config) {
+    return { ok: false, reason: 'disabled' };
+  }
+  if (!config.registrationEnabled) {
+    return { ok: false, reason: 'disabled' };
+  }
+  if (!providedToken) {
+    return { ok: false, reason: 'missing_token' };
+  }
+  if (!safeStringEqual(providedToken, config.inviteToken)) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Express middleware that enforces the registration gate. Mounted
+ * BEFORE `validateBody` on the /api/auth/register route so it 403s
+ * on closed/invalid-token requests before the Zod schema runs —
+ * saves a validator pass on doomed requests and keeps the public
+ * error surface tight (a 400 with field errors leaks the schema's
+ * existence; a 403 doesn't).
+ *
+ * Token arrives as `?token=...` in the query string. We read it
+ * from req.query so the gate works even when the body is malformed.
+ *
+ * On success, attaches nothing to req — the controller still owns
+ * its own request shape. On failure, terminates with a 403 + JSON
+ * `{ message }` shaped exactly like the controller would have produced.
+ */
+export async function registrationGate(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined;
+    const decision = await checkRegistrationAllowed(token);
+    if (!decision.ok) {
+      const messages: Record<typeof decision.reason, string> = {
+        disabled: 'New user registration is currently disabled.',
+        missing_token: 'Registration requires a valid invite link.',
+        invalid_token: 'This invite link is invalid or has been revoked.',
+      };
+      authLog.warn('register blocked', {
+        reason: decision.reason,
+        email: (req.body as { email?: string } | undefined)?.email,
+        ip: req.ip,
+      });
+      res.status(403).json({ message: messages[decision.reason] });
+      return;
+    }
+    next();
+  } catch (err) {
+    // Fail closed: if the gate can't decide (e.g. DB blip), don't
+    // allow registration through. Log and 503 so operators see it.
+    authLog.error('register gate error', { error: (err as Error).message });
+    res.status(503).json({ message: 'Registration is temporarily unavailable. Try again shortly.' });
+  }
+}

--- a/frontend/src/admin/components/settings/RegistrationControlCard.tsx
+++ b/frontend/src/admin/components/settings/RegistrationControlCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * RegistrationControlCard — admin UI for the v1.70 controlled-registration
+ * feature. Mounted on /admin/settings (alongside GoldenTicketSettingsCard).
+ *
+ * Endpoints (all admin-only):
+ *   GET   /api/admin/registration-config         → current state + link
+ *   PATCH /api/admin/registration-config         → toggle enabled
+ *   POST  /api/admin/registration-config/regenerate-token  → fresh token + link
+ *
+ * On regenerate we get the plaintext token + the full invite link ONCE
+ * from the response. We display it with a Copy button so the admin can
+ * paste it into Slack / email. We don't persist the plaintext anywhere
+ * client-side — the DB only stores the hash and the next GET returns
+ * the same plaintext because the backend keeps it on the server.
+ */
+import { useEffect, useState, useCallback } from 'react';
+import adminApi from '../../utils/adminApi';
+
+interface ConfigResponse {
+  enabled: boolean;
+  inviteLink: string;
+  tokenGeneratedAt: string;
+  lastToggledBy: { id: string; name: string | null; email: string | null } | null;
+  lastToggledAt: string;
+}
+
+interface RegenerateResponse {
+  token: string;
+  inviteLink: string;
+  tokenGeneratedAt: string;
+}
+
+interface Props {
+  onSaved: (msg: string, type: 'success' | 'error') => void;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function RegistrationControlCard({ onSaved }: Props): React.ReactElement {
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [inviteLink, setInviteLink] = useState('');
+  const [lastToggledBy, setLastToggledBy] = useState<ConfigResponse['lastToggledBy']>(null);
+  const [lastToggledAt, setLastToggledAt] = useState<string | null>(null);
+  const [tokenGeneratedAt, setTokenGeneratedAt] = useState<string | null>(null);
+
+  const [toggling, setToggling] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [confirmingRegen, setConfirmingRegen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await adminApi.get<ConfigResponse>('/admin/registration-config');
+      setEnabled(res.data.enabled);
+      setInviteLink(res.data.inviteLink);
+      setLastToggledBy(res.data.lastToggledBy);
+      setLastToggledAt(res.data.lastToggledAt);
+      setTokenGeneratedAt(res.data.tokenGeneratedAt);
+    } catch (err) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'Failed to load registration settings';
+      onSaved(msg, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [onSaved]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (next: boolean): Promise<void> => {
+    setToggling(true);
+    try {
+      const res = await adminApi.patch<{ enabled: boolean; lastToggledAt: string }>(
+        '/admin/registration-config',
+        { enabled: next },
+      );
+      setEnabled(res.data.enabled);
+      setLastToggledAt(res.data.lastToggledAt);
+      onSaved(next ? 'Registration enabled' : 'Registration disabled', 'success');
+    } catch (err) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'Toggle failed';
+      onSaved(msg, 'error');
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const regenerate = async (): Promise<void> => {
+    setRegenerating(true);
+    try {
+      const res = await adminApi.post<RegenerateResponse>(
+        '/admin/registration-config/regenerate-token',
+      );
+      setInviteLink(res.data.inviteLink);
+      setTokenGeneratedAt(res.data.tokenGeneratedAt);
+      setConfirmingRegen(false);
+      onSaved('Invite link regenerated — old link is now invalid.', 'success');
+    } catch (err) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'Regenerate failed';
+      onSaved(msg, 'error');
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  const copyLink = async (): Promise<void> => {
+    if (!inviteLink) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      onSaved('Could not copy to clipboard', 'error');
+    }
+  };
+
+  const lastToggledByLine = lastToggledBy
+    ? `${lastToggledBy.name ?? lastToggledBy.email ?? 'admin'} · ${formatDate(lastToggledAt)}`
+    : 'Never toggled';
+
+  return (
+    <div className="admin-card-surface">
+      <div className="admin-card-header">
+        <p className="text-sm font-semibold text-ink">Registration Control</p>
+        <p className="text-xs text-ink-faint mt-0.5">
+          Public self-registration is OFF by default. Share the invite link below
+          with new users; the link stops working as soon as you disable
+          registration or regenerate the token.
+        </p>
+      </div>
+
+      <div className="px-5 py-4 space-y-5">
+        {/* Toggle */}
+        <div className="flex items-center justify-between gap-4 pb-4 border-b border-border">
+          <div>
+            <p className="text-sm font-medium text-ink">Allow new registrations</p>
+            <p className="text-xs text-ink-faint mt-1">
+              When OFF, every <code className="font-mono">POST /api/auth/register</code>{' '}
+              returns 403 — including requests with a valid token.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label="Allow new registrations"
+            disabled={loading || toggling}
+            onClick={() => toggle(!enabled)}
+            className={[
+              'relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors',
+              enabled ? 'bg-emerald-500' : 'bg-border',
+              loading || toggling ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer',
+            ].join(' ')}
+          >
+            <span
+              className={[
+                'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform mt-0.5',
+                enabled ? 'translate-x-5' : 'translate-x-0.5',
+              ].join(' ')}
+            />
+          </button>
+        </div>
+
+        {/* Invite link */}
+        <div>
+          <label className="admin-label">Current invite link</label>
+          <div className="flex items-stretch gap-2">
+            <input
+              readOnly
+              value={loading ? 'Loading…' : inviteLink}
+              onFocus={(e) => e.currentTarget.select()}
+              className="admin-input font-mono text-xs flex-1"
+              aria-label="Current invite link URL"
+            />
+            <button
+              type="button"
+              onClick={copyLink}
+              disabled={!inviteLink || loading}
+              className="admin-btn-secondary shrink-0"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <p className="text-[11px] text-ink-faint mt-1.5">
+            Anyone with this link can register <em>while the toggle is ON</em>.
+            Regenerating instantly invalidates the old link.
+          </p>
+        </div>
+
+        {/* Regenerate */}
+        <div>
+          {!confirmingRegen ? (
+            <button
+              type="button"
+              onClick={() => setConfirmingRegen(true)}
+              disabled={loading || regenerating}
+              className="admin-btn-secondary"
+            >
+              Regenerate invite link
+            </button>
+          ) : (
+            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 space-y-2">
+              <p className="text-xs text-amber-900">
+                Regenerating will invalidate the current link immediately.
+                Anyone using the old link will get a 403.
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={regenerate}
+                  disabled={regenerating}
+                  className="admin-btn-primary"
+                >
+                  {regenerating ? 'Regenerating…' : 'Confirm regenerate'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingRegen(false)}
+                  disabled={regenerating}
+                  className="admin-btn-secondary"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Audit info */}
+        <div className="border-t border-border pt-3 space-y-1 text-xs text-ink-soft">
+          <div className="flex items-center justify-between">
+            <span>Token generated</span>
+            <span className="text-ink-faint">{formatDate(tokenGeneratedAt)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Last toggled by</span>
+            <span className="text-ink-faint">{lastToggledByLine}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/admin/pages/AdminSettings.tsx
+++ b/frontend/src/admin/pages/AdminSettings.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, type FormEvent } from 'react';
 import { motion } from 'framer-motion';
 import { useAdminAuth } from '../hooks/useAdminAuth';
 import adminApi from '../utils/adminApi';
+// v1.70 — Controlled-registration admin UI (toggle + invite link).
+import RegistrationControlCard from '../components/settings/RegistrationControlCard';
 
 interface ToastState { msg: string; type: 'success' | 'error'; }
 
@@ -100,6 +102,11 @@ export default function AdminSettings() {
           the admin's own /admin/settings page (not on /admin/features)
           because they're runtime tunables, not feature toggles. */}
       <GoldenTicketSettingsCard onSaved={showToast} />
+
+      {/* v1.70 — Controlled-registration: admin-only toggle + invite
+          link + regenerate button. The card manages its own state and
+          calls /api/admin/registration-config directly. */}
+      <RegistrationControlCard onSaved={showToast} />
     </div>
   );
 }

--- a/frontend/src/components/auth/AuthModal.tsx
+++ b/frontend/src/components/auth/AuthModal.tsx
@@ -21,7 +21,7 @@ type Tab = 'signin' | 'register';
  * response don't render on top of the fading backdrop.
  */
 export default function AuthModal() {
-  const { isOpen, initialTab, closeModal, prompt } = useAuthModal();
+  const { isOpen, initialTab, closeModal, prompt, inviteToken } = useAuthModal();
   const { login, register } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -174,7 +174,11 @@ export default function AuthModal() {
       await register(
         registerForm.name.trim(),
         registerForm.email.trim(),
-        registerForm.password
+        registerForm.password,
+        // v1.70 — pass the invite token if the user arrived via /?token=...
+        // Captured by AuthModalProvider on mount. Backend validates; if
+        // missing/invalid the gate returns 403 and the error message below.
+        inviteToken ?? undefined
       );
       // Same as handleLoginSubmit — set closing=true + closeModal()
       // so the provider's effect sees the isOpen transition and fires the

--- a/frontend/src/context/AuthModalContext.tsx
+++ b/frontend/src/context/AuthModalContext.tsx
@@ -26,6 +26,11 @@ interface AuthModalContextValue {
   // Optional text shown above the form (e.g. "Sign in to ask a question").
   prompt: string;
   setPrompt: (text: string) => void;
+  // v1.70 — Invite token captured from `?token=...` in the URL when the
+  // user lands on the invite link. Null when no token was supplied.
+  // The AuthModal reads this on register submit and passes it to
+  // `useAuth().register(...)` so the backend gate can validate it.
+  inviteToken: string | null;
 }
 
 const AuthModalContext = createContext<AuthModalContextValue | null>(null);
@@ -41,6 +46,28 @@ export function AuthModalProvider({ children, isAuthenticated }: ProviderProps) 
   const [initialTab, setInitialTab] = useState<'signin' | 'register'>('signin');
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [prompt, setPrompt] = useState('');
+  // v1.70 — Capture `?token=...` from the URL on mount. When present,
+  // auto-open the modal in the register tab so the user lands directly
+  // on the form (not on a sign-in screen they'll have to switch out of).
+  // We also strip the token from the URL after capture so a refresh
+  // doesn't re-trigger the modal — the token is now in component state.
+  const [inviteToken, setInviteToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    if (token) {
+      setInviteToken(token);
+      setInitialTab('register');
+      setIsOpen(true);
+      // Strip ?token= from the URL to avoid leaving the active token
+      // visible in browser history, address bar, and referer headers.
+      // Use replaceState so the back button doesn't re-trigger.
+      const cleaned = window.location.pathname + window.location.hash;
+      window.history.replaceState(null, '', cleaned);
+    }
+  }, []);
 
   const openModal = useCallback((tab: 'signin' | 'register' = 'signin') => {
     setInitialTab(tab);
@@ -107,7 +134,8 @@ export function AuthModalProvider({ children, isAuthenticated }: ProviderProps) 
     setPendingAction,
     prompt,
     setPrompt,
-  }), [isOpen, initialTab, openModal, closeModal, prompt]);
+    inviteToken,
+  }), [isOpen, initialTab, openModal, closeModal, prompt, inviteToken]);
 
   return <AuthModalContext.Provider value={value}>{children}</AuthModalContext.Provider>;
 }

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -30,7 +30,12 @@ export interface User {
 export interface AuthContextValue {
   user: User | null;
   login: (email: string, password: string) => Promise<User>;
-  register: (name: string, email: string, password: string) => Promise<User>;
+  // v1.70 — inviteToken is required when the controlled-registration
+  // gate is enabled. Backend will 403 with "missing_token" or
+  // "invalid_token" if it doesn't match the active admin-issued token.
+  // The token arrives from `?token=...` in the URL when the user clicks
+  // an admin-shared invite link.
+  register: (name: string, email: string, password: string, inviteToken?: string) => Promise<User>;
   logout: () => void;
   loading: boolean;
   isAuthenticated: boolean;
@@ -98,8 +103,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return loggedInUser;
   };
 
-  const register = async (name: string, email: string, password: string): Promise<User> => {
-    const res = await api.post('/auth/register', { name, email, password });
+  const register = async (name: string, email: string, password: string, inviteToken?: string): Promise<User> => {
+    // v1.70 — append `?token=` when the caller has one (typically because
+    // they arrived via /?token=xyz invite link). Backend gate rejects with
+    // 403 if the gate is closed or the token doesn't match.
+    const url = inviteToken ? `/auth/register?token=${encodeURIComponent(inviteToken)}` : '/auth/register';
+    const res = await api.post(url, { name, email, password });
     const { token, user: registeredUser } = res.data as { token: string; user: User };
     localStorage.setItem('yaksha_token', token);
     localStorage.setItem('yaksha_user', JSON.stringify(registeredUser));


### PR DESCRIPTION
## What

Blocks all self-registration by default. Users can only register via an admin-issued invite link. Admin can toggle the gate on/off from a new card on /admin/settings; toggling off instantly invalidates every outstanding invite.

## Behavior

- `POST /api/auth/register` → always 403 by default
- With `?token=<active-token>` in query AND toggle ON → proceeds
- With toggle OFF → 403 even with valid token
- Toggle change takes effect immediately (gate reads the singleton fresh on every call)

## Changes

### Backend
- `models/RegistrationConfig.ts` (NEW) — singleton doc with toggle flag, plaintext inviteToken, tokenGeneratedAt, lastToggledBy/At. `ensureRegistrationConfig()` creates on first access.
- `utils/auth/registrationGate.ts` (NEW) — `checkRegistrationAllowed(token)` helper + `registrationGate` Express middleware that 403s before `validateBody` runs. Token comparison via `crypto.timingSafeEqual`.
- `controllers/registrationControlController.ts` (NEW) — GET (config + invite link), PATCH (toggle), POST regenerate-token (returns plaintext once). Writes `AdminLog` entries on every change.
- `routes/registrationControl.ts` (NEW) — admin-only mount.
- `routes/auth.ts` — mount `registrationGate` middleware BEFORE `validateBody`.
- `controllers/authController.ts` — removed duplicated gate (now in middleware).
- `server.ts` — lazy-init the singleton at startup.

### Frontend
- `admin/components/settings/RegistrationControlCard.tsx` (NEW) — toggle, copy-link, regenerate-with-confirm, audit footer.
- `admin/pages/AdminSettings.tsx` — render new card below GoldenTicketSettingsCard.
- `context/AuthModalContext.tsx` — capture `?token=` on mount, auto-open register tab, strip token from URL via `replaceState`.
- `hooks/useAuth.tsx` + `components/auth/AuthModal.tsx` — `register(name, email, password, inviteToken?)` passes the token through.

## Verification

- `tsc --noEmit` exits 0 (backend and frontend)
- End-to-end smoke (8/8 assertions, live server):
  - no token + toggle ON → 403
  - valid token + toggle ON → 201 + JWT
  - regenerate → old 403, new 201
  - toggle OFF → valid tokens 403
- `AdminLog` audit entries written for enable/disable/regenerate

## Defaults applied (flagged for review)

- Role gate: admin only (UserRole has no super_admin)
- Token storage: plaintext at rest, hash-and-show-only-on-regenerate was the alternative
- Out of scope per spec: per-user codes, email invites, expiring tokens