### PR TITLE
feat(ingestion): structural metadata tagging for zoom + document insights

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "seed:badges": "tsx src/scripts/seedBadges.ts",
     "add:post": "tsx src/scripts/addPost.ts",
     "backfill:community": "tsx src/scripts/backfillCommunityEmbeddings.ts",
+    "backfill:insight-metadata": "tsx src/scripts/backfillInsightMetadata.ts",
     "backfill:public-metrics": "tsx src/scripts/backfillPublicMetrics.ts",
     "audit:data": "tsx src/scripts/auditData.ts",
     "cleanup:orphan-notifications": "tsx src/scripts/cleanupOrphanNotifications.ts",

--- a/apps/backend/src/integrations/zoom/zoomExtractor.ts
+++ b/apps/backend/src/integrations/zoom/zoomExtractor.ts
@@ -13,8 +13,11 @@
  *   4. Categorisation — each item is typed as 'FAQ' or 'Announcement'.
  */
 
-import { ZoomInsightType } from '../../modules/zoom/zoom-meeting.model.js';
+import { ZoomInsightType, type InsightCategory, type InsightAudience } from '../../modules/zoom/zoom-meeting.model.js';
 import { resolveProviderAsync } from '../../utils/ai/aiProvider.js';
+// Single source of truth for the structural-metadata taxonomy — shared with
+// the document-insight pipeline so categories/audiences never drift apart.
+import { INSIGHT_CATEGORIES, INSIGHT_AUDIENCES, normalizeTags } from '../../utils/ai/documentAiPipeline.js';
 import { parseVTTWithSpeakers, extractSnippet, isEmptyFromSegments, TranscriptSegment } from './vttParser.js';
 import { logger } from '../../utils/http/logger.js';
 
