### PR TITLE
feat: show program switcher on navbar for all authenticated users

### DIFF
--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -183,8 +183,8 @@ export default function Navbar({ showProgramSwitcher: _showProgramSwitcher = fal
                   <ZoomBubble />
                   {/* Spurti Points chip */}
                   <SpurtiChip />
-                  {user?.role === 'admin' && (
-                    <BatchSwitcher showCreateLink={true} className="hidden md:inline-flex" />
+                  {isAuthenticated && (
+                    <BatchSwitcher showCreateLink={user?.role === 'admin'} className="hidden md:inline-flex" />
                   )}
 
                   <NotificationBell />


### PR DESCRIPTION
Allows all authenticated users to switch programs from the desktop navbar, keeping the create link restricted to admins.