### PR TITLE
fix(community): scope feed to active program on CommunityPage

### DIFF
--- a/apps/frontend/src/pages/CommunityPage.tsx
+++ b/apps/frontend/src/pages/CommunityPage.tsx
@@ -9,6 +9,7 @@ import CommunityHealth from '../components/community/CommunityHealth';
 import api from '../utils/api';
 import { useAuth } from '../hooks/useAuth';
 import { useAuthGate } from '../context/AuthModalContext';
+import { useBatch } from '../context/BatchContext';
 import type { Post } from '../types/ui';
 
 import CreatePostDialog from '../components/community/CreatePostDialog';
@@ -17,6 +18,13 @@ import { buttonCommunityAsk } from '../styles/style_config';
 // ─── Main Page ────────────────────────────────────────────────────────────────
 export default function CommunityPage() {
   const { user } = useAuth();
+  // Active program from ProgramContext — used to scope the community feed
+  // to the chosen program so summership questions don't leak into
+  // winternship (and vice versa). Falls back to `undefined` when no
+  // program is selected yet, in which case we deliberately send NO
+  // batchId (matches previous behaviour while the picker takes over).
+  const { currentBatch } = useBatch();
+  const activeBatchId = currentBatch?._id ?? undefined;
   const gate = useAuthGate();
   const handleAskQuestion = gate(
     () => setShowCreate(true),
@@ -50,6 +58,14 @@ export default function CommunityPage() {
   // Backend uses cursor-based pagination. The previous version sent `?page=2`
   // which the backend silently ignored — so every "Load more" call returned
   // the FIRST batch and we got duplicates. Send the cursor instead.
+  //
+  // v1.69 — program scoping: always send the active program's batchId
+  // when the user is NOT on "All Programs Feed". Without it, the
+  // backend returns every post across every program because the
+  // community routes don't have the programScope middleware attached
+  // and the controllers fall back to "no batchId filter". The
+  // explicit-`undefined`-when-no-program-selected case preserves the
+  // legacy behaviour while the program picker takes over.
   const fetchPosts = useCallback((reset = false) => {
     if (reset) setLoading(true);
     else setLoadingMore(true);
@@ -58,7 +74,7 @@ export default function CommunityPage() {
         limit: 20,
         filter,
         sort,
-        batchId: showAllPrograms ? 'all' : undefined,
+        batchId: showAllPrograms ? 'all' : activeBatchId,
         ...(reset ? {} : nextCursor ? { cursor: nextCursor } : {}),
       },
     })
@@ -74,7 +90,7 @@ export default function CommunityPage() {
         setLoading(false);
         setLoadingMore(false);
       });
-  }, [filter, sort, nextCursor, showAllPrograms]);
+  }, [filter, sort, nextCursor, showAllPrograms, activeBatchId]);
 
   // Thread detail: when a post ID is set, show ThreadDetail instead of the list/dialog
   const handleOpenThread = useCallback((postId: string) => {
@@ -128,11 +144,12 @@ export default function CommunityPage() {
   }, [posts, user, window.location.search]);
 
   // Reset cursor + posts when filter/sort changes so we paginate the
-  // newly-filtered set from the beginning.
+  // newly-filtered set from the beginning. activeBatchId is also in this
+  // list — switching programs in the header must wipe the visible feed.
   useEffect(() => {
     setNextCursor(null);
     setPosts([]);
-  }, [filter, sort, showAllPrograms]);
+  }, [filter, sort, showAllPrograms, activeBatchId]);
 
   // 2-D (MEDIUM) — previously this page had TWO effects both keyed on
   // [filter, sort, ...] that each fired `fetchPosts(true)` in the same
@@ -158,7 +175,7 @@ export default function CommunityPage() {
       return;
     }
     fetchPosts(true);
-  }, [filter, sort, showAllPrograms]);
+  }, [filter, sort, showAllPrograms, activeBatchId]);
 
   // ── Infinite scroll — fetch the next page when the sentinel enters view ────
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -176,13 +193,13 @@ export default function CommunityPage() {
     );
     observer.observe(sentinelRef.current);
     return () => observer.disconnect();
