### PR TITLE
fix(rate-limit): build per-limiter RedisStore to fix ERR_ERL_STORE_REUSE

### DIFF
--- a/backend/utils/auth/rateLimit.ts
+++ b/backend/utils/auth/rateLimit.ts
@@ -18,7 +18,7 @@ import rateLimit, { ipKeyGenerator, type Store } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import { type Request, type Response } from 'express';
 import { logger } from '../http/logger.js';
-import { getRedisRateLimitStore } from './rateLimitRedis.js';
+import { createRedisRateLimitStore } from './rateLimitRedis.js';
 
 // ─── Shared key extractors ────────────────────────────────────────────────────
 
@@ -65,15 +65,24 @@ interface LimiterConfig {
  *
  * It limits “how many requests are allowed per unique key” inside a
  * time window (windowMs). When REDIS_TCP_URL is set, the store is
- * the Redis-backed RedisStore returned by getRedisRateLimitStore()
- * — limits are shared across all replicas hitting the same Redis.
+ * a Redis-backed RedisStore built by createRedisRateLimitStore() —
+ * limits are shared across all replicas hitting the same Redis.
  * Otherwise express-rate-limit uses its in-memory Map.
+ *
+ * Each call to this factory MUST receive its own Store instance.
+ * express-rate-limit v8 throws ERR_ERL_STORE_REUSE if the same Store
+ * is attached to more than one limiter, so we build a fresh RedisStore
+ * per call (keyed by config.keyPrefix) and share only the underlying
+ * IORedis connection across the whole process.
  */
 export function createIdentityLimiter(config: LimiterConfig) {
-  // Resolve the store once per limiter. The RedisStore is memoized
-  // inside rateLimitRedis.ts, so we don't open a new connection per
-  // limiter — just reuse the same one for all five pre-built limiters.
-  const store: Store | undefined = getRedisRateLimitStore();
+  // Build a fresh RedisStore per limiter. The IORedis client is shared
+  // inside rateLimitRedis.ts, so this opens no extra connections —
+  // it just wraps the same client in a new Store with a unique Redis
+  // key prefix (e.g. rl:login:…, rl:reg:…) so per-limiter counters
+  // stay isolated. When REDIS_TCP_URL is unset we get undefined and
+  // express-rate-limit falls back to its default MemoryStore.
+  const store: Store | undefined = createRedisRateLimitStore(config.keyPrefix ?? 'default');
   return rateLimit({
     windowMs: config.windowMs,
     max: config.max,

--- a/backend/utils/auth/rateLimitRedis.ts
+++ b/backend/utils/auth/rateLimitRedis.ts
@@ -3,24 +3,30 @@
  *
  * v1.70 — addresses issue #6 (in-memory rate limiter bypassable in
  * multi-instance deployments). The pre-built limiters in
- * `rateLimit.ts` (loginLimiter, registerLimiter, etc.) all call
- * `getRedisRateLimitStore()` at module load. When REDIS_TCP_URL is
- * set, the returned store is a `rate-limit-redis` RedisStore backed
- * by a fresh `ioredis` connection. When unset, `undefined` is returned
- * and express-rate-limit falls back to its in-memory Map — which
- * keeps dev / test environments working without Redis.
+ * `rateLimit.ts` (loginLimiter, registerLimiter, etc.) each call
+ * `createRedisRateLimitStore(prefix)` to obtain a fresh
+ * `rate-limit-redis` RedisStore bound to the shared IORedis client.
+ *
+ * Each limiter MUST own its own RedisStore instance — express-rate-limit
+ * v8 throws ERR_ERL_STORE_REUSE if the same Store is attached to more
+ * than one limiter (it tracks stores by identity and assumes sole
+ * ownership of each one). Distinct Redis key prefixes per limiter also
+ * keep counters isolated in Redis, which makes `KEYS rl:login:*`-style
+ * debugging work and prevents two limiters from clobbering each other
+ * if they ever share a request-key namespace.
+ *
+ * When REDIS_TCP_URL is unset, `createRedisRateLimitStore` returns
+ * `undefined` and express-rate-limit falls back to its default
+ * in-memory Map — which keeps dev / test environments working without
+ * Redis.
  *
  * Connection handling mirrors `utils/jobs/documentQueue.ts`:
  *  - URL parsing handles rediss:// (Upstash) → enable TLS
  *  - Uses REDIS_TCP_URL env var (consistent with BullMQ usage)
  *  - maxRetriesPerRequest: null (required by rate-limit-redis)
  *
- * Note: a fresh IORedis is created per call. That's intentional —
- * rate-limit-redis manages its own connection internally; we just
- * need a client that responds to the redis-compatible command API.
- * The cost is one extra TCP connection per process, which is
- * negligible compared to the BullMQ + Upstash REST clients we
- * already open.
+ * The IORedis client is memoized so the process opens at most one
+ * connection regardless of how many limiters exist.
  */
 
 import IORedis from 'ioredis';
@@ -28,12 +34,16 @@ import { RedisStore, type RedisReply } from 'rate-limit-redis';
 import type { Store } from 'express-rate-limit';
 import { logger } from '../http/logger.js';
 
-let _store: Store | undefined;
-let _initialized = false;
+// `undefined` → not yet initialised; `null` → tried, no REDIS_TCP_URL.
+let _client: IORedis | null | undefined;
+let _loggedMode = false;
 
 function buildRedisClient(): IORedis | null {
   const url = process.env.REDIS_TCP_URL;
-  if (!url) return null;
+  if (!url) {
+    logger.info('[rateLimitRedis] REDIS_TCP_URL not set — using in-memory rate limiter store (single-instance only)');
+    return null;
+  }
   try {
     const u = new URL(url);
     return new IORedis({
@@ -54,30 +64,44 @@ function buildRedisClient(): IORedis | null {
   }
 }
 
-/**
- * Returns a rate-limit-redis RedisStore when REDIS_TCP_URL is set,
- * or undefined to signal express-rate-limit to use its default
- * in-memory Map. Memoized so all limiters share one connection.
- */
-export function getRedisRateLimitStore(): Store | undefined {
-  if (_initialized) return _store;
-  _initialized = true;
-  const client = buildRedisClient();
-  if (!client) {
-    logger.info('[rateLimitRedis] REDIS_TCP_URL not set — using in-memory rate limiter store (single-instance only)');
-    return undefined;
+function getRedisClient(): IORedis | null {
+  if (_client === undefined) {
+    _client = buildRedisClient();
   }
+  return _client;
+}
+
+/**
+ * Build a fresh rate-limit-redis RedisStore bound to the shared IORedis
+ * client, namespaced under `prefix` so each limiter's counters live in
+ * their own slice of Redis keyspace.
+ *
+ * Returns `undefined` when REDIS_TCP_URL is unset, signalling
+ * express-rate-limit to fall back to its default in-memory Map.
+ *
+ * @param prefix Short identifier for the limiter (e.g. `'login'`,
+ *   `'reg'`, `'admin_write'`). Prepended to every Redis key the store
+ *   writes, becoming `rl:<prefix>:...`. The underlying IORedis client
+ *   is shared, so this does NOT open a new connection per call.
+ */
+export function createRedisRateLimitStore(prefix: string): Store | undefined {
+  const client = getRedisClient();
+  if (!client) return undefined;
   try {
-    _store = new RedisStore({
+    if (!_loggedMode) {
+      logger.info('[rateLimitRedis] Using Redis-backed rate limiter store');
+      _loggedMode = true;
+    }
+    return new RedisStore({
       // sendCommand is the bridge rate-limit-redis uses to talk to
       // any Redis-compatible client. The signature expects
       // Promise<RedisReply>; cast the ioredis return value through unknown.
       sendCommand: (...args: string[]): Promise<RedisReply> =>
         client.call(...(args as [string, ...string[]])) as unknown as Promise<RedisReply>,
-      prefix: 'rl:',  // namespace in Redis — keeps our keys separate from BullMQ/Upstash usage
+      // Scope keys per limiter so login/register/etc. counters stay
+      // isolated and Redis introspection (e.g. `KEYS rl:login:*`) works.
+      prefix: `rl:${prefix}:`,
     });
-    logger.info('[rateLimitRedis] Using Redis-backed rate limiter store');
-    return _store;
   } catch (err) {
     logger.warn(`[rateLimitRedis] Failed to construct RedisStore, falling back to in-memory: ${(err as Error).message}`);
     return undefined;


### PR DESCRIPTION
## Summary

`createIdentityLimiter` was sharing a single memoized `RedisStore` across every limiter. express-rate-limit v8 forbids that with `ERR_ERL_STORE_REUSE`, so the backend refused to start whenever `REDIS_TCP_URL` was set — every import that pulled a rate limiter threw at module-load.

Fix: share the IORedis *client* across the process (one TCP connection), but construct a *fresh* `RedisStore` per limiter with a unique Redis key prefix derived from the limiter's `keyPrefix`. Returns `undefined` when `REDIS_TCP_URL` is unset so dev/test fall back to express-rate-limit's in-memory Map.

Bonus: per-limiter Redis key prefixes (`rl:login:`, `rl:reg:`, `rl:pw:`, …) make `KEYS rl:login:*`-style debugging work and ensure counters can't clobber each other.

## Verification

- `npx tsc --noEmit` reports no new errors. (Two errors in `__tests__/authorize.test.ts` are pre-existing on `feat/main-cat-yh` — confirmed by stashing the diff and re-running the typecheck.)
- Backend boots clean: zero `ERR_ERL_STORE_REUSE`, reaches `backend listening port=6767`.
- `POST /api/auth/login` (behind `loginLimiter`) returns `401` with `ratelimit-policy: 10;w=900` and `ratelimit-remaining: 9` — the limiter is actively enforcing and incrementing through the new per-limiter RedisStore.

## Files changed

- `backend/utils/auth/rateLimitRedis.ts` — split memoization: client shared, store per-limiter. New `createRedisRateLimitStore(prefix)` API; old `getRedisRateLimitStore()` removed.
- `backend/utils/auth/rateLimit.ts` — call `createRedisRateLimitStore(config.keyPrefix ?? 'default')` so each `createIdentityLimiter` call gets its own Store with a namespaced Redis prefix.

No call-site changes needed (`routes/support.ts`, `controllers/documentController.ts`, the five pre-built limiters in `rateLimit.ts`) — they all use `createIdentityLimiter`, which now does the right thing.

Fixes #81