### PR TITLE
feat: make Welcome Package and AskAI chatbot admin-toggleable

### DIFF
--- a/apps/backend/src/modules/program/feature-flag.controller.ts
+++ b/apps/backend/src/modules/program/feature-flag.controller.ts
@@ -37,6 +37,21 @@ export const FEATURE_FLAGS = {
       'When disabled, document uploads are gated and the worker is stopped to free up resources.',
     defaultEnabled: true,
   },
+  welcomePackage: {
+    label: 'Welcome Package',
+    description:
+      'The student onboarding / orientation hub at /welcome (project discovery, ' +
+      'getting-started checklist, etc.). When disabled, the nav link is hidden and ' +
+      'the page shows the unavailable panel.',
+    defaultEnabled: true,
+  },
+  askAiChatbot: {
+    label: 'Ask AI Chatbot',
+    description:
+      'The floating AskAI assistant button shown on non-admin pages. When disabled, ' +
+      'the button is hidden from the UI. Toggle on to re-enable the chatbot for users.',
+    defaultEnabled: false,
+  },
 } as const;
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;

--- a/apps/frontend/src/components/layout/NavPills.tsx
+++ b/apps/frontend/src/components/layout/NavPills.tsx
@@ -16,14 +16,22 @@ export function useNavItems() {
   const { user } = useAuth();
   const supportOn = useFeatureFlag('sessionSupport');
   const goldenOn = useFeatureFlag('goldenTicket');
+  const welcomeOn = useFeatureFlag('welcomePackage');
 
   const goldenExtras: NavItem[] = goldenOn
     ? [{ label: 'Golden', to: '/golden', xlOnly: true as const }]
     : [];
-  
-  let allNavItems: NavItem[] = supportOn
-    ? [...baseNavItems, { label: 'Support', to: '/support' }, ...goldenExtras]
+
+  // Welcome Package nav link is admin-controlled. `welcomeOn` is undefined
+  // while flags load and null for an unknown key — only hide on an explicit
+  // `false` so the link doesn't disappear mid-load.
+  const visibleBaseItems = welcomeOn === false
+    ? baseNavItems.filter((item) => item.to !== '/welcome')
     : baseNavItems;
+
+  let allNavItems: NavItem[] = supportOn
+    ? [...visibleBaseItems, { label: 'Support', to: '/support' }, ...goldenExtras]
+    : visibleBaseItems;
 
   if (user?.role === 'admin') {
     allNavItems = allNavItems

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense, useState, useEffect } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { useFeatureFlag } from '../context/FeatureFlagContext';
 import Spinner from '../components/ui/Spinner';
 import { FeatureGate } from '../components/support/FeatureGate';
 import MainLayout from '../components/layout/MainLayout';
@@ -80,6 +81,7 @@ function GoldenRoute() {
 export default function AppRoutes() {
   const { loading } = useAuth();
   const location = useLocation();
+  const askAiEnabled = useFeatureFlag('askAiChatbot');
   const [mounted, setMounted] = useState(false);
 
   // Prevent flash: only render routes after first auth resolution
@@ -95,9 +97,11 @@ export default function AppRoutes() {
     );
   }
 
-  // Chatbot temporarily disabled from the frontend. To re-enable, restore:
-  // const showAskAI = !location.pathname.startsWith('/admin');
-  const showAskAI = false;
+  // Chatbot visibility is admin-controlled via the `askAiChatbot` feature
+  // flag (/admin/features). Never shown on admin pages. `askAiEnabled` is
+  // undefined while flags load and null for an unknown key — both treated
+  // as off so the button never flashes in.
+  const showAskAI = askAiEnabled === true && !location.pathname.startsWith('/admin');
 
   return (
     <>
@@ -128,7 +132,9 @@ export default function AppRoutes() {
               path="/welcome"
               element={
                 <AccountRoute>
-                  <WelcomePackagePage />
+                  <FeatureGate featureKey="welcomePackage" featureLabel="Welcome Package">
+                    <WelcomePackagePage />
+                  </FeatureGate>
                 </AccountRoute>
               }
             />


### PR DESCRIPTION
## Summary
Makes the **Welcome Package** and **AskAI chatbot** toggleable by admins, reusing the existing feature-flag system surfaced at `/admin/features`. No new infra — both flags auto-seed and changes take effect immediately for all users without a deploy.

## Changes
**Backend** (`feature-flag.controller.ts`) — two new flags added to the canonical `FEATURE_FLAGS` allow-list:
- `welcomePackage` — `defaultEnabled: true` (preserves current behavior)
- `askAiChatbot` — `defaultEnabled: false` (matches the chatbot's current hidden state)

**Frontend**
- `AppRoutes.tsx`: the floating AskAI button now renders only when `askAiChatbot` is on (and never on `/admin`), replacing the hard-coded `showAskAI = false`. The `/welcome` route is wrapped in `<FeatureGate featureKey="welcomePackage">`.
- `NavPills.tsx`: the "Welcome Package" nav pill hides when the flag is explicitly off.

Both gates only treat an explicit `false` as off — `undefined` (loading) / `null` (unknown key) avoid a flash during flag load.

## Scope note
This gates the **UI** only, not the backend `/welcome` / AskAI API endpoints — consistent with how other non-economic flags (e.g. `documentPipeline`) behave here. Happy to add `requireFeatureOn`-style endpoint checks if desired.

## Testing
- `tsc --noEmit` passes on both frontend and backend.