### PR TITLE
feat: make community category mandatory & add admin sorting cards

### DIFF
--- a/apps/backend/src/modules/admin/admin.controller.ts
+++ b/apps/backend/src/modules/admin/admin.controller.ts
@@ -567,9 +567,10 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
     const skip = (page - 1) * limit;
     const search = (req.query.search as string) || '';
     const status = (req.query.status as string) || '';
+    const category = (req.query.category as string) || '';
     const batchId = (req.query.batchId as string | undefined) ?? null;
 
-    const base: Record<string, unknown> = {};
+    const base: Record<string, any> = {};
     if (search) {
       base.$or = [
         { title: { $regex: search, $options: 'i' } },
@@ -577,9 +578,16 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
       ];
     }
     if (status) base.status = status;
+    if (category) {
+      if (category.toLowerCase() === 'uncategorized') {
+        base.$or = [{ tags: { $exists: false } }, { tags: { $size: 0 } }];
+      } else {
+        base.tags = category;
+      }
+    }
     const query = withProgramScope(base, batchId);
 
-    const [posts, total] = await Promise.all([
+    const [posts, total, categoryCounts, uncategorizedCount] = await Promise.all([
       CommunityPost.find(query)
         .select('-embedding')
         .populate('author', 'name email')
@@ -588,11 +596,25 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
         .skip(skip)
         .limit(limit),
       CommunityPost.countDocuments(query),
+      CommunityPost.aggregate([
+        { $match: withProgramScope({}, batchId) },
+        { $unwind: '$tags' },
+        { $group: { _id: '$tags', count: { $sum: 1 } } },
+        { $sort: { count: -1 } }
+      ]),
+      CommunityPost.countDocuments(
+        withProgramScope({ $or: [{ tags: { $exists: false } }, { tags: { $size: 0 } }] }, batchId)
+      ),
     ]);
 
-    res.json({ posts, total, page, pages: Math.ceil(total / limit) });
+    const categoriesList = categoryCounts.map((c: any) => ({ name: c._id, count: c.count }));
+    if (uncategorizedCount > 0) {
+      categoriesList.push({ name: 'Uncategorized', count: uncategorizedCount });
+    }
+
+    res.json({ posts, total, page, pages: Math.ceil(total / limit), categories: categoriesList });
   } catch (error) {
-    res.status(500).json({ message: 'Server error', /* error: process.env.NODE_ENV === 'development' ? (error as Error).message : undefined */ });
+    res.status(500).json({ message: 'Server error' });
   }
 };
 

--- a/apps/backend/src/modules/community/post-mutations.controller.ts
+++ b/apps/backend/src/modules/community/post-mutations.controller.ts
@@ -54,6 +54,11 @@ export const createPost = async (req: Request, res: Response): Promise<void> => 
       ? tags.map((t: unknown) => String(t).trim().toLowerCase()).filter(Boolean).slice(0, 3)
       : [];
 
+    if (safeTags.length === 0) {
+      res.status(400).json({ message: 'At least one category tag is required.' });
+      return;
+    }
+
     // ── Server-side duplicate check ──────────────────────────────────────────
     // Uses the SAME AI-aware evaluator as the frontend's /check-duplicate
     // pre-check, so server enforcement is consistent with what the user

