### PR TITLE
fix: resolve four production correctness issues

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,8 +19,8 @@ MONGODB_URI=#
 JWT_SECRET=#
 # Optional: dedicated refresh token secret (defaults to JWT_SECRET)
 JWT_REFRESH_SECRET=#
-# Optional: access token TTL (e.g. 15m, 1h, 7d — defaults to config.yaml)
-JWT_EXPIRES_IN=7d
+# Optional: access token TTL (e.g. 15m, 1h, 7d — defaults to 15m in auth.controller.ts)
+JWT_EXPIRES_IN=15m
 
 # ── Encryption & OAuth Secrets ─────────────────────────────────────────────────
 # Dedicated AES-GCM key for encrypting Zoom tokens, TOTP etc.

--- a/apps/backend/src/bootstrap/app.ts
+++ b/apps/backend/src/bootstrap/app.ts
@@ -87,7 +87,10 @@ export function createApp(config: any): Express {
 
   // Serve static assets and SPA fallback
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const frontendDistPath = path.resolve(__dirname, '../../../frontend/dist');
+  // v1.72 — fixed: __dirname = apps/backend/src/bootstrap → resolve via ../../apps/frontend/dist
+  // Previously resolves to ../../../frontend/dist → /app/frontend/dist (wrong, no such dir).
+  // Built frontend is at /app/apps/frontend/dist (see Dockerfile runtime stage COPY).
+  const frontendDistPath = path.resolve(__dirname, '../../apps/frontend/dist');
 
   // Serve static files under /csfaq base path
   app.use('/csfaq', express.static(frontendDistPath));

--- a/apps/backend/src/integrations/zoom/zoomOAuth.ts
+++ b/apps/backend/src/integrations/zoom/zoomOAuth.ts
@@ -26,7 +26,16 @@ const ZOOM_API_BASE    = 'https://api.zoom.us/v2';
 // Only validate when first called, after dotenv has loaded all env files
 function getClientId()     { const v = process.env.ZOOM_CLIENT_ID;     if (!v) throw new Error('Missing ZOOM_CLIENT_ID env var — add it to backend/.env.local');     return v; }
 function getClientSecret() { const v = process.env.ZOOM_CLIENT_SECRET; if (!v) throw new Error('Missing ZOOM_CLIENT_SECRET env var — add it to backend/.env.local');     return v; }
-function getRedirectUri()  { return process.env.ZOOM_REDIRECT_URI ?? 'http://localhost:6767/csfaq/api/zoom/auth/callback'; }
+function getRedirectUri()  {
+  const fallback = 'http://localhost:6767/csfaq/api/zoom/auth/callback';
+  if (process.env.NODE_ENV === 'production') {
+    if (!process.env.ZOOM_REDIRECT_URI) {
+      throw new Error('ZOOM_REDIRECT_URI is not set in production — set it in Infisical to your public backend URL');
+    }
+    return process.env.ZOOM_REDIRECT_URI;
+  }
+  return process.env.ZOOM_REDIRECT_URI ?? fallback;
+}
 
 /**
  * v1.69 — Phase 5: per-program Zoom credential resolver.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,8 @@ services:
   backend:
     image: ${DOCKERHUB_USERNAME:-vicharanashala}/csfaq-backend:${TAG:-latest}
     build: !reset null
+    # env_file cleared so Infisical CLI (via `command`) fully owns secrets injection.
+    # The .env file is created at runtime by the deploy script BEFORE container start.
     env_file: []
     environment:
       - NODE_ENV=production
@@ -25,7 +27,31 @@ services:
       - INFISICAL_ENVIRONMENT
       - INFISICAL_PROJECT_ID
       - INFISICAL_SECRET_PATH
+      # v1.72 — JWT_SECRET explicitly passed so the container can start even if
+      # Infisical hasn't been reached yet (the Infisical run command populates
+      # .env which is then read by the app — this is for local docker dev only).
+      - JWT_SECRET
     command: ["sh", "-c", "infisical run --env=\"$$INFISICAL_ENVIRONMENT\" --projectId=\"$$INFISICAL_PROJECT_ID\" --path=\"$$INFISICAL_SECRET_PATH\" -- node --import tsx src/server.ts"]
+
+  frontend:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      # Serve the pre-built frontend static files from the host.
+      # The deploy script builds the frontend and places dist/ here.
+      - ./apps/frontend/dist:/usr/share/nginx/html:ro
+    depends_on:
+      - backend
+    restart: unless-stopped
+    networks:
+      - yaksha-net
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   mongodb:
     # Use same image, but persist data on a named volume


### PR DESCRIPTION
1. app.ts: fix frontendDistPath (/app/frontend/dist was wrong, corrected to ../../apps/frontend/dist matching the Dockerfile COPY layout)

2. zoomOAuth.ts: fail fast in production if ZOOM_REDIRECT_URI is unset (was silently defaulting to localhost, breaking OAuth callbacks)

3. .env.example: JWT_EXPIRES_IN now documents 15m (matching auth.controller.ts default — was 7d which is a security risk for access tokens)

4. docker-compose.prod.yml: add nginx:alpine frontend service + inject JWT_SECRET in backend env vars

## What changed

<!-- One paragraph. What does this PR do, and why? -->

## Related issue

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Pipeline (auto-answer / FAQ audit / Zoom ingestion)
- [ ] Search (hybrid vector + keyword)
- [ ] Auth / middleware
- [ ] Docs

## Checklist

- [ ] `cd backend && npx tsc --noEmit` — clean
- [ ] `cd frontend && npx tsc --noEmit` — clean
- [ ] Tests pass (`npm test` in affected package)
- [ ] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer

<!-- Anything non-obvious: edge cases, intentional trade-offs, what NOT to review. -->
