### PR TITLE
chore: add PR template and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Something is broken or behaving unexpectedly
+labels: bug
+---
+
+> **Security issue?** Do NOT open a public issue — email maintainers directly.
+
+## Area
+
+<!-- Backend / Frontend / Pipeline (auto-answer|FAQ audit|Zoom) / Search / Auth / Infrastructure -->
+
+## Environment
+
+<!-- Node version, OS, branch name or commit SHA -->
+<!-- e.g. Node 20.x · Ubuntu 22.04 · main @ a2f1f7a -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Logs / error output
+
+```
+paste here
+```
+
+## Screenshots
+
+<!-- UI bugs — attach screenshot or recording -->
+
+## Anything else
+
+<!-- Related issues, workarounds, suspected root cause -->

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: Something is broken or behaving unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For **security issues**, do NOT open a public issue — email the maintainers directly.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system is affected?
+      options:
+        - Backend (API / Express)
+        - Frontend (React / UI)
+        - Pipeline — auto-answer
+        - Pipeline — FAQ audit
+        - Pipeline — Zoom ingestion
+        - Search (hybrid vector + keyword)
+        - Auth / middleware
+        - Infrastructure / Docker
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "Node version, OS, branch name or commit SHA"
+      placeholder: "Node 20.x, Ubuntu 22.04, main @ a2f1f7a"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably trigger the bug
+      placeholder: |
+        1. POST /api/search with body { "query": "..." }
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste backend logs, browser console errors, or API responses
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: UI bugs — attach a screenshot or screen recording
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Related issues, workarounds discovered, suspected root cause

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/vicharanashala/crowd-source-faq/security/advisories/new
+    about: Do NOT open a public issue for security bugs — use GitHub's private advisory instead
+  - name: Question / discussion
+    url: https://github.com/vicharanashala/crowd-source-faq/discussions
+    about: Questions, ideas, architecture discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+labels: enhancement
+---
+
+> North star: **automate the FAQ lifecycle end-to-end, zero people in the loop.**
+
+## Area
+
+<!-- Backend / Frontend / Pipeline (auto-answer|FAQ audit|Zoom) / Search / Auth / Infrastructure / New -->
+
+## Problem / motivation
+
+<!-- What is currently broken, missing, or painful? Who is affected? -->
+
+## Proposed solution
+
+<!-- Describe what you want. Be specific: API shape, UI behaviour, or pipeline change. -->
+
+## Alternatives considered
+
+<!-- Other approaches evaluated and why rejected -->
+
+## Does this move toward zero-human FAQ automation?
+
+<!-- Yes — directly automates a manual step -->
+<!-- Yes — enables automation downstream -->
+<!-- Neutral — improves DX / reliability -->
+<!-- No — but important because: -->
+
+## Anything else
+
+<!-- Mockups, related issues, constraints, prior art -->

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature Request
+description: Propose a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Shamagama's north star: **automate the FAQ lifecycle end-to-end, zero people in the loop.**
+        Before filing, check that your proposal ladders up to that goal.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system does this touch?
+      options:
+        - Backend (API / Express)
+        - Frontend (React / UI)
+        - Pipeline — auto-answer
+        - Pipeline — FAQ audit
+        - Pipeline — Zoom ingestion
+        - Search (hybrid vector + keyword)
+        - Auth / middleware
+        - Infrastructure / Docker
+        - New area
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What is currently broken, missing, or painful? Who is affected?
+      placeholder: "Community managers spend 20 min per FAQ audit cycle because..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you want. Be specific about API shape, UI behaviour, or pipeline change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why you rejected them
+
+  - type: dropdown
+    id: ladder
+    attributes:
+      label: Does this move toward zero-human FAQ automation?
+      options:
+        - "Yes — directly automates a manual step"
+        - "Yes — enables automation downstream"
+        - "Neutral — improves DX / reliability"
+        - "No — but important for another reason (explain below)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, related issues, constraints, prior art

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## What changed
+
+<!-- One paragraph. What does this PR do, and why? -->
+
+## Related issue
+
+<!--
+Closes #ISSUE-NUMBER
+Refs #ISSUE-NUMBER (if partial)
+-->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor (no behaviour change)
+- [ ] Docs / comments only
+- [ ] CI / tooling
+
+## Area affected
+
+- [ ] Backend (Express / Mongoose)
+- [ ] Frontend (React / Vite)
+- [ ] Pipeline (auto-answer / FAQ audit / Zoom ingestion)
+- [ ] Search (hybrid vector + keyword)
+- [ ] Auth / middleware
+- [ ] Docs
+
+## Checklist
+
+- [ ] `cd backend && npx tsc --noEmit` — clean
+- [ ] `cd frontend && npx tsc --noEmit` — clean
+- [ ] Tests pass (`npm test` in affected package)
+- [ ] Single logical change — unrelated fixes noted in description, not fixed here
+- [ ] Docs updated if route / API / env var / pipeline behaviour changed
+- [ ] Rebased onto `main`, no merge commits
+
+## Notes for reviewer
+
+<!-- Anything non-obvious: edge cases, intentional trade-offs, what NOT to review. -->


### PR DESCRIPTION
## Summary

- Adds `PULL_REQUEST_TEMPLATE.md` with type/area checkboxes, typecheck checklist, and reviewer notes section
- Adds `ISSUE_TEMPLATE/bug_report.md` and `bug_report.yml` — environment, repro steps, expected/actual, logs, screenshots
- Adds `ISSUE_TEMPLATE/feature_request.md` and `feature_request.yml` — problem/motivation, solution, north-star alignment check
- Adds `ISSUE_TEMPLATE/config.yml` — disables blank issues, routes security bugs to private advisories and questions to Discussions

Both `.md` (classic inline template) and `.yml` (structured form) variants provided so contributors can pick their preferred format.

## Test plan

- [ ] Open a new issue on the repo — confirm template picker shows Bug Report and Feature Request options
- [ ] Select each template — verify fields render correctly
- [ ] Open a new PR — verify template pre-fills in the description box

🤖 Generated with [Claude Code](https://claude.com/claude-code)