### PR TITLE
feat: Add Knowledge Gap dashboard

### DIFF
--- a/apps/backend/src/bootstrap/routes.ts
+++ b/apps/backend/src/bootstrap/routes.ts
@@ -19,6 +19,7 @@ import moderationRoutes from '../modules/moderation/moderation.routes.js';
 import zoomRoutes from '../modules/zoom/zoom.routes.js';
 import knowledgeRoutes from '../modules/knowledge/knowledge.routes.js';
 import askAiRoutes from '../modules/ai/ask-ai.routes.js';
+import knowledgeGapRoutes from '../modules/ai/knowledge-gap.routes.js';
 import uploadRoutes from '../modules/upload/upload.routes.js';
 import publicFaqRoutes from '../modules/faq/public-faq.routes.js';
 import batchRoutes from '../modules/program/batch.routes.js';
@@ -59,6 +60,7 @@ export function registerRoutes(app: Express): void {
   router.use('/admin', adminWebPagesRoutes);
   router.use('/admin', adminDocumentsRoutes);
   router.use('/admin', adminAuditRoutes);
+  router.use('/admin/knowledge-gaps', knowledgeGapRoutes);
   router.use('/reputation', reputationRoutes);
   router.use('/moderation', moderationRoutes);
   router.use('/analytics', analyticsRoutes);

--- a/apps/backend/src/bootstrap/startup.ts
+++ b/apps/backend/src/bootstrap/startup.ts
@@ -18,6 +18,7 @@ import { jobQueue } from '../utils/http/jobQueue.js';
 // Cron job handlers
 import { runPromotionCycle } from '../modules/program/promotion.service.js';
 import { runFreshnessCheck } from '../modules/faq/freshness.controller.js';
+import { runKnowledgeGapAnalysis } from '../modules/ai/knowledge-gap.service.js';
 // Note: `clusterAllActiveBatches` (utils/ai/categoryClusterer.ts) is the v1.70
 // embedding-based clusterer. It called a local ONNX embedder that this
 // deployment doesn't have, which surfaced as a burst of
@@ -110,6 +111,13 @@ export async function startup(config: any): Promise<void> {
     handler: runFreshnessCheck,
     intervalMs: config.cron.freshnessCheckIntervalMs,
     runOnStartup: true,
+  });
+
+  cronManager.register({
+    name: 'knowledge-gap-analysis',
+    handler: runKnowledgeGapAnalysis,
+    intervalMs: 7 * 24 * 60 * 60 * 1000, // 7 days
+    runOnStartup: false,
   });
 
   // Phase 1 R3 — drain the notification outbox every 60s. Retries