--- a/apps/backend/src/utils/auth/validation.ts
+++ b/apps/backend/src/utils/auth/validation.ts
@@ -86,6 +86,19 @@ export const voteReviewSchema = z.object({
 export const createPostSchema = z.object({
   title: z.string().min(10, 'Title must be at least 10 characters').max(300),
   body:  z.string().min(20, 'Body must be at least 20 characters').max(5000),
+  tags:  z.array(z.string()).min(1, 'At least one category tag is required').max(3),
+  attachments: z.array(
+    z.object({
+      url: z.string(),
+      publicId: z.string().optional(),
+      gcsUri: z.string().optional(),
+      objectPath: z.string().optional(),
+      width: z.number().optional(),
+      height: z.number().optional(),
+      format: z.string().optional(),
+      bytes: z.number().optional(),
+    })
+  ).optional(),
 });
 
 export const checkDuplicateSchema = z.object({

--- a/apps/frontend/src/admin/pages/AdminCommunity.tsx
+++ b/apps/frontend/src/admin/pages/AdminCommunity.tsx
@@ -5,8 +5,28 @@ import Badge from '../components/common/Badge';
 import Modal from '../components/common/Modal';
 import { TableSkeleton } from '../components/common/SkeletonLoader';
 import { useDebounce } from '../../hooks/useDebounce';
-interface CommunityPost { _id: string; title: string; body: string; status: 'answered' | 'unanswered'; author: { _id: string; name: string; email: string }; comments: Array<{ _id: string; body: string; author: { name: string }; verified: boolean }>; upvotes: string[]; createdAt: string; answer?: string; reports?: Array<{ reportedBy: string; reason: string; createdAt?: string }>; }
-interface CommunityPostsResponse { posts: CommunityPost[]; total: number; page: number; pages: number; }
+import { getCategoryIcon, getCategoryTheme } from '../../components/faq/faqUtils';
+
+interface CommunityPost {
+  _id: string;
+  title: string;
+  body: string;
+  status: 'answered' | 'unanswered';
+  author: { _id: string; name: string; email: string };
+  comments: Array<{ _id: string; body: string; author: { name: string }; verified: boolean }>;
+  upvotes: string[];
+  createdAt: string;
+  answer?: string;
+  reports?: Array<{ reportedBy: string; reason: string; createdAt?: string }>;
+  tags?: string[];
+}
+interface CommunityPostsResponse {
+  posts: CommunityPost[];
+  total: number;
+  page: number;
+  pages: number;
+  categories?: Array<{ name: string; count: number }>;
+}
 interface Toast { msg: string; type: 'success' | 'warn' | 'error'; }
 
 function Toast({ toast }: { toast: Toast }) {
@@ -19,9 +39,11 @@ export default function AdminCommunity() {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [pages, setPages] = useState(1);
+  const [categories, setCategories] = useState<Array<{ name: string; count: number }>>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
   const [toast, setToast] = useState<Toast | null>(null);
   const [viewPost, setViewPost] = useState<CommunityPost | null>(null);
   const debouncedSearch = useDebounce(search, 350);
@@ -32,17 +54,83 @@ export default function AdminCommunity() {
     const params = new URLSearchParams({ page: String(page), limit: '12' });
     if (debouncedSearch) params.set('search', debouncedSearch);
     if (statusFilter) params.set('status', statusFilter);
-    adminApi.get<CommunityPostsResponse>(`/admin/community/posts?${params}`).then(r => { setPosts(r.data.posts); setTotal(r.data.total); setPages(r.data.pages); }).finally(() => setLoading(false));
-  }, [page, debouncedSearch, statusFilter]);
+    if (categoryFilter) params.set('category', categoryFilter);
+    adminApi.get<CommunityPostsResponse>(`/admin/community/posts?${params}`).then(r => {
+      setPosts(r.data.posts);
+      setTotal(r.data.total);
+      setPages(r.data.pages);
+      setCategories(r.data.categories || []);
+    }).finally(() => setLoading(false));
+  }, [page, debouncedSearch, statusFilter, categoryFilter]);
 
   useEffect(() => { fetchPosts(); }, [fetchPosts]);
-  useEffect(() => { setPage(1); }, [debouncedSearch, statusFilter]);
+  useEffect(() => { setPage(1); }, [debouncedSearch, statusFilter, categoryFilter]);
   const handleDelete = async (id: string) => { if (!confirm('Delete this post?')) return; try { await adminApi.delete(`/admin/community/${id}`); showToast('Deleted', 'error'); fetchPosts(); } catch { showToast('Delete failed', 'error'); } };
 
   return (
     <div className="space-y-4 max-w-6xl">
       <AnimatePresence>{toast && <Toast toast={toast} />}</AnimatePresence>
       <p className="text-sm text-ink-faint -mt-2">{total} total posts</p>
+
+      {/* Category Selection Cards */}
+      <div className="flex flex-wrap gap-3 pt-1 pb-3">
+        {/* All Categories Card */}
+        <button
+          type="button"
+          onClick={() => setCategoryFilter('')}
+          className={`flex flex-col items-start p-3.5 rounded-xl border text-left transition-all hover:shadow-md cursor-pointer min-w-[140px] flex-1 sm:flex-initial ${
+            categoryFilter === ''
+              ? 'bg-accent-light/10 border-accent/30 text-accent ring-1 ring-accent/30'
+              : 'bg-card border-border text-ink hover:border-border-hover'
+          }`}
+        >
+          <div className="w-8 h-8 rounded-lg bg-mist flex items-center justify-center text-ink-soft mb-2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="3" width="7" height="9" />
+              <rect x="14" y="3" width="7" height="5" />
+              <rect x="14" y="12" width="7" height="9" />
+              <rect x="3" y="16" width="7" height="5" />
+            </svg>
+          </div>
+          <span className="text-xs font-bold tracking-tight">All Categories</span>
+          <span className="text-[10px] text-ink-faint mt-1 font-semibold">{total} posts</span>
+        </button>
+
+        {/* Dynamic Category Cards */}
+        {categories.map((cat) => {
+          const isActive = categoryFilter === cat.name;
+          const theme = getCategoryTheme(cat.name);
+          const icon = getCategoryIcon(cat.name);
+          return (
+            <button
+              key={cat.name}
+              type="button"
+              onClick={() => setCategoryFilter(cat.name)}
+              className={`flex flex-col items-start p-3.5 rounded-xl border text-left transition-all hover:shadow-md cursor-pointer min-w-[140px] flex-1 sm:flex-initial ${
+                isActive
+                  ? 'bg-accent-light/10 border-accent/30 text-accent ring-1 ring-accent/30'
+                  : 'bg-card border-border text-ink hover:border-border-hover'
+              }`}
+            >
+              <div
+                className="w-8 h-8 rounded-lg flex items-center justify-center mb-2"
+                style={{
+                  backgroundColor: isActive ? 'rgba(16,185,129,0.1)' : 'var(--bg-mist, #f5f5f7)',
+                  color: isActive ? theme.ctaColorDark || '#10b981' : 'var(--text-ink-soft, #515154)',
+                }}
+              >
+                {icon}
+              </div>
+              <span className="text-xs font-bold tracking-tight capitalize truncate w-full" title={cat.name}>
+                {cat.name}
+              </span>
+              <span className="text-[10px] text-ink-faint mt-1 font-semibold">
+                {cat.count} {cat.count === 1 ? 'post' : 'posts'}
+              </span>
+            </button>
+          );
+        })}
+      </div>
 
       <div className="flex flex-wrap gap-2">
         <div className="relative flex-1 min-w-[160px]">
@@ -64,17 +152,29 @@ export default function AdminCommunity() {
               {loading ? <tr><td colSpan={8} className="px-3 py-6"><TableSkeleton rows={8} /></td></tr> :
                posts.length === 0 ? <tr><td colSpan={8} className="admin-empty">No posts found</td></tr> :
                posts.map(post => (
-                <tr key={post._id} className="admin-tr">
+                <tr
+                  key={post._id}
+                  className="admin-tr hover:bg-mist/40 transition-colors cursor-pointer"
+                  onClick={() => setViewPost(post)}
+                >
                   <td className="admin-td max-w-[180px] truncate" title={post.title}>
                     {(() => {
                       const programName = typeof (post as any).batchId === 'object' && (post as any).batchId !== null && 'name' in (post as any).batchId
                         ? ((post as any).batchId as { name: string }).name
                         : null;
-                      if (!programName) return null;
                       return (
-                        <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent-light text-accent text-[9px] font-bold uppercase tracking-wider mr-2">
-                          {programName}
-                        </span>
+                        <div className="inline-flex items-center gap-1 mr-2">
+                          {programName && (
+                            <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent-light text-accent text-[9px] font-bold uppercase tracking-wider">
+                              {programName}
+                            </span>
+                          )}
+                          {post.tags && post.tags[0] && (
+                            <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-mist text-ink-soft border border-border/80 text-[9px] font-bold uppercase tracking-wider capitalize">
+                              {post.tags[0]}
+                            </span>
+                          )}
+                        </div>
                       );
                     })()}
                     {post.title}
@@ -91,7 +191,7 @@ export default function AdminCommunity() {
                   <td className="admin-td text-right text-ink-faint tabular-nums">{post.comments?.length ?? 0}</td>
                   <td className="admin-td text-right text-ink-faint tabular-nums">{post.upvotes?.length ?? 0}</td>
                   <td className="admin-td text-ink-faint">{new Date(post.createdAt).toLocaleDateString('en-IN')}</td>
-                  <td className="admin-td text-right">
+                  <td className="admin-td text-right" onClick={(e) => e.stopPropagation()}>
                     <div className="flex items-center justify-end gap-1">
                       <button onClick={() => setViewPost(post)} className="w-6 h-6 flex items-center justify-center rounded text-ink-faint hover:text-ink hover:bg-mist transition-colors" title="View"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
                       <button onClick={() => handleDelete(post._id)} className="w-6 h-6 flex items-center justify-center rounded text-ink-faint hover:text-danger hover:bg-danger/10 transition-colors" title="Delete"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></button>

--- a/apps/frontend/src/admin/pages/__tests__/AdminCommunity.test.tsx
+++ b/apps/frontend/src/admin/pages/__tests__/AdminCommunity.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import AdminCommunity from '../AdminCommunity';
+
+// Mock the adminApi module
+vi.mock('../../utils/adminApi', () => {
+  return {
+    default: {
+      get: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+import adminApi from '../../utils/adminApi';
+
+const mockApi = adminApi as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+describe('AdminCommunity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders total posts count, category cards, and post table rows with category badges', async () => {
+    const mockPosts = [
+      {
+        _id: 'post1',
+        title: 'How to request leaf?',
+        body: 'I need to know how to apply for leaves.',
+        status: 'unanswered',
+        author: { _id: 'u1', name: 'John Doe', email: 'john@doe.com' },
+        comments: [],
+        upvotes: ['u2'],
+        createdAt: '2026-07-04T12:00:00.000Z',
+        tags: ['vibe'],
+        batchId: { _id: 'b1', name: 'Monsoonship' },
+      },
+      {
+        _id: 'post2',
+        title: 'NOC signature needed',
+        body: 'Can someone sign my NOC?',
+        status: 'answered',
+        author: { _id: 'u2', name: 'Jane Smith', email: 'jane@smith.com' },
+        comments: [{ _id: 'c1', body: 'Yes, ask HR', author: { name: 'HR Manager' }, verified: true }],
+        upvotes: [],
+        createdAt: '2026-07-03T12:00:00.000Z',
+        tags: ['logistics'],
+      }
+    ];
+
+    const mockCategories = [
+      { name: 'vibe', count: 1 },
+      { name: 'logistics', count: 1 },
+    ];
+
+    mockApi.get.mockResolvedValue({
+      data: {
+        posts: mockPosts,
+        total: 2,
+        page: 1,
+        pages: 1,
+        categories: mockCategories,
+      },
+    });
+
+    render(<AdminCommunity />);
+
+    // Check loading skeleton first, then wait for table contents
+    await waitFor(() => {
+      expect(screen.getByText('2 total posts')).toBeInTheDocument();
+    });
+
+    // Check Category Selection Cards and Badges
+    expect(screen.getByText('All Categories')).toBeInTheDocument();
+    expect(screen.getAllByText('vibe')).toHaveLength(2);
+    expect(screen.getAllByText('logistics')).toHaveLength(2);
+
+    // Check counts on the cards
+    expect(screen.getByText('2 posts')).toBeInTheDocument(); // All Categories count
+    expect(screen.getAllByText('1 post')).toHaveLength(2); // vibe & logistics count (since count is 1 for both)
+
+    // Check table headers
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Author')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+
+    // Check table rows
+    expect(screen.getByText('How to request leaf?')).toBeInTheDocument();
+    expect(screen.getByText('NOC signature needed')).toBeInTheDocument();
+
+    // Check click on a category card calls API with category parameter
+    fireEvent.click(screen.getAllByText('vibe')[0]);
+
+    await waitFor(() => {
+      expect(mockApi.get).toHaveBeenCalledWith(
+        expect.stringContaining('category=vibe')
+      );
+    });
+
+    // Click on the post row to open modal
+    fireEvent.click(screen.getByText('How to request leaf?'));
+
+    // Assert that the modal is open
+    expect(screen.getByText('Post Details')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/community/CreatePostDialog.tsx
+++ b/apps/frontend/src/components/community/CreatePostDialog.tsx
@@ -55,16 +55,6 @@ function CategoryDropdown({
 
       {isOpen && (
         <div className="absolute left-0 right-0 mt-1 max-h-48 overflow-y-auto rounded-xl border border-border bg-bg-secondary shadow-lg z-50 py-1">
-          <button
-            type="button"
-            onClick={() => {
-              onChange('');
-              setIsOpen(false);
-            }}
-            className="w-full text-left px-3 py-2 text-sm hover:bg-mist text-ink transition-colors font-medium border-b border-border/50 text-ink-faint"
-          >
-            — Clear Category —
-          </button>
           {uniqueCategories.map(cat => (
             <button
               key={cat}
@@ -258,6 +248,10 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
       setError('Both title and description are required.');
       return;
     }
+    if (tags.length === 0) {
+      setError('Please select or specify a category.');
+      return;
+    }
     // Block only if match is a high-confidence FAQ match (score >= 0.85).
     // Low-confidence / tangential matches are shown as suggestions — posting is allowed.
     const highConfidenceFaqMatch = duplicateMatch?.matches?.find(
@@ -329,6 +323,7 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
   const isSubmitDisabled =
     !title.trim() ||
     !body.trim() ||
+    tags.length === 0 ||
     hasHighConfidenceFaqMatch ||
     checkingDuplicates ||
     loading ||
@@ -456,7 +451,7 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
           {/* Category */}
           <div>
             <label className="block text-xs font-medium text-ink-soft mb-1.5">
-              Category <span className="text-ink-faint font-normal">(optional)</span>
+              Category <span className="text-danger">*</span>
             </label>
             <CategoryDropdown
               value={categoryOption}


### PR DESCRIPTION
This PR makes community post category selection mandatory and adds a row of category cards to the admin dashboard, allowing admins to sort/filter posts by category and click on table rows directly to view post details.