@@ -23,6 +26,15 @@ export interface ExtractedItem {
   question?: string;       // only for FAQ
   answer_or_content: string;
   confidence_score: number;
+  // ── Structural metadata (tagged at ingestion) ──────────────────────────
+  /** Single closest category from the closed taxonomy. */
+  category: InsightCategory;
+  /** Primary audience from the closed taxonomy. */
+  audience: InsightAudience;
+  /** Normalized long-tail keyword tags ([a-z0-9-]). */
+  tags: string[];
+  /** 1-3 sentence summary — also fed into the keyword index for recall. */
+  summary: string;
   /** ISO 8601 wall-clock timestamp from the transcript when this Q&A appeared */
   transcriptTimestamp?: string;
   /** Speaker name from the transcript for this Q&A */
@@ -63,7 +75,10 @@ const SYSTEM_PROMPT = `You are a precise meeting-notes analyst. Your task is to 
 
 Output rules (strictly follow these):
 - Return ONLY a valid JSON array. No preamble, no explanation, no markdown.
-- Each array item MUST have these exact fields: "type" ("FAQ" or "Announcement"), "question" (string, only for FAQ; omit or null for Announcement), "answer_or_content" (string), "confidence_score" (number 0.0 to 1.0, how certain you are this was correctly extracted), "transcript_snippet" (string, MAX 150 chars, ONLY the exact transcript excerpt that answers THIS specific question or contains THIS announcement — do NOT include other questions/answers), "start_sec" (number, approximate seconds offset in the transcript where this item starts — used to locate the exact segment).
+- Each array item MUST have these exact fields: "type" ("FAQ" or "Announcement"), "question" (string, only for FAQ; omit or null for Announcement), "answer_or_content" (string), "confidence_score" (number 0.0 to 1.0, how certain you are this was correctly extracted), "category" (string, see list below), "audience" (string, see list below), "tags" (array of 2-6 short lowercase keyword strings), "summary" (string, 1-3 sentences packing the key searchable terms), "transcript_snippet" (string, MAX 150 chars, ONLY the exact transcript excerpt that answers THIS specific question or contains THIS announcement — do NOT include other questions/answers), "start_sec" (number, approximate seconds offset in the transcript where this item starts — used to locate the exact segment).
+- "category" — pick the SINGLE closest value from this exact list (copy verbatim): ${INSIGHT_CATEGORIES.map((c) => `"${c}"`).join(', ')}. If nothing fits, use "General".
+- "audience" — who this is primarily for. One of: ${INSIGHT_AUDIENCES.map((a) => `"${a}"`).join(', ')}. Use "All" if unsure.
+- "tags" — specific terms a user would actually type (e.g. "offer-letter", "stipend", "deadline"). No sentences.
 - For FAQs, "question" must be a natural question asked by a participant.
 - For Announcements, "question" should be null.
 - Set confidence_score to 0.0 if the text is garbled, ambiguous, or you're guessing.
@@ -87,6 +102,10 @@ export async function extractInsightsFromTranscript(
         question: 'How do I request an NOC?',
         answer_or_content: 'You can request an NOC by submitting the NOC form on the student dashboard.',
         confidence_score: 0.95,
+        category: 'Logistics & Access',
+        audience: 'Intern',
+        tags: ['noc', 'dashboard'],
+        summary: 'Interns request an NOC via the NOC form on the student dashboard.',
         transcript_snippet: 'John: You can request NOC by emailing NOC coordinator or submit NOC form.',
       }
     ];
@@ -255,11 +274,25 @@ function parseExtractedItems(raw: string, segments: TranscriptSegment[]): Extrac
         const rawSnippet = !isNaN(snippetStartSec) ? extractSnippet(segments, snippetStartSec, 120) : '';
         // Fall back to keyword-based extraction if time-based didn't apply
         const finalSnippet = rawSnippet || keywordSnippet(segments, item.question, String(item.answer_or_content ?? ''));
+        // Structural metadata — validate against the closed taxonomy, fall
+        // back to the safe defaults when the model returns an off-list value.
+        const rawCategory = String(raw['category'] ?? '').trim();
+        const category: InsightCategory = (INSIGHT_CATEGORIES as readonly string[]).includes(rawCategory)
+          ? (rawCategory as InsightCategory)
+          : 'General';
+        const rawAudience = String(raw['audience'] ?? '').trim();
+        const audience: InsightAudience = (INSIGHT_AUDIENCES as readonly string[]).includes(rawAudience)
+          ? (rawAudience as InsightAudience)
+          : 'All';
         return {
           type: item.type,
           question: item.question ?? undefined,
           answer_or_content: String(item.answer_or_content).slice(0, 500),
           confidence_score: confidence,
+          category,
+          audience,
+          tags: normalizeTags(raw['tags']),
+          summary: String(raw['summary'] ?? '').slice(0, 600),
           transcriptTimestamp: ts || undefined,
           speaker: spkr || undefined,
           transcript_snippet: (finalSnippet || String(item.transcript_snippet ?? '')).slice(0, 220),

--- a/apps/backend/src/modules/faq/faq.model.ts
+++ b/apps/backend/src/modules/faq/faq.model.ts
@@ -300,7 +300,13 @@ const faqSchema = new MongooseSchema(
   { timestamps: true }
 );
 
-faqSchema.index({ question: 'text', answer: 'text' });
+// Keyword search index — `tags` (carried forward from insight ingestion
+// metadata) are weighted alongside question/answer so tag terms boost both
+// the /api/search lexical ranker and the RAG retrieval that share this index.
+faqSchema.index(
+  { question: 'text', answer: 'text', tags: 'text' },
+  { weights: { question: 10, tags: 5, answer: 2 }, name: 'faq_text' },
+);
 faqSchema.index({ trustLevel: 1, objectionStatus: 1, promotedAt: 1 });
 faqSchema.index({ sourceType: 1, sourceCommunityPostId: 1 });
 // Hot-field indexes for admin/frontend queries

--- a/apps/backend/src/modules/knowledge/document-insight.model.ts
+++ b/apps/backend/src/modules/knowledge/document-insight.model.ts
@@ -25,6 +25,21 @@ import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
 
 export type DocumentInsightType = 'FAQ' | 'Announcement' | 'Policy' | 'HowTo' | 'Fact';
 
+/** Closed taxonomy — kept in sync with documentAiPipeline.INSIGHT_CATEGORIES. */
+export type DocumentInsightCategory =
+  | 'Onboarding'
+  | 'Schedule & Deadlines'
+  | 'Assignments & Projects'
+  | 'Policies & Rules'
+  | 'Technical Setup'
+  | 'Certification & Evaluation'
+  | 'Payment & Stipend'
+  | 'Logistics & Access'
+  | 'Career & Placement'
+  | 'General';
+
+export type DocumentInsightAudience = 'Intern' | 'Mentor' | 'Admin' | 'All';
+
 export type DocumentInsightStatus =
   | 'pending_review'
   | 'approved'
@@ -43,6 +58,15 @@ export interface IDocumentInsight extends Document {
   status: DocumentInsightStatus;
   /** AI confidence (0-1). Echoed from the AI response. */
   confidence_score: number;
+  // ── Structural metadata (LLM-tagged at ingestion) ──────────────────────
+  /** Single closest category from the closed taxonomy. */
+  category: DocumentInsightCategory;
+  /** Primary audience this insight serves. */
+  audience: DocumentInsightAudience;
+  /** Normalized long-tail keyword tags ([a-z0-9-]). */
+  tags: string[];
+  /** 1-3 sentence summary — also indexed for keyword search recall. */
+  summary: string;
   /** Page number / cell reference for tabular sources, if known. */
   pageNumber: number | null;
   /** Short excerpt of the source text this insight was extracted from. */
@@ -94,6 +118,32 @@ const documentInsightSchema = new MongooseSchema<IDocumentInsight>(
       index: true,
     },
     confidence_score: { type: Number, default: 0, min: 0, max: 1 },
+    // ── Structural metadata (LLM-tagged at ingestion) ──────────────────────
+    category: {
+      type: String,
+      enum: [
+        'Onboarding',
+        'Schedule & Deadlines',
+        'Assignments & Projects',
+        'Policies & Rules',
+        'Technical Setup',
+        'Certification & Evaluation',
+        'Payment & Stipend',
+        'Logistics & Access',
+        'Career & Placement',
+        'General',
+      ],
+      default: 'General',
+      index: true,
+    },
+    audience: {
+      type: String,
+      enum: ['Intern', 'Mentor', 'Admin', 'All'],
+      default: 'All',
+      index: true,
+    },
+    tags: { type: [String], default: [], index: true },
+    summary: { type: String, default: '', maxlength: 600 },
     pageNumber: { type: Number, default: null },
     sourceExcerpt: { type: String, default: '', maxlength: 500 },
     searchMatchCount: { type: Number, default: 0, min: 0, index: true },
@@ -125,6 +175,17 @@ documentInsightSchema.index({ status: 1, searchMatchCount: -1, createdAt: -1 });
 
 // "Insights from this document" detail view
 documentInsightSchema.index({ documentId: 1, createdAt: -1 });
+
+// Keyword search recall — the LLM summary is term-dense, so indexing it
+// alongside question/answer is the cheapest way to recover the relevance
+// the embedding model used to provide. `tags` boosts exact keyword hits.
+documentInsightSchema.index(
+  { question: 'text', answer_or_content: 'text', summary: 'text', tags: 'text' },
+  { weights: { question: 10, summary: 6, tags: 4, answer_or_content: 2 }, name: 'insight_text' },
+);
+
+// Faceted filtering / tag boosting at search time (status-scoped).
+documentInsightSchema.index({ status: 1, category: 1, audience: 1 });
 
 // ─── Export ──────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/modules/zoom/zoom-meeting.model.ts
+++ b/apps/backend/src/modules/zoom/zoom-meeting.model.ts
@@ -5,6 +5,22 @@ import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
 export type ZoomMeetingStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'dead_letter';
 export type ZoomInsightType   = 'FAQ' | 'Announcement';
 
+/** Closed taxonomy — kept in sync with documentAiPipeline.INSIGHT_CATEGORIES. */
+export type InsightCategory =
+  | 'Onboarding'
+  | 'Schedule & Deadlines'
+  | 'Assignments & Projects'
+  | 'Policies & Rules'
+  | 'Technical Setup'
+  | 'Certification & Evaluation'
+  | 'Payment & Stipend'
+  | 'Logistics & Access'
+  | 'Career & Placement'
+  | 'General';
+
+/** Closed taxonomy — kept in sync with documentAiPipeline.INSIGHT_AUDIENCES. */
+export type InsightAudience = 'Intern' | 'Mentor' | 'Admin' | 'All';
+
 /**
  * How the transcript entered the system.
  * - webhook    : received via Zoom webhook (auto-download)
@@ -34,6 +50,15 @@ export interface IZoomInsight extends Document {
   question?: string;
   answer_or_content: string;
   confidence_score: number;
+  // ── Structural metadata (LLM-tagged at ingestion) ──────────────────────
+  /** Single closest category from the closed taxonomy. */
+  category: InsightCategory;
+  /** Primary audience this insight serves. */
+  audience: InsightAudience;
+  /** Normalized long-tail keyword tags ([a-z0-9-]). */
+  tags: string[];
+  /** 1-3 sentence summary — also indexed for keyword search recall. */
+  summary: string;
   status: 'pending_review' | 'approved' | 'rejected';
   reviewedBy?: Types.ObjectId;
   reviewedAt?: Date;
@@ -132,6 +157,30 @@ const zoomInsightSchema = new MongooseSchema<IZoomInsight>(
       min: 0,
       max: 1,
     },
+    // ── Structural metadata (LLM-tagged at ingestion) ──────────────────────
+    category: {
+      type: String,
+      enum: [
+        'Onboarding',
+        'Schedule & Deadlines',
+        'Assignments & Projects',
+        'Policies & Rules',
+        'Technical Setup',
+        'Certification & Evaluation',
+        'Payment & Stipend',
+        'Logistics & Access',
+        'Career & Placement',
+        'General',
+      ] as InsightCategory[],
+      default: 'General',
+    },
+    audience: {
+      type: String,
+      enum: ['Intern', 'Mentor', 'Admin', 'All'] as InsightAudience[],
+      default: 'All',
+    },
+    tags: { type: [String], default: [] },
+    summary: { type: String, default: '', maxlength: 600 },
     status: {
       type: String,
       enum: ['pending_review', 'approved', 'rejected'],
@@ -268,6 +317,14 @@ zoomMeetingSchema.index({ status: 1, nextRetryAt: 1, retryCount: 1 });
 zoomInsightSchema.index({ meetingId: 1 });
 zoomInsightSchema.index({ status: 1, type: 1 });
 zoomInsightSchema.index({ publishedFaqId: 1 }, { sparse: true });
+// Keyword search recall — index the term-dense summary alongside
+// question/answer; `tags` boosts exact keyword hits.
+zoomInsightSchema.index(
+  { question: 'text', answer_or_content: 'text', summary: 'text', tags: 'text' },
+  { weights: { question: 10, summary: 6, tags: 4, answer_or_content: 2 }, name: 'zoom_insight_text' },
+);
+// Faceted filtering / tag boosting at search time (status-scoped).
+zoomInsightSchema.index({ status: 1, category: 1, audience: 1 });
 
 // ─── Models ────────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/modules/zoom/zoom.controller.ts
+++ b/apps/backend/src/modules/zoom/zoom.controller.ts
@@ -418,6 +418,11 @@ export async function processTranscriptPayloadInternal(
       question: item.question,
       answer_or_content: item.answer_or_content,
       confidence_score: item.confidence_score,
+      // Structural metadata tagged at ingestion by the AI pipeline.
+      category: item.category,
+      audience: item.audience,
+      tags: item.tags,
+      summary: item.summary,
       transcript_snippet: item.transcript_snippet,
       // ── Provenance ─────────────────────────────────────────────────────────
       sourcing,
@@ -618,17 +623,20 @@ export async function convertInsightToFAQ(req: Request, res: Response): Promise<
     const { default: FAQ } = await import('../faq/faq.model.js');
     const { generateEmbedding } = await import('../../utils/ai/embeddings.js');
 
-    const tags: string[] = [];
-    if (insight.question) {
+    // Prefer the LLM-generated structural tags; fall back to a naive
+    // word-split of the question for legacy insights with no tags. The
+    // tags feed the FAQ text index so they power search/RAG retrieval.
+    let tags: string[] = Array.isArray(insight.tags) ? insight.tags : [];
+    if (tags.length === 0 && insight.question) {
       const words = insight.question.toLowerCase().match(/\b\w{4,}\b/g) ?? [];
-      tags.push(...words.slice(0, 5));
+      tags = words.slice(0, 5);
     }
 
     const faq = await FAQ.create({
       question: insight.question ?? insight.answer_or_content.slice(0, 200),
       answer: insight.answer_or_content,
       tags,
-      category: 'Zoom',
+      category: insight.category ?? 'General',
       status: 'approved',
       sourceType: 'zoom_transcript',
       sourceMeetingId: (insight.meetingId as any)?._id ?? null,

--- a/apps/backend/src/scripts/addIndexes.ts
+++ b/apps/backend/src/scripts/addIndexes.ts
@@ -60,6 +60,61 @@ async function migrate() {
     }
   }
 
+  // ── Text indexes (drop-and-recreate) ──────────────────────────────────────
+  // MongoDB allows only ONE text index per collection, so a changed text-index
+  // spec (e.g. FAQ gaining `tags`) conflicts with the old one. We detect any
+  // existing text index with a different name and drop it before creating the
+  // new weighted one. Idempotent: re-running is a no-op once names match.
+  const textIndexes: { coll: string; name: string; key: Record<string, 'text'>; weights: Record<string, number> }[] = [
+    {
+      coll: 'yaksha_faq_faqs',
+      name: 'faq_text',
+      key: { question: 'text', answer: 'text', tags: 'text' },
+      weights: { question: 10, tags: 5, answer: 2 },
+    },
+    {
+      coll: 'yaksha_faq_document_insights',
+      name: 'insight_text',
+      key: { question: 'text', answer_or_content: 'text', summary: 'text', tags: 'text' },
+      weights: { question: 10, summary: 6, tags: 4, answer_or_content: 2 },
+    },
+    {
+      coll: 'yaksha_zoom_insights',
+      name: 'zoom_insight_text',
+      key: { question: 'text', answer_or_content: 'text', summary: 'text', tags: 'text' },
+      weights: { question: 10, summary: 6, tags: 4, answer_or_content: 2 },
+    },
+  ];
+
+  for (const ti of textIndexes) {
+    const coll = db.collection(ti.coll);
+    // Drop any stale text index (a text index reports key { _fts: 'text', ... }).
+    try {
+      const existing = await coll.indexes();
+      for (const ix of existing) {
+        const isText = Object.values(ix.key as Record<string, unknown>).includes('text');
+        if (isText && ix.name && ix.name !== ti.name) {
+          console.log(`Dropping stale text index "${ix.name}" on ${ti.coll}...`);
+          await coll.dropIndex(ix.name);
+        }
+      }
+    } catch (err: any) {
+      // NamespaceNotFound (26) — collection doesn't exist yet; createIndex makes it.
+      if (err.code !== 26) console.log(`  (skip stale-index scan on ${ti.coll}: ${err.message})`);
+    }
+    console.log(`Creating text index "${ti.name}" on ${ti.coll}...`);
+    try {
+      await coll.createIndex(ti.key, { name: ti.name, weights: ti.weights });
+      console.log('  ✓ Created');
+    } catch (err: any) {
+      if (err.code === 85 || err.code === 86) {
+        console.log('  ✓ Already exists — skipping');
+      } else {
+        throw err;
+      }
+    }
+  }
+
   console.log('\n✅ All indexes applied successfully.');
   console.log('Note: TTL index takes up to 60s to begin processing deletions.\n');
 

--- a/apps/backend/src/scripts/backfillInsightMetadata.ts
+++ b/apps/backend/src/scripts/backfillInsightMetadata.ts
@@ -1,0 +1,90 @@
+/**
+ * Backfill structural metadata (category / audience / tags / summary) onto
+ * EXISTING document + zoom insights that were created before the ingestion
+ * tagging prompt existed.
+ *
+ * Run: npm run backfill:insight-metadata
+ *
+ * Idempotent: only rows whose `summary` is missing or empty are processed,
+ * so re-running it resumes where a previous run stopped (e.g. after a crash
+ * or rate-limit). Each row costs one cheap LLM call via tagInsight(), which
+ * never throws — a single bad row falls back to safe defaults and the run
+ * continues.
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+dotenv.config({ path: '.env.local' });
+import mongoose from 'mongoose';
+import { tagInsight, PROMPT_VERSION } from '../utils/ai/documentAiPipeline.js';
+
+const DOC_COLL = 'yaksha_faq_document_insights';
+const ZOOM_COLL = 'yaksha_zoom_insights';
+
+interface InsightRow {
+  _id: mongoose.Types.ObjectId;
+  question?: string;
+  answer_or_content?: string;
+}
+
+/** Throttle between LLM calls so we don't trip provider rate limits. */
+const DELAY_MS = 200;
+
+async function backfillCollection(
+  db: NonNullable<typeof mongoose.connection.db>,
+  collName: string,
+  opts: { setPromptVersion: boolean },
+): Promise<void> {
+  const coll = db.collection(collName);
+  // Untagged = no summary field yet, or an empty summary string.
+  const rows = (await coll
+    .find({ $or: [{ summary: { $exists: false } }, { summary: '' }] })
+    .toArray()) as unknown as InsightRow[];
+
+  console.log(`\n${collName}: ${rows.length} untagged insights`);
+  if (rows.length === 0) return;
+
+  let done = 0;
+  let errors = 0;
+  for (const row of rows) {
+    try {
+      const meta = await tagInsight(row.question ?? '', row.answer_or_content ?? '');
+      const set: Record<string, unknown> = {
+        category: meta.category,
+        audience: meta.audience,
+        tags: meta.tags,
+        summary: meta.summary,
+      };
+      if (opts.setPromptVersion) set.aiPromptVersion = PROMPT_VERSION;
+      await coll.updateOne({ _id: row._id }, { $set: set });
+      done++;
+      process.stdout.write(`\r  ${collName}: ${done}/${rows.length}   `);
+    } catch (err) {
+      errors++;
+      console.error(`\n  [backfill] Failed to tag ${collName} ${row._id}: ${(err as Error).message}`);
+    }
+    await new Promise((r) => setTimeout(r, DELAY_MS));
+  }
+  console.log(`\n  ✓ ${done} tagged${errors ? `, ${errors} errors` : ''}`);
+}
+
+async function main(): Promise<void> {
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI not set.');
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.MONGODB_URI);
+  const db = mongoose.connection.db!;
+
+  // Document insights carry an aiPromptVersion stamp; zoom insights don't.
+  await backfillCollection(db, DOC_COLL, { setPromptVersion: true });
+  await backfillCollection(db, ZOOM_COLL, { setPromptVersion: false });
+
+  console.log('\n✅ Insight metadata backfill complete!');
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error((err as Error).message);
+  process.exit(1);
+});

--- a/apps/backend/src/utils/ai/documentAiPipeline.ts
+++ b/apps/backend/src/utils/ai/documentAiPipeline.ts
@@ -21,6 +21,60 @@ import { resolveProviderAsync, chatWithConfig } from './aiProvider.js';
 import { logger } from '../http/logger.js';
 import type { DocumentInsightType } from '../../modules/knowledge/document-insight.model.js';
 
+// ─── Controlled taxonomy ───────────────────────────────────────────────────
+//
+// Closed vocabulary for the LLM-generated metadata. WHY a fixed list:
+// free-form tags drift ("offer-letter" vs "offer letter" vs "joining-doc"),
+// which fragments the index and makes tag-based boosting/faceting miss. A
+// closed enum keeps `category` + `audience` stable across documents and
+// model swaps. `tags` stay open (the long tail) but are normalized before
+// storage. Tune these two lists to your program's real domain — adding a
+// value here is the only change needed; the prompt + model read from them.
+export const INSIGHT_CATEGORIES = [
+  'Onboarding',
+  'Schedule & Deadlines',
+  'Assignments & Projects',
+  'Policies & Rules',
+  'Technical Setup',
+  'Certification & Evaluation',
+  'Payment & Stipend',
+  'Logistics & Access',
+  'Career & Placement',
+  'General',
+] as const;
+
+export const INSIGHT_AUDIENCES = ['Intern', 'Mentor', 'Admin', 'All'] as const;
+
+const MAX_TAGS_PER_INSIGHT = 8;
+const MAX_TAG_LENGTH = 40;
+
+/**
+ * Normalize a raw LLM tag list into stable storage form: lowercase, hyphen-
+ * separated, [a-z0-9-] only, deduped, length + count capped. Defensive
+ * against the model returning a string, nulls, or junk instead of an array.
+ */
+export function normalizeTags(raw: unknown): string[] {
+  const list = Array.isArray(raw) ? raw : typeof raw === 'string' ? raw.split(',') : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of list) {
+    if (typeof item !== 'string') continue;
+    const tag = item
+      .toLowerCase()
+      .trim()
+      .replace(/[\s_]+/g, '-')
+      .replace(/[^a-z0-9-]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, MAX_TAG_LENGTH);
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+    if (out.length >= MAX_TAGS_PER_INSIGHT) break;
+  }
+  return out;
+}
+
 // ─── Schemas ─────────────────────────────────────────────────────────────────
 
 const InsightSchema = z.object({
@@ -28,6 +82,15 @@ const InsightSchema = z.object({
   question: z.string().max(500).default(''),
   answer_or_content: z.string().min(1).max(5000),
   confidence_score: z.number().min(0).max(1),
+  // ── Structural metadata (tagged at ingestion) ──────────────────────────
+  /** Single closest category from the closed taxonomy. */
+  category: z.enum(INSIGHT_CATEGORIES).catch('General'),
+  /** Primary audience from the closed taxonomy. */
+  audience: z.enum(INSIGHT_AUDIENCES).catch('All'),
+  /** Open long-tail tags, normalized to [a-z0-9-]. */
+  tags: z.preprocess(normalizeTags, z.array(z.string()).max(MAX_TAGS_PER_INSIGHT)).default([]),
+  /** 1-3 sentence summary — also fed into the keyword index for recall. */
+  summary: z.string().max(600).default(''),
   /** Optional 0-based character offset in the source text. */
   source_offset: z.number().int().nonnegative().optional(),
 });
@@ -61,7 +124,7 @@ export type ExtractedDocumentInsight = z.infer<typeof InsightSchema>;
 
 // ─── Prompts ─────────────────────────────────────────────────────────────────
 
-const _PROMPT_VERSION = 'v1';
+export const PROMPT_VERSION = 'v2';
 
 const SYSTEM_PROMPT = `You are a precise knowledge-base analyst. Read the provided document text and extract anything that a user might later search for or ask about. Be generous: when in doubt, include it. The admin review queue will sort quality from there.
 
@@ -74,6 +137,14 @@ const SYSTEM_PROMPT = `You are a precise knowledge-base analyst. Read the provid
 4. **Announcement** — A dated event, deadline, or change.
 5. **Fact** — A standalone fact, definition, or reference point that users will likely want to look up. Use this liberally: dates, names, numbers, glossaries, specifications, summaries, named entities. Empty \`question\` is fine for Facts.
 
+**Structural metadata (REQUIRED on every insight):**
+- "category" — pick the SINGLE closest value from this exact list (copy verbatim):
+  ${INSIGHT_CATEGORIES.map((c) => `"${c}"`).join(', ')}.
+  If nothing fits, use "General".
+- "audience" — who this is primarily for. One of: ${INSIGHT_AUDIENCES.map((a) => `"${a}"`).join(', ')}. Use "All" if unsure.
+- "tags" — 2 to 6 short lowercase keyword tags (e.g. "offer-letter", "stipend", "deadline"). Specific terms a user would actually type. No sentences.
+- "summary" — a 1 to 3 sentence plain-language summary of the insight. This powers search, so pack in the key terms a user might search for.
+
 **Output rules:**
 - Start with { and end with }. Nothing else.
 - Prefer MANY short, atomic insights over a few long ones. A 5-page PDF should produce 15-30 insights, not 3.
@@ -81,7 +152,10 @@ const SYSTEM_PROMPT = `You are a precise knowledge-base analyst. Read the provid
 - For each insight, set confidence_score to your honest 0.0-1.0 estimate. Keep ≥ 0.4.
 - question can be empty for Policy / HowTo / Announcement / Fact.
 - Use ONLY facts present in the text. Never invent steps, dates, or rules.
-- If the document is genuinely empty / noise, return { "insights": [] }. Don't fabricate.`;
+- If the document is genuinely empty / noise, return { "insights": [] }. Don't fabricate.
+
+Each insight object looks like:
+{"type":"FAQ","question":"...","answer_or_content":"...","confidence_score":0.8,"category":"Onboarding","audience":"Intern","tags":["offer-letter","joining"],"summary":"..."}`;
 
 // ─── Public entry point ──────────────────────────────────────────────────────
 
@@ -170,6 +244,68 @@ Extract the most useful FAQ / Policy / HowTo / Announcement insights as JSON.`;
     return [];
   }
   return result.data.insights;
