### PR TITLE
fix(zoom-vtt): parse VTT once per ingestion (fixes #10)

### DIFF
--- a/backend/controllers/zoomController.ts
+++ b/backend/controllers/zoomController.ts
@@ -19,7 +19,7 @@ import mongoose from 'mongoose';
 import { ZoomMeeting, ZoomInsight } from '../models/ZoomMeeting.js';
 import User from '../models/User.js';
 import { downloadTranscriptAsUser, getPastRecordings } from '../utils/zoom/zoomOAuth.js';
-import { parseVTT, parseVTTWithSpeakers, isEmptyTranscript } from '../utils/zoom/vttParser.js';
+import { parseVTT, parseVTTWithSpeakers, isEmptyTranscript, isEmptyFromSegments } from '../utils/zoom/vttParser.js';
 import { processZoomMeetingForKnowledge } from '../services/knowledgeBase.js';
 import { extractInsightsFromTranscript } from '../utils/zoom/zoomExtractor.js';
 import { CircuitOpenError } from '../utils/http/circuitBreaker.js';
@@ -377,8 +377,14 @@ export async function processTranscriptPayloadInternal(
   });
 
   try {
-    // Empty check (both formats)
-    const { empty, warning } = isEmptyTranscript(rawContent);
+    // Empty check (both formats).
+    // v1.70 — fix #10: parse VTT ONCE, derive both the empty-check
+    // AND the segments from the same parse. Previously isEmptyTranscript
+    // internally called parseVTT (→ parseVTTWithSpeakers), and then
+    // we called parseVTTWithSpeakers again on the same content to
+    // extract segments. Double work for every ingested transcript.
+    const segments = parseVTTWithSpeakers(rawContent);
+    const { empty, warning } = isEmptyFromSegments(segments);
     if (empty) {
       await ZoomMeeting.findByIdAndUpdate(meeting._id, {
         status: 'failed',
@@ -392,8 +398,6 @@ export async function processTranscriptPayloadInternal(
       httpLog.warn(`[Zoom] Transcript for meeting ${meeting._id} is short (<50 chars) — processing anyway`);
     }
 
-    // Parse: VTT with speakers or plain text
-    const segments = parseVTTWithSpeakers(rawContent);
     const plainText = segments.map(s => `${s.speaker ? s.speaker + ': ' : ''}${s.text}`).join('\n');
 
     await ZoomMeeting.findByIdAndUpdate(meeting._id, {

--- a/backend/utils/zoom/vttParser.ts
+++ b/backend/utils/zoom/vttParser.ts
@@ -188,3 +188,21 @@ export function isEmptyTranscript(vttContent: string): { empty: boolean; warning
   const chars = text.replace(/\s/g, '').length;
   return { empty: chars < 30, warning: chars < 50 };
 }
+
+/**
+ * v1.70 — fix #10: same empty-detection logic, but takes the
+ * already-parsed segments instead of the raw VTT content. Lets callers
+ * parse once and reuse the result for both the empty-check and
+ * downstream processing — previously the empty check internally called
+ * parseVTT (which itself calls parseVTTWithSpeakers), so callers that
+ * also needed the segments were parsing the same transcript twice.
+ *
+ * Thresholds match isEmptyTranscript (empty <30 chars, warning <50).
+ */
+export function isEmptyFromSegments(segments: TranscriptSegment[]): { empty: boolean; warning: boolean } {
+  const chars = segments
+    .map((s) => `${s.speaker ? s.speaker + ' ' : ''}${s.text}`)
+    .join('')
+    .replace(/\s/g, '').length;
+  return { empty: chars < 30, warning: chars < 50 };
+}

--- a/backend/utils/zoom/zoomExtractor.ts
+++ b/backend/utils/zoom/zoomExtractor.ts
@@ -15,7 +15,7 @@
 
 import { ZoomInsightType } from '../../models/ZoomMeeting.js';
 import { resolveProviderAsync } from '../ai/aiProvider.js';
-import { parseVTTWithSpeakers, extractSnippet, isEmptyTranscript, TranscriptSegment } from './vttParser.js';
+import { parseVTTWithSpeakers, extractSnippet, isEmptyTranscript, isEmptyFromSegments, TranscriptSegment } from './vttParser.js';
 import { logger } from '../http/logger.js';
 
 export interface ExtractedItem {
@@ -36,9 +36,14 @@ export interface ExtractedItem {
 function parseTranscript(raw: string): TranscriptSegment[] {
   const trimmed = raw.trim();
   if (trimmed.startsWith('WEBVTT')) {
-    const { warning } = isEmptyTranscript(raw);
+    // v1.70 — fix #10: parse VTT once, derive both the warning log AND
+    // the segments from the same parse. Previously isEmptyTranscript
+    // internally called parseVTT (→ parseVTTWithSpeakers), and then we
+    // called parseVTTWithSpeakers again on the same content below.
+    const segments = parseVTTWithSpeakers(raw);
+    const { warning } = isEmptyFromSegments(segments);
     if (warning) logger.warn('[zoomExtractor] Transcript below 50 chars — processing anyway.');
-    return parseVTTWithSpeakers(raw);
+    return segments;
   }
   // Plain .txt: one line = one paragraph
   return trimmed


### PR DESCRIPTION
## The bug

Zoom VTT ingestion parsed every transcript **twice**. `isEmptyTranscript(content)` calls `parseVTT(content)` internally → which calls `parseVTTWithSpeakers(content)`. The callers then call `parseVTTWithSpeakers(rawContent)` again on the same content to get the actual segments. So one VTT ingestion = two full state-machine parses.

## Why it matters

The VTT parser is a state machine over the entire transcript (timestamps, speaker detection, text blocks). For a 1-hour meeting that's ~200KB of text and ~500 state transitions per parse. Doubling that is a real CPU hit, especially during batch ingestions (admin reprocessing many meetings after a fix).

## The fix

Added `isEmptyFromSegments(segments: TranscriptSegment[]): {empty, warning}` to `backend/utils/zoom/vttParser.ts` — same heuristics (chars<30 = empty, chars<50 = warning) but takes the already-parsed segments. Updated both call sites:

- `backend/controllers/zoomController.ts:381` — the per-meeting ingestion
- `backend/utils/zoom/zoomExtractor.ts:39` — the AI-extraction helper

Both now parse once, derive empty/warning from the same segments, then use the segments downstream.

`isEmptyTranscript(content)` is kept (not deleted) for any future plain-text callers — its signature is correct for inputs without segments.

## Verification

- tsc --noEmit exits 0
- Smoke 4 cases (empty / short / warning-threshold / normal VTT): new helper produces identical `{empty, warning}` to the old one

Fixes #10