### PR TITLE
fix(auth): align register password hint with the 8-char policy

### DIFF
--- a/apps/frontend/src/components/auth/AuthModal.tsx
+++ b/apps/frontend/src/components/auth/AuthModal.tsx
@@ -430,7 +430,7 @@ export default function AuthModal() {
               placeholder="••••••••"
               disabled={loading}
             />
-            <p className="text-[10px] text-ink-faint -mt-2">Minimum 6 characters</p>
+            <p className="text-[10px] text-ink-faint -mt-2">At least 8 characters, including a letter and a number</p>
             <Input
               id="modal-register-confirm"
               name="confirmPassword"


### PR DESCRIPTION
## Summary
Follow-up to the QA/security audit (PR #111). During browser verification of the new password policy, the static helper text under the register password field still read **"Minimum 6 characters"** while validation now enforces **8 chars + a letter + a number**. This aligns the hint with the enforced policy.

## Change
- `apps/frontend/src/components/auth/AuthModal.tsx`: hint text → "At least 8 characters, including a letter and a number".

## Verification
Confirmed in a real browser (Playwright/Chromium against the running app): the register form now shows the corrected hint, a weak password is rejected with the matching error, and a compliant password passes the client-side check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)