+}
+
+// ─── Per-insight tagging (backfill / re-tag of EXISTING rows) ────────────────
+
+const MetadataSchema = z.object({
+  category: z.enum(INSIGHT_CATEGORIES).catch('General'),
+  audience: z.enum(INSIGHT_AUDIENCES).catch('All'),
+  tags: z.preprocess(normalizeTags, z.array(z.string()).max(MAX_TAGS_PER_INSIGHT)).default([]),
+  summary: z.string().max(600).default(''),
+});
+
+export type InsightMetadata = z.infer<typeof MetadataSchema>;
+
+const TAG_SYSTEM_PROMPT = `You assign structured metadata to a SINGLE knowledge-base entry (a question + its answer/content).
+
+Output ONLY a raw JSON object — start with { and end with }. No prose, no markdown fences, no <think> blocks.
+
+Fields (all required):
+- "category" — the SINGLE closest value from this exact list (copy verbatim): ${INSIGHT_CATEGORIES.map((c) => `"${c}"`).join(', ')}. If nothing fits, use "General".
+- "audience" — who this is primarily for. One of: ${INSIGHT_AUDIENCES.map((a) => `"${a}"`).join(', ')}. Use "All" if unsure.
+- "tags" — 2 to 6 short lowercase keyword tags a user would actually type (e.g. "offer-letter", "stipend"). No sentences.
+- "summary" — a 1 to 3 sentence plain-language summary packing the key searchable terms.
+
+Example: {"category":"Onboarding","audience":"Intern","tags":["offer-letter","joining"],"summary":"..."}`;
+
+/** Safe defaults used when the entry is empty or the AI call/parse fails. */
+const DEFAULT_METADATA: InsightMetadata = { category: 'General', audience: 'All', tags: [], summary: '' };
+
+/**
+ * Tag one already-stored insight. Used by the backfill script to add
+ * structural metadata to rows created before the tagging prompt existed.
+ * Never throws — returns safe defaults on any failure so a single bad row
+ * can't abort a long backfill run.
+ */
+export async function tagInsight(question: string, content: string): Promise<InsightMetadata> {
+  const q = (question ?? '').trim();
+  const c = (content ?? '').trim();
+  if (q.length + c.length < 10) return { ...DEFAULT_METADATA };
+
+  try {
+    const config = await resolveProviderAsync();
+    const userMsg = `Question: ${q || '(none)'}\n\nAnswer / content:\n${c.slice(0, 4000)}\n\nReturn the metadata JSON object.`;
+    const text = await chatWithConfig(config, [
+      { role: 'system', content: TAG_SYSTEM_PROMPT },
+      { role: 'user', content: userMsg },
+    ]);
+
+    const cleaned = stripAllWrappers(text);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      const recovered = extractJsonSubstring(cleaned);
+      if (recovered === null) return { ...DEFAULT_METADATA };
+      parsed = JSON.parse(recovered);
+    }
+    const result = MetadataSchema.safeParse(parsed);
+    return result.success ? result.data : { ...DEFAULT_METADATA };
+  } catch (err) {
+    logger.warn(`[documentAiPipeline] tagInsight failed: ${(err as Error).message}`);
+    return { ...DEFAULT_METADATA };
+  }
 }
 
 /** Best-effort: keep whole paragraphs up to `maxChars`, cut on a paragraph boundary. */

