### PR TITLE
fix(search): keyword fallback + repair FAILED Atlas vector index

### DIFF
--- a/apps/backend/src/modules/search/search.controller.ts
+++ b/apps/backend/src/modules/search/search.controller.ts
@@ -271,13 +271,25 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
       return;
     }
 
-    // 2. Compute AI Embedding for the search term
-    const embedding = await generateQueryEmbedding(query);
+    // 2. Compute AI Embedding for the search term. If the embedding service
+    //    is unreachable (e.g. local model/endpoint down), DON'T fail the whole
+    //    request — degrade gracefully to keyword-only search. The hybrid
+    //    pipeline already runs a $text ranker, so results still come back.
+    let embedding: number[] | null = null;
+    try {
+      embedding = await generateQueryEmbedding(query);
+    } catch (embErr) {
+      httpLog.warn('search.embedding.failed — falling back to keyword-only search', {
+        error: embErr instanceof Error ? embErr.message : String(embErr),
+      });
+    }
 
-    // 3. Execute Vector and Text searches in parallel across both collections for maximum speed
+    // 3. Execute Vector (when an embedding is available) + Text searches in
+    //    parallel across both collections for maximum speed.
+    const empty = Promise.resolve([] as SearchResultItem[]);
     const [faqVec, commVec, faqTxt, commTxt] = await Promise.all([
-      runVectorSearch('yaksha_faq_faqs', embedding, 5, batchIdObjectId),
-      runVectorSearch('yaksha_faq_communityposts', embedding, 5, batchIdObjectId),
+      embedding ? runVectorSearch('yaksha_faq_faqs', embedding, 5, batchIdObjectId) : empty,
+      embedding ? runVectorSearch('yaksha_faq_communityposts', embedding, 5, batchIdObjectId) : empty,
       runTextSearch('yaksha_faq_faqs', query, 5, batchIdObjectId),
       runTextSearch('yaksha_faq_communityposts', query, 5, batchIdObjectId)
     ]);

--- a/apps/backend/src/scripts/createVectorIndex.ts
+++ b/apps/backend/src/scripts/createVectorIndex.ts
@@ -43,12 +43,18 @@ if (!MONGO_URI) {
   process.exit(1);
 }
 
-const DB_NAME = 'yaksha_faq';
+// Connect to the SAME database the app uses. connectDB() (config/db.ts) calls
+// mongoose.connect(MONGODB_URI) with no dbName, so it uses the URI's default
+// database. Hardcoding a different dbName here created the index on the wrong
+// DB, leaving the app's collections without a usable vector index. Honour an
+// explicit MONGODB_DB override but otherwise inherit the URI's database.
+const DB_NAME = process.env.MONGODB_DB?.trim() || undefined;
 const SHOULD_DROP = process.argv.includes('--drop');
 
 async function createIndexes() {
-  await mongoose.connect(MONGO_URI, { dbName: DB_NAME });
+  await mongoose.connect(MONGO_URI, DB_NAME ? { dbName: DB_NAME } : {});
   const db = mongoose.connection.db!;
+  console.log(`Connected to database: ${db.databaseName}`);
 
   const faqCollection = db.collection('yaksha_faq_faqs');
   const postCollection = db.collection('yaksha_faq_communityposts');
@@ -73,16 +79,25 @@ async function createIndexes() {
   // $vectorSearch had no field to query. Switched to the
   // (A) array format — it's the canonical one Atlas UI
   // generates today.
+  // Atlas `vectorSearch` indexes require field type 'vector' (the legacy
+  // 'knnVector' value is rejected with "fields[0].type must be one of
+  // [autoEmbed, embeddedDocuments, filter, text, vector]" → index FAILED).
+  // The `batchId` filter field is required because the search controller
+  // scopes $vectorSearch with `filter: { batchId }` for per-program search.
   const VECTOR_INDEX = {
     name: 'vector_index',
     type: 'vectorSearch',
     definition: {
       fields: [
         {
-          type: 'knnVector',
+          type: 'vector',
           path: 'embedding',
           numDimensions: activeDimensions,
           similarity: 'dotProduct',
+        },
+        {
+          type: 'filter',
+          path: 'batchId',
         },
       ],
     },

--- a/apps/backend/src/scripts/setupNewCluster.ts
+++ b/apps/backend/src/scripts/setupNewCluster.ts
@@ -273,16 +273,23 @@ async function main(): Promise<void> {
     // which isn't a real Atlas format — the index got
     // created but $vectorSearch had no field to query.
     // Switched to the canonical `fields` array form.
+    // Atlas `vectorSearch` indexes require field type 'vector' ('knnVector'
+    // is rejected → index FAILED). `batchId` filter supports per-program
+    // scoped $vectorSearch in the search controller.
     const VECTOR_INDEX = {
       name: 'vector_index',
       type: 'vectorSearch',
       definition: {
         fields: [
           {
-            type: 'knnVector',
+            type: 'vector',
             path: 'embedding',
             numDimensions: embeddingDim,
             similarity: 'dotProduct',
+          },
+          {
+            type: 'filter',
+            path: 'batchId',
           },
         ],
       },


### PR DESCRIPTION
## Problem

The search bar showed results briefly, then **"Search failed. Please check your connection and try again"** — and for some keywords it never worked. Backend logs were full of `Failed to generate embedding … Connection error`.

Two distinct bugs:

1. **`/api/search` hard-failed when the embedding service was unreachable.** `generateQueryEmbedding()` wasn't error-handled, so any embedding outage threw and 500'd the entire request. Cached queries (Redis/LRU) still worked, so it looked intermittent — results flashing then erroring.
2. **The Atlas `vector_index` was in `FAILED` state** — created with the invalid field type `"knnVector"`. Atlas's `vectorSearch` index requires `type: "vector"`:
   ```
   Invalid definition: fields[0].type must be one of [autoEmbed, embeddedDocuments, filter, text, vector]
   ```
   So `$vectorSearch` returned nothing even when embeddings were present — semantic search never actually worked.

## Changes

- **`search.controller.ts`** — graceful fallback: the embedding step is wrapped in try/catch. **Embedding reachable → vector + text (RRF); embedding down → keyword-only `$text` search.** Search never hard-fails again.
- **`createVectorIndex.ts` + `setupNewCluster.ts`** — `knnVector` → `vector`, and added the `batchId` filter field the search controller scopes `$vectorSearch` on.
- **`createVectorIndex.ts`** — stopped hardcoding `dbName: 'yaksha_faq'`; it now inherits the URI's database (matching `connectDB()`), with an optional `MONGODB_DB` override. Previously it built the index on the wrong DB.

## Verification

- `tsc --noEmit` clean.
- **Embedding available** (+ index rebuilt with the fix): direct `$vectorSearch` returns the exact FAQ at score **1.0**, related ones at 0.93 / 0.90 (all clear the 0.80 threshold).
- **Embedding unreachable**: `POST /api/search` returns **200** with keyword results — no error.

## Operational note

After deploy, recreate the vector indexes so the live `FAILED` index is replaced:
```
npm run create:vector-index -- --drop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)