### PR TITLE
perf(admin-log): add createdAt index for activity feed and retention policy

### DIFF
--- a/backend/models/AdminLog.ts
+++ b/backend/models/AdminLog.ts
@@ -62,4 +62,14 @@ const adminLogSchema = new MongooseSchema(
   { timestamps: true }
 );
 
+// ─── Indexes ─────────────────────────────────────────────────────────────────
+
+// Paginated activity feed (GET /api/admin/activity-feed): sorts the entire
+// collection by -createdAt. Also used by the retention-policy cron
+// (retentionPolicy.ts cleanAdminLogs) which deletes by { createdAt: $lt }.
+// Without this index both operations are full collection scans that grow
+// linearly with platform usage (every FAQ approval, ban, and settings change
+// writes a row).
+adminLogSchema.index({ createdAt: -1 });
+
 export default mongoose.model<IAdminLog>('AdminLog', adminLogSchema, 'yaksha_faq_adminlogs');


### PR DESCRIPTION
### Summary

This PR adds a descending index on the `createdAt` field of the `AdminLog` model to optimize the primary query patterns used by the admin activity feed and the retention cleanup job.

### Rationale

A review of the current `AdminLog` query patterns identified two primary workloads:

1. **Activity Feed Retrieval**

   ```ts
   AdminLog.find().sort('-createdAt')
   ```

   Retrieves all admin logs ordered by newest first.

2. **Retention Policy Cleanup**

   ```ts
   deleteMany({ createdAt: { $lt: before } })
   ```

   Removes log entries older than the configured retention period.

A descending index on `createdAt` allows MongoDB to efficiently satisfy both workloads by avoiding collection scans and in-memory sorting.

A compound index such as `{ adminId: 1, createdAt: -1 }` was considered but rejected because neither query filters on `adminId`. Since MongoDB uses the leading fields of a compound index, that index would not benefit these workloads.

### Verification

* ✅ `npx tsc --noEmit`
* ✅ `npm run test`

Both completed successfully.