--- a/apps/backend/src/utils/documentPromotion.ts
+++ b/apps/backend/src/utils/documentPromotion.ts
@@ -54,8 +54,11 @@ export async function promoteInsightToFaq(
   const faq = await FAQ.create({
     question: fallbackQuestion,
     answer: insight.answer_or_content,
-    tags: [],
-    category: 'document-promotion',
+    // Carry the LLM-generated structural metadata forward so it powers
+    // FAQ search/RAG retrieval (tags feed the FAQ text index; category
+    // feeds faceting). Falls back to safe defaults for legacy insights.
+    tags: insight.tags ?? [],
+    category: insight.category ?? 'General',
     status: 'approved',
     sourceType: 'manual', // existing union — document-promotion source would be additive; reusing 'manual' for v1
     createdBy: reviewedByUserId ?? null,

--- a/apps/backend/src/utils/jobs/documentJob.ts
+++ b/apps/backend/src/utils/jobs/documentJob.ts
@@ -17,7 +17,7 @@
 import DocumentRecord, { type IDocumentRecord } from '../../modules/knowledge/document-record.model.js';
 import DocumentInsight from '../../modules/knowledge/document-insight.model.js';
 import { extractTextFromFile, type ExtractionResult } from '../documentExtractor.js';
-import { extractInsightsFromText } from '../ai/documentAiPipeline.js';
+import { extractInsightsFromText, PROMPT_VERSION } from '../ai/documentAiPipeline.js';
 import { logger } from '../http/logger.js';
 import type { DocumentJobData, DocumentJobResult } from './documentQueue.js';
 
@@ -68,6 +68,11 @@ export async function processDocument(data: DocumentJobData): Promise<DocumentJo
       question: i.question ?? '',
       answer_or_content: i.answer_or_content,
       confidence_score: i.confidence_score,
+      // Structural metadata tagged at ingestion by the AI pipeline.
+      category: i.category,
+      audience: i.audience,
+      tags: i.tags,
+      summary: i.summary,
       status: 'pending_review' as const,
       pageNumber: null,
       sourceExcerpt: excerptAround(extraction.text, i.question, 240),
@@ -76,7 +81,7 @@ export async function processDocument(data: DocumentJobData): Promise<DocumentJo
       reviewedAt: null,
       publishedFaqId: null,
       promotionReason: null,
-      aiPromptVersion: 'v1',
+      aiPromptVersion: PROMPT_VERSION,
     }));
     await DocumentInsight.insertMany(rows);
   }


