### PR TITLE
chore(frontend): hide chatbot (AskAI) from UI

### DIFF
--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -95,7 +95,9 @@ export default function AppRoutes() {
     );
   }
 
-  const showAskAI = !location.pathname.startsWith('/admin');
+  // Chatbot temporarily disabled from the frontend. To re-enable, restore:
+  // const showAskAI = !location.pathname.startsWith('/admin');
+  const showAskAI = false;
 
   return (
     <>


### PR DESCRIPTION
## Summary
Temporarily hides the AskAI chatbot button from the frontend without removing its functionality or styling.

## Changes
- Gate `AskAIButton` rendering behind `showAskAI = false` in `apps/frontend/src/routes/AppRoutes.tsx`.
- The original visibility condition (`!location.pathname.startsWith('/admin')`) is preserved as a comment so it can be re-enabled with a one-line change.

## Notes
- No component, logic, or CSS was removed — the chatbot is simply not rendered for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)