### PR TITLE
fix(db): remove duplicate expiresAt index on AdminSession schema

### DIFF
--- a/apps/backend/src/models/AdminSession.ts
+++ b/apps/backend/src/models/AdminSession.ts
@@ -57,7 +57,9 @@ const adminSessionSchema = new MongooseSchema<IAdminSession>(
     adminUsername: { type: String, required: true },
     source: { type: String, enum: ['discord', 'rest'], required: true },
     createdAt: { type: Date, default: Date.now },
-    expiresAt: { type: Date, required: true, index: true },
+    // Index defined explicitly below (schema.index({ expiresAt: 1 })) — do not
+    // also set `index: true` here or Mongoose logs a duplicate-index warning.
+    expiresAt: { type: Date, required: true },
     lastUsedAt: { type: Date, default: Date.now },
     ipAddress: { type: String, default: null },
     userAgent: { type: String, default: null },


### PR DESCRIPTION
## Summary
Full functional smoke-check of the running app (backend + frontend) surfaced one concrete issue: the **AdminSession** schema declared the `expiresAt` index twice, so Mongoose logged a duplicate-index warning on every backend boot.

## What was checked
Ran the backend (connected to MongoDB) and the frontend, then drove the main routes in a real browser (Playwright/Chromium): **home, programs, FAQ, community, support, saved, admin**. Result: **all pages render, 0 JavaScript errors, 0 console errors, 0 5xx responses.** Auth-gated pages correctly prompt sign-in; `/admin` correctly redirects unauthenticated users. The app is functionally healthy.

The only defect found was at the data layer (visible only at runtime):

```
[MONGOOSE] Warning: Duplicate schema index on {"expiresAt":1} found.
```

## Fix
`apps/backend/src/models/AdminSession.ts` declared `expiresAt` with field-level `index: true` **and** an explicit `schema.index({ expiresAt: 1 })`. Removed the field-level `index: true` and kept the explicit, documented index — same resulting indexes, no more warning.

## Verification
- Backend reboots clean — duplicate-index warning gone (count: 0), `/api/health` 200.
- `tsc --noEmit` passes.
- Admin session tests pass (14).