### PR DESCRIPTION
## What & why

Adopts **structural tagging at ingestion** for the Zoom and document insight pipelines: the existing LLM extraction calls now also return `category` / `audience` / `tags` / `summary`, which are stored in indexed fields and wired into FAQ search/RAG retrieval. First concrete step toward reducing reliance on the embedding model by strengthening the lexical retrieval layer.

## Changes

**Ingestion tagging**
- `documentAiPipeline.ts` / `zoomExtractor.ts`: shared closed taxonomy (`INSIGHT_CATEGORIES`, `INSIGHT_AUDIENCES`) + `normalizeTags`; prompts emit the four metadata fields with defensive validation and safe fallbacks. Document prompt bumped to `v2`.
- `document-insight.model.ts` / `zoom-meeting.model.ts`: new fields + weighted `$text` index (including the term-dense `summary`) + `{status, category, audience}` facet index. Persistence wired in `documentJob.ts` and `zoom.controller.ts`.

**Search/RAG wiring**
- Promotion carries the LLM metadata onto the FAQ (the searched collection): `documentPromotion.ts` and `zoom.controller.convertInsightToFAQ` set `faq.tags` / `faq.category` (legacy fallbacks preserved).
- `faq.model.ts`: FAQ `$text` index extended to `{question, answer, tags}` with weights, so tags feed **both** `/api/search` and RAG lexical recall (they share the index).

**Migration & backfill (idempotent)**
- `addIndexes.ts`: drop-and-recreate of the text indexes (Mongo allows one text index per collection).
- `backfillInsightMetadata.ts` (+ `npm run backfill:insight-metadata`): re-tags existing rows via a never-throwing `tagInsight()` helper.

## Deploy steps
1. `npm run migrate` — builds the new text/facet indexes, drops the stale FAQ text index.
2. `npm run backfill:insight-metadata` — tags pre-existing insights.

## Verification
- `tsc --noEmit` clean (exit 0)
- Full backend test suite: **230 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)