### PR TITLE
feat(scripts): backfillZoomInsightSnippets.ts (fixes #11)

### DIFF
--- a/backend/scripts/backfillZoomInsightSnippets.ts
+++ b/backend/scripts/backfillZoomInsightSnippets.ts
@@ -1,0 +1,95 @@
+/**
+ * Backfill script — populates `transcript_snippet` on existing Zoom
+ * insights that were created before the field was reliably populated.
+ *
+ * Why: issue #11 — pre-2026 insights have empty `transcript_snippet`,
+ * which renders as "—" in the admin UI. Filling the field here means
+ * future reads work without any fallback logic in the UI.
+ *
+ * Idempotent: re-running is safe (the $or filter only matches rows
+ * with empty/missing snippet). No destructive operations.
+ *
+ * Run: npx tsx scripts/backfillZoomInsightSnippets.ts
+ */
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import { ZoomInsight, ZoomMeeting } from '../models/ZoomMeeting.js';
+import type { IZoomMeeting } from '../models/ZoomMeeting.js';
+
+// Cap matches the system-prompt constraint in zoomExtractor.ts:
+// "Maximum 150 characters in transcript_snippet."
+const SNIPPET_MAX_CHARS = 150;
+
+function buildSnippet(transcript: string): string {
+  // Collapse whitespace (the raw transcript may have tabs / newlines
+  // / multiple spaces from VTT timestamps + speaker labels). Truncate
+  // at the cap; if we sliced mid-word, that's acceptable for a UI hint.
+  return transcript.replace(/\s+/g, ' ').trim().slice(0, SNIPPET_MAX_CHARS);
+}
+
+async function main(): Promise<void> {
+  if (!process.env.MONGODB_URI) {
+    console.error('ERROR: MONGODB_URI not set in backend/.env');
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log('Connected to MongoDB.');
+
+  // Cursor over the matching insights. We only fetch the snippet
+  // field plus meetingId — small documents, stream-friendly.
+  const cursor = ZoomInsight.find({
+    $or: [
+      { transcript_snippet: { $exists: false } },
+      { transcript_snippet: null },
+      { transcript_snippet: '' },
+    ],
+  })
+    .select('_id meetingId')
+    .lean()
+    .cursor();
+
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for await (const insight of cursor) {
+    try {
+      if (!insight.meetingId) {
+        skipped++;
+        continue;
+      }
+      const meeting = await ZoomMeeting.findById(insight.meetingId)
+        .select('rawTranscriptText')
+        .lean() as Pick<IZoomMeeting, 'rawTranscriptText'> | null;
+      const transcript = meeting?.rawTranscriptText;
+      if (!transcript) {
+        skipped++;
+        continue;
+      }
+      const snippet = buildSnippet(transcript);
+      if (!snippet) {
+        skipped++;
+        continue;
+      }
+      await ZoomInsight.updateOne({ _id: insight._id }, { $set: { transcript_snippet: snippet } });
+      updated++;
+    } catch (err) {
+      failed++;
+      console.error(`  ✗ ${String(insight._id)}: ${(err as Error).message}`);
+    }
+    process.stdout.write(`\r  Updated: ${updated}   Skipped: ${skipped}   Failed: ${failed}   `);
+  }
+
+  process.stdout.write('\n');
+  console.log(`Done. Updated: ${updated}, Skipped: ${skipped}, Failed: ${failed}`);
+
+  await mongoose.disconnect();
+  // Don't process.exit — let the event loop drain so mongoose cleanup
+  // finishes without abort (matches the pattern in backfillEmbeddings.ts).
+}
+
+main().catch((err) => {
+  console.error('\nBackfill failed:', (err as Error).message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

One-time idempotent backfill script that populates `transcript_snippet` on existing Zoom insights that have it empty. The field was added later than the insight schema itself, so pre-2026 insights render as `—` in the admin UI.

## Why

Issue #11 — old approved insights have empty snippets. Filling them now means future reads work without any fallback logic in the UI, and admin sees the actual excerpt.

## How

- Find insights where `transcript_snippet` is missing, null, or empty.
- For each, look up the parent ZoomMeeting's `rawTranscriptText`.
- Collapse whitespace + slice to 150 chars (matches the system-prompt cap in `zoomExtractor.ts`).
- Write back with `updateOne` (small write, no schema validation overhead).

Idempotent: the query filter only matches rows that still need filling, so re-running is safe.

## Verification

- tsc --noEmit exits 0
- Ran against live cluster today: 0 insights needed backfill, script exits cleanly. Will do the right thing whenever old data is restored from backup.

## Out of scope

- Adding npm script alias — trivial follow-up; keeping PR focused on the script itself.

Fixes #11