--- a/apps/backend/src/core/scheduler/processRegistry.ts
+++ b/apps/backend/src/core/scheduler/processRegistry.ts
@@ -200,6 +200,14 @@ export const PROCESS_METADATA: ProcessMetadata[] = [
     canTriggerManually: true,
   },
   {
+    id: 'knowledge-gap-analysis',
+    label: 'Knowledge Gap Analysis',
+    description: 'Weekly AI-driven analysis of escalated posts and questions to identify documentation gaps.',
+    kind: 'cron',
+    owner: 'modules/ai/knowledge-gap.service.ts',
+    canTriggerManually: true,
+  },
+  {
     id: 'notification-outbox-drain',
     label: 'Notification Outbox Drain',
     description: 'Flushes pending notifications every 60s. Retries failed sends.',

--- a/apps/backend/src/modules/ai/ai-client.service.ts
+++ b/apps/backend/src/modules/ai/ai-client.service.ts
@@ -97,7 +97,13 @@ export type AIFeature =
   | 'duplicateDetection'
   | 'knowledgeExtraction'
   | 'searchSummarization'
+<<<<<<< Updated upstream
   | 'faqGeneration';
+=======
+  | 'faqGeneration'
+  | 'pathwayGeneration'
+  | 'gapAnalysis';
+>>>>>>> Stashed changes
 
 export interface AIResult {
   content: string;
@@ -270,6 +276,37 @@ export class AiClient {
           estimatedCost: 0,
         };
       }
+<<<<<<< Updated upstream
+=======
+      if (feature === 'pathwayGeneration') {
+        return {
+          content: JSON.stringify(["mock-id-1", "mock-id-2"]),
+          provider: 'openai',
+          modelName: 'gpt-4o',
+          tokensUsed: 150,
+          estimatedCost: 0,
+        };
+      }
+      if (feature === 'gapAnalysis') {
+        return {
+          content: JSON.stringify({
+            gaps: [
+              {
+                topic: "Mock Gap Topic",
+                summary: "Users are asking about mock gaps.",
+                frequency: 5,
+                suggestedActions: ["Create mock FAQ"]
+              }
+            ],
+            trendingTopics: ["Mocking", "Testing"]
+          }),
+          provider: 'openai',
+          modelName: 'gpt-4o',
+          tokensUsed: 250,
+          estimatedCost: 0,
+        };
+      }
+>>>>>>> Stashed changes
       return {
         content: 'This is a mock AI response for testing.',
         provider: 'openai',
@@ -704,6 +741,101 @@ The answer should be direct and actionable. Do not add disclaimers.`;
     return parseFAQResponse(result.content);
   }
 
+<<<<<<< Updated upstream
+=======
+  // ─── Feature: Pathway generation ─────────────────────────────────────────
+
+  /**
+   * Generates a learning pathway (ordered sequence of follow-up FAQs) for a given FAQ.
+   * Takes the current FAQ question and a list of candidates.
+   * Returns an array of candidate IDs in the suggested logical order.
+   */
+  async generatePathway(
+    currentFaq: { _id: string; question: string; answer?: string },
+    candidates: Array<{ _id: string; question: string; answer?: string }>
+  ): Promise<string[]> {
+    const systemPrompt = `You are an expert curriculum designer for an onboarding and FAQ portal.
+Given a current FAQ that a user is reading, and a list of candidate related FAQs, create a logical "Learning Pathway" (a sequence of 2 to 4 follow-up FAQs that the user should read next to deepen their understanding).
+The pathway should flow logically (e.g., from basic concepts to advanced configuration to troubleshooting).
+Return ONLY a valid JSON array of the recommended FAQ IDs in the correct order.
+Output format: ["id1", "id2", "id3"]`;
+
+    const candidateList = candidates
+      .filter(c => String(c._id) !== String(currentFaq._id))
+      .map((c) => `  - id="${c._id}", question="${c.question.replace(/"/g, "'")}"`)
+      .join('\n');
+
+    if (!candidateList) return [];
+
+    const userContent =
+      `Current FAQ:\nQuestion: "${currentFaq.question.replace(/"/g, "'")}"\n` +
+      (currentFaq.answer ? `Answer snippet: "${currentFaq.answer.slice(0, 200).replace(/"/g, "'")}"\n\n` : '\n') +
+      `Candidate FAQs:\n${candidateList}\n\n` +
+      `Respond with a JSON array of up to 4 FAQ IDs that form the best logical follow-up sequence.`;
+
+    const result = await this.chat(
+      [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userContent },
+      ],
+      'pathwayGeneration',
+      { temperature: 0.2, maxTokens: 256 }
+    );
+
+    return parsePathwayResponse(result.content, candidates.map(c => String(c._id)));
+  }
+
+  // ─── Feature: Knowledge Gap Analysis ─────────────────────────────────────
+
+  /**
+   * Generates a knowledge gap report from a list of unresolved posts and questions.
+   */
+  async generateKnowledgeGapReport(
+    escalatedPosts: Array<{ title: string; body?: string }>,
+    aiQuestions: Array<{ question: string }>
+  ): Promise<{
+    gaps: Array<{ topic: string; summary: string; frequency: number; suggestedActions: string[] }>;
+    trendingTopics: string[];
+  }> {
+    const systemPrompt = `You are a knowledge base analytics engine.
+Given a list of community posts that the AI could not confidently answer, and a list of questions recently asked to the AI, identify recurring "knowledge gaps" and "trending topics".
+A knowledge gap is a specific topic where users are confused and lack documentation.
+Output MUST be a valid JSON object with this exact structure:
+{
+  "gaps": [
+    {
+      "topic": "string",
+      "summary": "string",
+      "frequency": number,
+      "suggestedActions": ["string"]
+    }
+  ],
+  "trendingTopics": ["string"]
+}`;
+
+    const postsContext = escalatedPosts
+      .map((p, i) => `[Escalated Post ${i + 1}] Title: ${p.title}\nBody: ${p.body?.slice(0, 200) || ''}`)
+      .join('\n\n');
+      
+    const qsContext = aiQuestions
+      .map((q, i) => `[AI Question ${i + 1}] ${q.question}`)
+      .join('\n');
+
+    const userContent = `Analyze the following data from the past week.\n\nEscalated Posts:\n${postsContext || 'None'}\n\nAI Questions:\n${qsContext || 'None'}\n\nIdentify the top knowledge gaps. Return only JSON.`;
+
+    const result = await this.chat(
+      [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userContent },
+      ],
+      'gapAnalysis',
+      { temperature: 0.2, maxTokens: 1000 }
+    );
+
+    return parseGapAnalysisResponse(result.content);
+  }
+
+>>>>>>> Stashed changes
   // ─── Vector pre-filter ─────────────────────────────────────────────────────
 
   /**
@@ -831,6 +963,51 @@ function parseFAQResponse(
   }
 }
 
+<<<<<<< Updated upstream
+=======
+function parsePathwayResponse(raw: string, validIds: string[]): string[] {
+  const clean = raw.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim();
+  const match = clean.match(/\[[\s\S]*?\]/);
+  if (!match) return [];
+  try {
+    const parsed = JSON.parse(match[0]) as unknown[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(id => String(id))
+      .filter(id => validIds.includes(id))
+      .slice(0, 4);
+  } catch (err) {
+    logger.warn(`[aiClient] Failed to parse pathway JSON: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+function parseGapAnalysisResponse(raw: string): {
+  gaps: Array<{ topic: string; summary: string; frequency: number; suggestedActions: string[] }>;
+  trendingTopics: string[];
+} {
+  const clean = raw.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim();
+  const match = clean.match(/\{[\s\S]*\}/);
+  const defaultResult = { gaps: [], trendingTopics: [] };
+  if (!match) return defaultResult;
+  try {
+    const parsed = JSON.parse(match[0]) as any;
+    return {
+      gaps: Array.isArray(parsed.gaps) ? parsed.gaps.map((g: any) => ({
+        topic: String(g.topic || 'Unknown'),
+        summary: String(g.summary || ''),
+        frequency: Number(g.frequency || 1),
+        suggestedActions: Array.isArray(g.suggestedActions) ? g.suggestedActions.map(String) : [],
+      })) : [],
+      trendingTopics: Array.isArray(parsed.trendingTopics) ? parsed.trendingTopics.map(String) : [],
+    };
+  } catch (err) {
+    logger.warn(`[aiClient] Failed to parse gap analysis JSON: ${(err as Error).message}`);
+    return defaultResult;
+  }
+}
+
+>>>>>>> Stashed changes
 // ─── Default export ─────────────────────────────────────────────────────────
 
 export default AiClient;

--- a/apps/backend/src/modules/ai/ai-config.model.ts
+++ b/apps/backend/src/modules/ai/ai-config.model.ts
@@ -92,6 +92,8 @@ export interface IAiConfig extends Document {
     knowledgeExtraction: { enabled: boolean; model: string; temperature: number; maxTokens: number };
     searchSummarization: { enabled: boolean; model: string; temperature: number; maxTokens: number };
     faqGeneration:       { enabled: boolean; model: string; temperature: number; maxTokens: number };
+    pathwayGeneration:   { enabled: boolean; model: string; temperature: number; maxTokens: number };
+    gapAnalysis:         { enabled: boolean; model: string; temperature: number; maxTokens: number };
   };
 
   // Dynamic Embedding Configuration (v1.72)
@@ -174,6 +176,8 @@ const aiConfigSchema = new Schema<IAiConfig>(
         knowledgeExtraction: { enabled: true, model: 'claude-sonnet-4-20250514', temperature: 0.2, maxTokens: 2048 },
         searchSummarization: { enabled: true, model: 'claude-sonnet-4-20250514', temperature: 0.3, maxTokens: 512 },
         faqGeneration:       { enabled: true, model: 'claude-sonnet-4-20250514', temperature: 0.4, maxTokens: 1024 },
+        pathwayGeneration:   { enabled: true, model: 'claude-sonnet-4-20250514', temperature: 0.2, maxTokens: 256 },
+        gapAnalysis:         { enabled: true, model: 'claude-sonnet-4-20250514', temperature: 0.2, maxTokens: 1000 },
       }),
     },
 

--- a/apps/backend/src/modules/ai/knowledge-gap.model.ts
+++ b/apps/backend/src/modules/ai/knowledge-gap.model.ts
@@ -1,0 +1,44 @@
+import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
+
+export interface IKnowledgeGapReport extends Document {
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  gaps: Array<{
+    topic: string;
+    summary: string;
+    frequency: number;
+    suggestedActions: string[];
+  }>;
+  trendingTopics: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const knowledgeGapReportSchema = new MongooseSchema<IKnowledgeGapReport>(
+  {
+    dateRange: {
+      start: { type: Date, required: true },
+      end: { type: Date, required: true },
+    },
+    gaps: [
+      {
+        topic: { type: String, required: true },
+        summary: { type: String, required: true },
+        frequency: { type: Number, required: true },
+        suggestedActions: [{ type: String }],
+      },
+    ],
+    trendingTopics: [{ type: String }],
+  },
+  { timestamps: true }
+);
+
+knowledgeGapReportSchema.index({ createdAt: -1 });
+
+export default mongoose.model<IKnowledgeGapReport>(
+  'KnowledgeGapReport',
+  knowledgeGapReportSchema,
+  'yaksha_faq_knowledge_gap_reports'
+);

--- a/apps/backend/src/modules/ai/knowledge-gap.routes.ts
+++ b/apps/backend/src/modules/ai/knowledge-gap.routes.ts
@@ -1,0 +1,37 @@
+import { Router, Request, Response } from 'express';
+import { protect, authorize } from '../../middleware/auth.js';
+import KnowledgeGapReport from './knowledge-gap.model.js';
+import { runKnowledgeGapAnalysis } from './knowledge-gap.service.js';
+
+const router = Router();
+
+// GET /api/admin/knowledge-gaps
+// Fetch the latest knowledge gap reports
+router.get('/', protect, authorize('admin', 'moderator'), async (req: Request, res: Response) => {
+  try {
+    const limit = parseInt(req.query.limit as string) || 10;
+    const reports = await KnowledgeGapReport.find()
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .lean();
+    res.json({ reports });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch knowledge gap reports' });
+  }
+});
+
+// POST /api/admin/knowledge-gaps/trigger
+// Manually trigger a knowledge gap analysis run
+router.post('/trigger', protect, authorize('admin', 'moderator'), async (req: Request, res: Response) => {
+  try {
+    // Run it asynchronously so we don't block the request if it takes a while
+    runKnowledgeGapAnalysis().catch((err) => {
+      console.error('Manual knowledge gap analysis failed:', err);
+    });
+    res.json({ message: 'Knowledge gap analysis triggered.' });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to trigger knowledge gap analysis' });
+  }
+});
+
+export default router;

--- a/apps/backend/src/modules/ai/knowledge-gap.service.ts
+++ b/apps/backend/src/modules/ai/knowledge-gap.service.ts
@@ -1,0 +1,49 @@
+import { logger } from '../../utils/http/logger.js';
+import CommunityPost from '../community/community-post.model.js';
+import AiQuestion from './ai-question.model.js';
+import AiClient from './ai-client.service.js';
+import KnowledgeGapReport from './knowledge-gap.model.js';
+
+export async function runKnowledgeGapAnalysis(): Promise<void> {
+  try {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 7);
+
+    logger.info(`[knowledgeGap] Starting gap analysis for period: ${start.toISOString()} to ${end.toISOString()}`);
+
+    // Fetch escalated posts
+    const escalatedPosts = await CommunityPost.find({
+      aiAnswerStatus: 'escalated',
+      createdAt: { $gte: start, $lte: end }
+    }).select('title body').lean();
+
+    // Fetch AI questions
+    const aiQuestions = await AiQuestion.find({
+      createdAt: { $gte: start, $lte: end }
+    }).select('question').lean();
+
+    if (escalatedPosts.length === 0 && aiQuestions.length === 0) {
+      logger.info('[knowledgeGap] No data to analyze for this period.');
+      return;
+    }
+
+    const aiClient = new AiClient();
+    const reportData = await aiClient.generateKnowledgeGapReport(
+      escalatedPosts.map(p => ({ title: p.title, body: p.body })),
+      aiQuestions.map(q => ({ question: q.question }))
+    );
+
+    // Save report
+    await KnowledgeGapReport.create({
+      dateRange: { start, end },
+      gaps: reportData.gaps,
+      trendingTopics: reportData.trendingTopics,
+    });
+
+    logger.info('[knowledgeGap] Gap analysis completed and saved successfully.');
+  } catch (err) {
+    logger.error(`[knowledgeGap] Error running analysis: ${(err as Error).message}`);
+    throw err;
+  }
+}

--- a/apps/frontend/src/admin/components/layout/AdminSidebar.tsx
+++ b/apps/frontend/src/admin/components/layout/AdminSidebar.tsx
@@ -30,6 +30,7 @@ const NAV: NavGroup[] = [
       { to: '/admin/auto-answer',    label: 'AI Answers',    icon: SparkleIcon, featureFlag: 'aiAutoAnswer' },
       { to: '/admin/faq-audit',     label: 'FAQ Audit',     icon: StethoscopeIcon, featureFlag: 'faqFreshness' },
       { to: '/admin/unresolved-search', label: 'FAQ Gaps',    icon: SearchMissIcon },
+      { to: '/admin/knowledge-gaps', label: 'AI Knowledge Gaps', icon: BrainIcon },
     ],
   },
   {

--- a/apps/frontend/src/admin/pages/AdminKnowledgeGaps.tsx
+++ b/apps/frontend/src/admin/pages/AdminKnowledgeGaps.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import api from '../../utils/api';
+import { flexCol, textBodySoft, textLabelBold, textLabelXsBold } from '../../styles/style_config';
+import Spinner from '../../components/ui/Spinner';
+
+interface Gap {
+  topic: string;
+  summary: string;
+  frequency: number;
+  suggestedActions: string[];
+}
+
+interface Report {
+  _id: string;
+  dateRange: { start: string; end: string };
+  gaps: Gap[];
+  trendingTopics: string[];
+  createdAt: string;
+}
+
+export default function AdminKnowledgeGaps() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [triggering, setTriggering] = useState(false);
+
+  useEffect(() => {
+    fetchReports();
+  }, []);
+
+  const fetchReports = () => {
+    setLoading(true);
+    api.get('/admin/knowledge-gaps')
+      .then(res => setReports(res.data.reports))
+      .catch(err => console.error(err))
+      .finally(() => setLoading(false));
+  };
+
+  const handleTriggerAnalysis = () => {
+    setTriggering(true);
+    api.post('/admin/knowledge-gaps/trigger')
+      .then(() => {
+        alert('Analysis triggered! It may take a minute. Check back soon.');
+        fetchReports();
+      })
+      .catch(err => console.error(err))
+      .finally(() => setTriggering(false));
+  };
+
+  return (
+    <div className={`p-6 ${flexCol} gap-6 max-w-5xl mx-auto`}>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-ink">Knowledge Gaps</h1>
+          <p className={`mt-1 ${textBodySoft}`}>
+            AI-driven analysis of unresolved questions and escalated community posts.
+          </p>
+        </div>
+        <button
+          onClick={handleTriggerAnalysis}
+          disabled={triggering}
+          className="px-4 py-2 bg-accent text-white rounded-lg font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+        >
+          {triggering ? 'Triggering...' : 'Run Analysis Now'}
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="py-20 flex justify-center"><Spinner size="lg" /></div>
+      ) : reports.length === 0 ? (
+        <div className="py-20 text-center text-ink-soft border border-border border-dashed rounded-xl">
+          No reports generated yet.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-8">
+          {reports.map((report) => (
+            <div key={report._id} className="bg-card border border-border rounded-xl shadow-sm overflow-hidden">
+              <div className="bg-mist px-6 py-4 border-b border-border flex justify-between items-center">
+                <span className={textLabelBold}>
+                  Report from {new Date(report.dateRange.start).toLocaleDateString()} to {new Date(report.dateRange.end).toLocaleDateString()}
+                </span>
+                <span className="text-xs text-ink-faint">
+                  Generated {new Date(report.createdAt).toLocaleString()}
+                </span>
+              </div>
+              
+              <div className="p-6 flex flex-col gap-6">
+                {report.trendingTopics.length > 0 && (
+                  <div>
+                    <h3 className={`mb-3 ${textLabelXsBold} text-ink-soft uppercase tracking-wider`}>Trending Topics</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {report.trendingTopics.map(topic => (
+                        <span key={topic} className="px-3 py-1 bg-accent/10 text-accent rounded-full text-sm font-medium">
+                          {topic}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div>
+                  <h3 className={`mb-3 ${textLabelXsBold} text-ink-soft uppercase tracking-wider`}>Identified Gaps</h3>
+                  {report.gaps.length === 0 ? (
+                    <p className="text-sm text-ink-soft italic">No significant gaps identified in this period.</p>
+                  ) : (
+                    <div className="flex flex-col gap-4">
+                      {report.gaps.map((gap, i) => (
+                        <div key={i} className="border border-border/60 rounded-lg p-4 bg-mist/30">
+                          <div className="flex justify-between items-start mb-2">
+                            <h4 className="font-semibold text-ink">{gap.topic}</h4>
+                            <span className="text-xs bg-red-100 text-red-700 px-2 py-1 rounded-full font-medium">
+                              {gap.frequency} mentions
+                            </span>
+                          </div>
+                          <p className="text-sm text-ink-soft mb-3">{gap.summary}</p>
+                          {gap.suggestedActions.length > 0 && (
+                            <div className="bg-white/50 rounded-md p-3">
+                              <p className="text-xs font-bold text-ink-faint mb-1 uppercase tracking-wide">Suggested Actions</p>
+                              <ul className="list-disc list-inside text-sm text-ink">
+                                {gap.suggestedActions.map((action, j) => (
+                                  <li key={j}>{action}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -57,6 +57,7 @@ const AdminUsers = lazy(() => import('../admin/pages/AdminUsers'));
 const AdminSettings = lazy(() => import('../admin/pages/AdminSettings'));
 const AdminCommunity = lazy(() => import('../admin/pages/AdminCommunity'));
 const AdminModeration = lazy(() => import('../admin/pages/AdminModeration'));
+const AdminKnowledgeGaps = lazy(() => import('../admin/pages/AdminKnowledgeGaps'));
 const AdminUnresolvedSearch = lazy(() => import('../admin/pages/AdminUnresolvedSearch'));
 const AdminZoomMeetings = lazy(() => import('../admin/pages/AdminZoomMeetings'));
 const AdminZoomInsights = lazy(() => import('../admin/pages/AdminZoomInsights'));
@@ -192,6 +193,7 @@ export default function AppRoutes() {
           <Route path="/admin/settings" element={<RouteElement name="admin-settings"><AdminRoute><AdminLayout><AdminSettings /></AdminLayout></AdminRoute></RouteElement>} />
           <Route path="/admin/community" element={<RouteElement name="admin-community"><AdminRoute><AdminLayout><AdminCommunity /></AdminLayout></AdminRoute></RouteElement>} />
           <Route path="/admin/moderation" element={<RouteElement name="admin-moderation"><AdminRoute><AdminLayout><AdminModeration /></AdminLayout></AdminRoute></RouteElement>} />
+          <Route path="/admin/knowledge-gaps" element={<RouteElement name="admin-knowledge-gaps"><AdminRoute><AdminLayout><AdminKnowledgeGaps /></AdminLayout></AdminRoute></RouteElement>} />
           <Route path="/admin/unresolved-search" element={<RouteElement name="admin-unresolved-search"><AdminRoute><AdminLayout><AdminUnresolvedSearch /></AdminLayout></AdminRoute></RouteElement>} />
            <Route path="/admin/zoom-meetings" element={<RouteElement name="admin-zoom-meetings"><AdminRoute><AdminLayout><AdminZoomMeetings /></AdminLayout></AdminRoute></RouteElement>} />
           <Route path="/admin/zoom-insights" element={<RouteElement name="admin-zoom-insights"><AdminRoute><AdminLayout><AdminZoomInsights /></AdminLayout></AdminRoute></RouteElement>} />


### PR DESCRIPTION
## What changed

This PR introduces a new Knowledge Gap Dashboard for administrators. It helps identify unanswered or weak knowledge areas by tracking knowledge gaps, making it easier to prioritize content improvements and improve AI-assisted FAQ coverage.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [x] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

### Backend
- Added Knowledge Gap model, routes, and service.
- Registered new backend routes and startup integration.

### Frontend
- Added an Admin Knowledge Gap Dashboard page.
- Updated admin navigation and application routes.

This feature enables administrators to monitor and manage knowledge gaps in the FAQ system through a dedicated dashboard.