### PR TITLE
fix(community/thread-detail): clear floating navbar on post open

### DIFF
--- a/apps/frontend/src/components/community/ThreadDetail.tsx
+++ b/apps/frontend/src/components/community/ThreadDetail.tsx
@@ -327,16 +327,21 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
 
   return (
     <>
-      {/* Background overlay that matches the search-overlay / chat-overlay premium blur */}
-      <div className="search-overlay !z-40" aria-hidden="true" onClick={onClose} />
-      
-      {/* Scrollable container for the modal itself */}
+      {/* Background overlay that matches the search-overlay / chat-overlay premium blur.
+          z-30 sits below the navbar (z-50) so the navbar floats above the dim layer. */}
+      <div className="search-overlay !z-30" aria-hidden="true" onClick={onClose} />
+
+      {/* Scrollable container for the modal itself.
+          z-[60] sits above the navbar (z-50) so the dialog never gets
+          covered by it. pt-20 sm:pt-24 clears the floating navbar
+          (top-4 + h-16 ≈ 80px desktop; top-2 + h-14 ≈ 64px mobile,
+          with a touch of breathing room). */}
       <div
-        className="fixed inset-0 z-50 flex items-start justify-center pt-14 sm:pt-16 px-4 sm:px-6 pb-6 overflow-y-auto pointer-events-none"
+        className="fixed inset-0 z-[60] flex items-start justify-center pt-20 sm:pt-24 px-4 sm:px-6 pb-6 overflow-y-auto pointer-events-none"
       >
         <div
           className="relative w-full max-w-3xl bg-card rounded-2xl border border-border shadow-float animate-fade-in overflow-hidden flex flex-col pointer-events-auto"
-          style={{ maxHeight: 'calc(100vh - 5rem)' }}
+          style={{ maxHeight: 'calc(100vh - 7rem)' }}
         >
         {/* Action error banner */}
         {actionError && (

--- a/apps/frontend/src/pages/CommunityPage.tsx
+++ b/apps/frontend/src/pages/CommunityPage.tsx
@@ -481,9 +481,13 @@ export default function CommunityPage() {
 
       <Footer />
 
-      {/* Thread detail — full-page overlay replaces the list view */}
+      {/* Thread detail — full-page overlay replaces the list view.
+          z-30 (below the navbar's z-50) so the navbar floats on top of
+          the page-cover background. The inner modal at z-[60] escapes
+          this stacking context via its higher z-index and sits above
+          the navbar. */}
       {selectedPostId && (
-        <div className="fixed inset-0 z-40 bg-bg overflow-y-auto">
+        <div className="fixed inset-0 z-30 bg-bg overflow-y-auto">
           <ThreadDetail
             postId={selectedPostId}
             onClose={handleCloseDetail}


### PR DESCRIPTION
## What changed

Opening a question on the community board showed the dialog with its
top edge hidden behind the floating navbar. Root cause was a stacking-
context trap: the wrapper in `CommunityPage.tsx` was `z-40` on a
`position: fixed` element, which creates a new stacking context, so
the inner modal at `z-50` was trapped underneath the navbar's `z-50`
in the root context. On top of that, the modal's `pt-14 sm:pt-16`
(56-64px) left its top edge inside the navbar's ~80px footprint.

Changes:
- `CommunityPage.tsx` — wrapper `z-40` → `z-30`. The dim page-cover
  layer now sits below the navbar as designed (navbar floats above
  the dimmed background) and stops trapping inner z-indexes.
- `ThreadDetail.tsx` — backdrop `!z-40` → `!z-30` to match the wrapper.
- `ThreadDetail.tsx` — modal container `z-50` → `z-[60]`, so it
  escapes the wrapper's stacking context and paints above the navbar.
- `ThreadDetail.tsx` — top padding `pt-14 sm:pt-16` → `pt-20 sm:pt-24`
  to clear the navbar's footprint (top-4 + h-16 ≈ 80px desktop;
  top-2 + h-14 ≈ 64px mobile).
- `ThreadDetail.tsx` — inner panel `max-height: calc(100vh - 5rem)`
  → `calc(100vh - 7rem)` to match the new top padding so the dialog
  still fits in the viewport on shorter laptop screens.

## Related issue

None.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [ ] Pipeline (auto-answer / FAQ audit / Zoom ingestion)
- [ ] Search (hybrid vector + keyword)
- [ ] Auth / middleware
- [ ] Docs

## CI verification

- [x] `pnpm typecheck` — passes
- [ ] `pnpm test:run` — see notes (2 pre-existing test files fail on
      `main`; confirmed unrelated to this fix)
- [ ] GitHub Actions green on the merge commit
- [x] Manually verified the modal no longer overlaps the navbar in
      the community → click-post flow
- [x] Single logical change — navbar overlap fix only
- [x] No docs change needed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

- Test suite has 2 pre-existing failures in
  `apps/frontend/src/utils/__tests__/api.test.ts` (8 failing tests
  across abort-controller guard assertions). Confirmed via `git stash`
  round-trip that these fail on `main` before any change here; they
  are unrelated to the layout fix.
- A separate PR (#138) carries the wider Yaksha palette theme
  refactor (public site + admin chrome). This PR is intentionally
  scoped to the navbar-overlap bug only, so it can be reviewed and
  merged independently.