### PR TITLE
fix(db): recover from broken DNS resolver before Atlas SRV lookup

### DIFF
--- a/apps/backend/src/config/db.ts
+++ b/apps/backend/src/config/db.ts
@@ -1,9 +1,61 @@
 // Import Mongoose to interact with MongoDB
+import dns from 'node:dns';
 import mongoose, { Connection } from 'mongoose';
 import { dbLog } from '../utils/http/logger.js';
 
 // Cache connection in serverless environment
 let cachedConnection: Connection | null = null;
+
+/**
+ * Ensure Node's DNS resolver can actually answer SRV queries before we try a
+ * `mongodb+srv://` connection.
+ *
+ * On some Windows / VPN setups Node (c-ares) ends up with a useless resolver —
+ * e.g. `127.0.0.1` (nothing listening there) or an IPv6 link-local server
+ * (`fe80::…`, which c-ares can't query) — so the Atlas SRV lookup fails with
+ * `querySrv ECONNREFUSED` even though the system resolver works fine. We detect
+ * that and fall back to public DNS. Override with `DNS_SERVERS=8.8.8.8,1.1.1.1`.
+ */
+function ensureUsableDnsServers(): void {
+  const override = (process.env.DNS_SERVERS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (override.length > 0) {
+    try {
+      dns.setServers(override);
+      dbLog.info('DNS servers set from DNS_SERVERS', { servers: override });
+    } catch (err) {
+      dbLog.alert('failed to apply DNS_SERVERS override', { message: (err as Error).message });
+    }
+    return;
+  }
+
+  let current: string[] = [];
+  try {
+    current = dns.getServers();
+  } catch {
+    /* getServers can throw on odd platforms — treat as "unknown / broken" */
+  }
+
+  const isUnusable = (s: string): boolean =>
+    s.startsWith('127.') || s === '::1' || s.toLowerCase().startsWith('fe80');
+
+  const broken = current.length === 0 || current.every(isUnusable);
+  if (broken) {
+    const fallback = ['8.8.8.8', '1.1.1.1'];
+    try {
+      dns.setServers(fallback);
+      dbLog.info('DNS resolver looked unusable for SRV — switched to public DNS', {
+        previous: current,
+        now: fallback,
+      });
+    } catch (err) {
+      dbLog.alert('failed to set fallback DNS servers', { message: (err as Error).message });
+    }
+  }
+}
 
 // v1.67 — Wire mongoose's connection event listeners so we get
 // DISCORD-pinging ALERTS on disconnect / reconnection, not just
@@ -35,6 +87,9 @@ const connectDB = async (): Promise<Connection> => {
     dbLog.alert('MONGODB_URI missing at startup', { nodeEnv: process.env.NODE_ENV });
     throw new Error('MONGODB_URI environment variable is missing');
   }
+
+  // Fix a broken DNS resolver before the mongodb+srv SRV lookup runs.
+  ensureUsableDnsServers();
 
   try {
     // Connect using the URI from environment variables with a 5-second timeout


### PR DESCRIPTION
## Problem

Backend startup fails to connect to MongoDB Atlas with:

```
[db] connection failed at startup {"message":"querySrv ECONNREFUSED _mongodb._tcp.<cluster>.mongodb.net"}
```

…and every DB-backed request then 500s with `buffering timed out after 10000ms` (e.g. `GET /csfaq/api/batches`).

This is **not** an IP-allowlist problem (reproduced with `0.0.0.0/0` allowed). The `mongodb+srv://` scheme needs a DNS **SRV** lookup, and on some Windows/VPN setups Node's c-ares resolver ends up with an unusable DNS server — observed `127.0.0.1` (nothing listening) and IPv6 link-local `fe80::…` (which c-ares can't query) — so `querySrv` returns `ECONNREFUSED` even though the OS resolver answers SRV fine.

## Fix

`connectDB()` now calls `ensureUsableDnsServers()` before connecting:
- Inspects `dns.getServers()`.
- **Only** when it looks unusable for SRV (empty, loopback `127.*`/`::1`, or link-local `fe80:*`) does it fall back to public DNS (`8.8.8.8`, `1.1.1.1`).
- Healthy environments (prod / Vercel / Atlas-hosted) are left completely untouched.
- Overridable via `DNS_SERVERS=8.8.8.8,1.1.1.1` (or corporate DNS) in env.

## Verification

- `tsc --noEmit` clean.
- Isolated repro: forced `dns.setServers(['127.0.0.1'])` → fix switched to public DNS → Atlas `connect OK`.
- Live: startup log shows `DNS resolver looked unusable for SRV — switched to public DNS {"previous":["127.0.0.1"],"now":["8.8.8.8","1.1.1.1"]}` then `connected at startup`; `GET /csfaq/api/batches` returns **200** with data instead of a 500 timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)