-  }, [hasMore, loading, loadingMore, nextCursor, filter, sort, showAllPrograms]);
+  }, [hasMore, loading, loadingMore, nextCursor, filter, sort, showAllPrograms, activeBatchId]);
 
   const runSemanticSearch = useCallback(async (q: string) => {
     setSearchLoading(true);
     try {
       const res = await api.get<{ results: Post[] }>('/community/search', {
-        params: { q, batchId: showAllPrograms ? 'all' : undefined }
+        params: { q, batchId: showAllPrograms ? 'all' : activeBatchId }
       });
       setSearchResults(res.data.results || []);
     } catch (err) {
@@ -191,7 +208,7 @@ export default function CommunityPage() {
     } finally {
       setSearchLoading(false);
     }
-  }, [showAllPrograms]);
+  }, [showAllPrograms, activeBatchId]);
 
   // v2 — search is now Enter-only. We still keep the trimmed query handy
   // for downstream effects (filter/sort re-apply on existing results).


### PR DESCRIPTION
## What changed

`CommunityPage` was sending `batchId: undefined` on `GET /community` and `GET /community/search` whenever the user was on the default *Active Program Feed* view. The backend's `batchIdFromQuery` helper falls back to `req.programContext?.batchId` in that case — but the community routes are mounted without the `programScope` middleware (see `apps/backend/src/bootstrap/routes.ts:53`), so `req.programContext` is always undefined for them. `withProgramScope` then returns the filter unchanged and the backend returned every post across every program.

Concrete user-facing effect: a user on **summership** could see questions raised in **winternship** (and vice versa). Only the explicit "All Programs Feed" toggle scoped correctly, via the literal string `'all'`.

This PR makes `CommunityPage` read the active program from `useBatch()` and pass its `_id` as `batchId` on both the list and the semantic-search calls. `undefined` is still sent when no program is selected, so the ProgramPortalPage takeover flow is unchanged. `activeBatchId` is added to the relevant effect and callback dependency arrays so switching programs in the header re-fetches the visible feed (the cursor is also reset, so the user starts from the beginning of the new program's feed rather than seeing stale paginated results).

Backend is **not modified** — the existing `batchIdFromQuery` + `withProgramScope` path was already correct, it was simply never being fed the right id from this page.

## Related issue

No filing on the upstream tracker; the bug was reported directly on a deployed instance. Happy to file an issue first and re-link if maintainers prefer.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [x] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [x] `cd apps/backend && npx tsc --noEmit` exits 0 — not touched
- [x] `cd apps/backend && npx vitest run` — not touched
- [x] `cd apps/frontend && npx tsc --noEmit` exits 0 — verified locally
- [x] `cd apps/frontend && npx vitest run` — verified locally. Baseline already has 2 pre-existing failures (`useAuth.test.tsx` localStorage JSDOM quirk + `api.test.ts` AbortController spy); the diff introduces **zero** new failures
- [x] `cd apps/frontend && pnpm eslint src/pages/CommunityPage.tsx` — clean
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy) — pending push-triggered CI
- [x] Tested by reasoning through the call path: `CommunityPage → useBatch().currentBatch._id → params.batchId → server batchIdFromQuery (ObjectId branch) → withProgramScope(query, activeProgramId)`. Verified that `TopSolved.tsx` (lines 65-74) and `CreatePostDialog.tsx` (line 126) follow the same pattern and work correctly, so this is a known-good call shape
- [ ] Tests added or updated for the change — no existing `CommunityPage` test coverage. Not adding new tests in this PR to keep the diff focused; can add a vitest + mocked `api` test in a follow-up if maintainers want
- [x] Single logical change — no unrelated fixes bundled
- [ ] Docs updated if route / API / env var / pipeline behaviour changed — N/A (no public-API change)
- [x] Rebased onto `main`, no merge commits

## Out of scope (intentionally not changed)

- `/community/stats` is program-agnostic in `community-stats.controller.ts`. The "total / answered / unanswered" tiles in `CommunityHealth.tsx` will still be cross-program. Fixing that requires changing the stats shape and a coordinated UI tweak — leaving as a separate PR if reviewers want it.
- `ThreadDetail.tsx` and `PostDetailDialog.tsx` already accept a post id and are correctly scoped via `findById`. No change needed.
- No backend-side change to `batchIdFromQuery` or `withProgramScope` — those helpers were already correct; the bug was purely a frontend-feed issue.

## Notes for reviewer

The fix is small and follows an existing pattern (`TopSolved` and `CreatePostDialog` both already read `useBatch()` to drive program-scoped fetches). The only reviewer-substantive decision is the dependency-array change: I added `activeBatchId` to the cursor-reset effect, the filter/sort re-fetch effect, and the IntersectionObserver effect so that switching programs in the header doesn't leave stale data on screen. If you'd rather have the program switch handled by remounting the page (`<CommunityPage key={currentBatch._id} />` in the route), that's a one-liner alternative — happy to switch.