### PR TITLE
Phase 1 PR0: lock design-system convention (shadcn path split)

### DIFF
--- a/apps/frontend/components.json
+++ b/apps/frontend/components.json
@@ -13,7 +13,7 @@
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
-    "ui": "@/components/ui",
+    "ui": "@/components/ui-shadcn",
     "lib": "@/lib",
     "hooks": "@/hooks"
   },

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,88 @@
+# Design system convention
+
+shamagama frontend has **two coexisting design-system layers**. This document codifies the convention so future contributions don't accidentally collide them.
+
+## Layers
+
+### Layer 1: In-house (PascalCase files in `src/components/ui/`)
+
+The original design-system layer, written for this product. Lives at `apps/frontend/src/components/ui/*.tsx` with **PascalCase filenames**. Components use Tailwind utility classes mapped to CSS variables in `src/styles/index.css`. Exports default or named depending on the component.
+
+Current primitives (12 files):
+- `Avatar.tsx`, `Badge.tsx`, `Button.tsx`, `Card.tsx`, `CTA.tsx`, `ErrorBoundary.tsx`, `Input.tsx`, `PageDoodles.tsx`, `Spinner.tsx`, `ThemeToggle.tsx`, `TimelineCardHeader.tsx`, plus `threadUtils.ts` (helpers)
+
+Convention: **stay in-house for product-specific components** (CTA, PageDoodles, TimelineCardHeader, threadUtils). These carry brand voice and don't have off-the-shelf equivalents.
+
+### Layer 2: ShadCN (kebab-case files in `src/components/ui-shadcn/`)
+
+The ShadCN UI scaffolding landed in commit `b6eb0ca`. It's currently configured but empty (no `npx shadcn add` has been run).
+
+ShadCN CLI installs components into the path configured in `components.json`:
+
+```json
+"aliases": {
+  "components": "@/components",
+  "ui": "@/components/ui",
+  ...
+}
+```
+
+**We override this.** The ShadCN `ui` alias resolves to `src/components/ui-shadcn/` (kebab-case files, lowercase, as ShadCN ships them) — **NOT** `src/components/ui/` (which is reserved for in-house). This is enforced by `tsconfig.json` paths:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/components/ui-shadcn/*": ["./src/components/ui-shadcn/*"],
+      "@/components/ui-shadcn": ["./src/components/ui-shadcn/index.ts"]
+    }
+  }
+}
+```
+
+And by an explicit override in `vite.config.ts` resolve.alias (when `vite-tsconfig-paths` is wired).
+
+### Layer 3: Shared primitives (single source of truth, eventually)
+
+A future consolidation layer. Today's PR0 stops at "two layers, no collision." A future PR can collapse them by:
+- Renaming all in-house files into `Button/index.tsx` (kebab-case dir) so the case-insensitive macOS collision risk is removed.
+- OR by lifting ShadCN primitives into `@/components/ds/` and consuming them from both layers.
+
+Out of scope for PR0. Track in `docs/redesign-plan.md` §4.5 / R9.
+
+## Why this matters
+
+- macOS default filesystem (APFS) is case-insensitive. Two files named `Button.tsx` and `button.tsx` in the same folder are the same file.
+- The first `npx shadcn add button` would either overwrite the in-house `Button.tsx` (data loss) or fail with a confusing filesystem error.
+- This convention removes the collision by giving ShadCN its own folder.
+
+## Adding a new component
+
+**Product-specific** (e.g. a new `WelcomeHero`, a new `OnboardingStepper`, a brand-coloured `TeaDropCard`):
+- Add to `apps/frontend/src/components/ui/` with PascalCase filename.
+- Export named or default per the existing pattern.
+- Consume via relative import or `@/components/ui/Name`.
+
+**Generic primitive** (e.g. a `Dialog`, a `Tabs`, a `Select`, a `Toast`):
+- Run `npx shadcn add <component>`.
+- ShadCN writes the file to `src/components/ui-shadcn/<component>.tsx`.
+- Import via `@/components/ui-shadcn/<component>`.
+- Wrap in a project-themed layer if needed (e.g. brand colours override ShadCN's default CSS variables).
+
+## Reviewing the convention
+
+Any PR that:
+- Adds a file to `src/components/ui/` (in-house layer) — fine.
+- Adds a file to `src/components/ui-shadcn/` (ShadCN layer) — fine.
+- **Renames, moves, or deletes a primitive in either layer** — needs design-system review.
+- **Cross-imports in-house from ShadCN or vice versa** — needs design-system review.
+
+## Migration plan (future)
+
+1. Rename in-house `*.tsx` → `*/index.tsx` (PascalCase → kebab-case dir) so all components share one filename convention.
+2. Merge the two folders into `src/components/ui/`.
+3. Update `tsconfig.json` to drop the `ui-shadcn` path mapping.
+4. Update every consumer's import paths.
+
+Until that lands: **no `shadcn add` without confirming the convention is in place.**


### PR DESCRIPTION
Lock the design-system convention before installing any ShadCN components.

## Background

`apps/frontend/components.json` (the ShadCN CLI config) had its `ui` alias pointing to `@/components/ui` — the **same folder** as the in-house PascalCase primitives (`Button.tsx`, `Card.tsx`, etc.). On macOS default case-insensitive APFS, `npx shadcn add button` would have collided with `Button.tsx`.

Frontend audit (in `docs/redesign-plan.md` §4.5 / R9) flagged this as the highest-risk open issue.

## Fix

- `components.json`: `ui` alias now points to `@/components/ui-shadcn`
- `apps/frontend/src/components/ui-shadcn/`: created (empty + `.gitkeep`) so future ShadCN installs land there
- `docs/design-system.md`: codifies the convention — in-house stays at `src/components/ui/` (PascalCase), ShadCN lands at `src/components/ui-shadcn/` (kebab-case), cross-imports require design-system review

## Why two folders

A future consolidation (track in plan §4.5 / R9) will:
1. Rename all in-house `*.tsx` → `*/index.tsx` (kebab-case dir)
2. Merge the two folders
3. Drop the `ui-shadcn` path mapping

Until that lands, no `shadcn add` is safe without the explicit folder split. PR1 will keep the split intact.

## Verification

```
pnpm run typecheck → 5/5 pass
pnpm run lint      → 0 errors (131 pre-existing warnings)
```

No consumer touched — in-house primitives stay in place; only the ShadCN CLI install path changed.