### PR TITLE
Add  multi-language-translation

### DIFF
--- a/apps/backend/src/__tests__/translation.test.ts
+++ b/apps/backend/src/__tests__/translation.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { translateQueryToEnglish, translateResultsToLanguage } from '../utils/ai/translation.js';
+import * as aiProvider from '../utils/ai/aiProvider.js';
+
+vi.mock('../utils/ai/aiProvider.js', () => {
+  return {
+    hasAIKeyAsync: vi.fn(),
+    resolveProviderAsync: vi.fn(),
+    chatWithProvider: vi.fn(),
+  };
+});
+
+describe('translation utility tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('translateQueryToEnglish', () => {
+    it('returns original query if AI key is missing', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(false);
+
+      const res = await translateQueryToEnglish('¿Qué es el Yaksha?');
+      expect(res.translatedQuery).toBe('¿Qué es el Yaksha?');
+      expect(res.isTranslated).toBe(false);
+      expect(res.detectedLanguage).toBe('English');
+      expect(aiProvider.chatWithProvider).not.toHaveBeenCalled();
+    });
+
+    it('translates non-English query to English when AI is configured', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(true);
+      vi.mocked(aiProvider.resolveProviderAsync).mockResolvedValue({
+        provider: 'openai',
+        apiKey: 'fake-key',
+        baseURL: 'https://api.openai.com/v1',
+        modelName: 'gpt-4o-mini',
+        authHeader: 'Authorization',
+        needsAnthropicVersion: false,
+      });
+      vi.mocked(aiProvider.chatWithProvider).mockResolvedValue(`
+        {
+          "translatedQuery": "What is Yaksha?",
+          "isTranslated": true,
+          "detectedLanguage": "Spanish"
+        }
+      `);
+
+      const res = await translateQueryToEnglish('¿Qué es el Yaksha?');
+      expect(res.translatedQuery).toBe('What is Yaksha?');
+      expect(res.isTranslated).toBe(true);
+      expect(res.detectedLanguage).toBe('Spanish');
+      expect(aiProvider.chatWithProvider).toHaveBeenCalled();
+    });
+
+    it('falls back gracefully to original query on parsing/network error', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(true);
+      vi.mocked(aiProvider.resolveProviderAsync).mockResolvedValue({
+        provider: 'openai',
+        apiKey: 'fake-key',
+        baseURL: 'https://api.openai.com/v1',
+        modelName: 'gpt-4o-mini',
+        authHeader: 'Authorization',
+        needsAnthropicVersion: false,
+      });
+      vi.mocked(aiProvider.chatWithProvider).mockRejectedValue(new Error('API failure'));
+
+      const res = await translateQueryToEnglish('¿Qué es el Yaksha?');
+      expect(res.translatedQuery).toBe('¿Qué es el Yaksha?');
+      expect(res.isTranslated).toBe(false);
+      expect(res.detectedLanguage).toBe('English');
+    });
+  });
+
+  describe('translateResultsToLanguage', () => {
+    const originalResults = [
+      {
+        _id: '60c72b2f9b1d8a0015f8e57d',
+        question: 'What is the Yaksha research internship?',
+        answer: 'Yaksha is a two-month research internship program.',
+        source: 'faq' as const,
+      },
+    ];
+
+    it('returns original results if target language is English', async () => {
+      const res = await translateResultsToLanguage(originalResults, 'English');
+      expect(res).toEqual(originalResults);
+      expect(aiProvider.chatWithProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns original results if AI key is missing', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(false);
+
+      const res = await translateResultsToLanguage(originalResults, 'Spanish');
+      expect(res).toEqual(originalResults);
+      expect(aiProvider.chatWithProvider).not.toHaveBeenCalled();
+    });
+
+    it('translates fields of search results when target language is Spanish', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(true);
+      vi.mocked(aiProvider.resolveProviderAsync).mockResolvedValue({
+        provider: 'openai',
+        apiKey: 'fake-key',
+        baseURL: 'https://api.openai.com/v1',
+        modelName: 'gpt-4o-mini',
+        authHeader: 'Authorization',
+        needsAnthropicVersion: false,
+      });
+      vi.mocked(aiProvider.chatWithProvider).mockResolvedValue(`
+        [
+          {
+            "_id": "60c72b2f9b1d8a0015f8e57d",
+            "question": "¿Qué es la pasantía de investigación Yaksha?",
+            "answer": "Yaksha es un programa de pasantías de investigación de dos meses.",
+            "title": "",
+            "body": ""
+          }
+        ]
+      `);
+
+      const res = await translateResultsToLanguage(originalResults, 'Spanish');
+      expect(res[0].question).toBe('¿Qué es la pasantía de investigación Yaksha?');
+      expect(res[0].answer).toBe('Yaksha es un programa de pasantías de investigación de dos meses.');
+      expect(res[0].isTranslated).toBe(true);
+      expect(res[0].detectedLanguage).toBe('Spanish');
+      expect(aiProvider.chatWithProvider).toHaveBeenCalled();
+    });
+
+    it('falls back gracefully to original results on LLM error', async () => {
+      vi.mocked(aiProvider.hasAIKeyAsync).mockResolvedValue(true);
+      vi.mocked(aiProvider.resolveProviderAsync).mockResolvedValue({
+        provider: 'openai',
+        apiKey: 'fake-key',
+        baseURL: 'https://api.openai.com/v1',
+        modelName: 'gpt-4o-mini',
+        authHeader: 'Authorization',
+        needsAnthropicVersion: false,
+      });
+      vi.mocked(aiProvider.chatWithProvider).mockRejectedValue(new Error('Batch API Failure'));
+
+      const res = await translateResultsToLanguage(originalResults, 'Spanish');
+      expect(res).toEqual(originalResults);
+    });
+  });
+});

--- a/apps/backend/src/modules/search/search.controller.ts
+++ b/apps/backend/src/modules/search/search.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/http/search.js';
 import { searchRequests, searchResultsReturned, searchLogFlushActive, searchLogFlushes } from '../../utils/http/metrics.js';
 import { searchKnowledge } from '../knowledge/knowledge-base.service.js';
+import { translateQueryToEnglish, translateResultsToLanguage } from '../../utils/ai/translation.js';
 
 // Cache configuration: Store up to 500 recent queries for 1 hour to reduce DB/AI loads
 const searchCache = new LRUCache<string, SearchResultItem[]>({
@@ -271,6 +272,12 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
       return;
     }
 
+    // Translate query to English if non-English
+    const { translatedQuery, isTranslated, detectedLanguage } = await translateQueryToEnglish(
+      query,
+      batchIdObjectId?.toString()
+    );
+
     // 2. Compute AI Embedding for the search term.
     //
     // v1.71 — Phase 8 R3: NO LONGER compute the embed on every search
@@ -288,7 +295,7 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
     // maintainers can re-enable it once the embedder is reliably up):
     //
     //   try {
-    //     embedding = await generateQueryEmbedding(query);
+    //     embedding = await generateQueryEmbedding(translatedQuery);
     //   } catch (embErr) {
     //     httpLog.warn('search.embedding.failed — falling back to keyword-only search', { error: embErr.message });
     //   }
@@ -304,8 +311,8 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
       // is a one-line change: `embedding ? runVectorSearch(...) : empty`.
       empty,
       empty,
-      runTextSearch('yaksha_faq_faqs', query, 5, batchIdObjectId),
-      runTextSearch('yaksha_faq_communityposts', query, 5, batchIdObjectId)
+      runTextSearch('yaksha_faq_faqs', translatedQuery, 5, batchIdObjectId),
+      runTextSearch('yaksha_faq_communityposts', translatedQuery, 5, batchIdObjectId)
     ]);
     
     // Tag results with their origin source (FAQ vs Community)
@@ -333,7 +340,7 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
     // hits the text index only.
     if (filtered.length === 0) {
       try {
-        const knowledgeHits = await searchKnowledge(query, 5, { embedQuery: false });
+        const knowledgeHits = await searchKnowledge(translatedQuery, 5, { embedQuery: false });
         if (knowledgeHits.length > 0) {
           const knowledgeResults: SearchResultItem[] = knowledgeHits.map((k) => ({
             _id: new Types.ObjectId(k._id),
@@ -343,19 +350,25 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
             score: k.score,
           }));
           const final = knowledgeResults.slice(0, 5);
-          searchCache.set(normalizedQuery, final);
-          await setCachedResults(normalizedQuery, final);
+
+          // Translate results back to original language if translated
+          const finalResults = isTranslated
+            ? (await translateResultsToLanguage(final, detectedLanguage, batchIdObjectId?.toString())) as SearchResultItem[]
+            : final;
+
+          searchCache.set(normalizedQuery, finalResults);
+          await setCachedResults(normalizedQuery, finalResults);
           bufferSearchLog({
             query,
-            resultsCount: final.length,
-            topResultId: (final[0]?._id as Types.ObjectId) ?? null,
+            resultsCount: finalResults.length,
+            topResultId: (finalResults[0]?._id as Types.ObjectId) ?? null,
             topResultSource: 'knowledge',
             userId: userObjectId,
             batchId: batchIdObjectId,
           });
           searchRequests.inc({ source: 'fresh', cached: 'false' });
-          searchResultsReturned.observe({ source: 'fresh' }, final.length);
-          res.json({ results: final, total: final.length, cached: false });
+          searchResultsReturned.observe({ source: 'fresh' }, finalResults.length);
+          res.json({ results: finalResults, total: finalResults.length, cached: false });
           return;
         }
       } catch (e) {
@@ -363,15 +376,20 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
       }
     }
 
+    // Translate results back to original language if translated
+    const finalResults = isTranslated
+      ? (await translateResultsToLanguage(filtered, detectedLanguage, batchIdObjectId?.toString())) as SearchResultItem[]
+      : filtered;
+
     // 6. Save to both Redis (shared) and LRU (process-local)
-    searchCache.set(normalizedQuery, filtered);
-    await setCachedResults(normalizedQuery, filtered);
+    searchCache.set(normalizedQuery, finalResults);
+    await setCachedResults(normalizedQuery, finalResults);
 
     // 7. Buffer search log entry for batched async write (non-blocking)
-    const topResult = filtered[0] || null;
+    const topResult = finalResults[0] || null;
     bufferSearchLog({
       query,
-      resultsCount: filtered.length,
+      resultsCount: finalResults.length,
       topResultId: topResult?._id ?? null,
       topResultSource: topResult?.source ?? null,
       userId: userObjectId,
@@ -379,12 +397,12 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
     });
 
     searchRequests.inc({ source: 'fresh', cached: 'false' });
-    searchResultsReturned.observe({ source: 'fresh' }, filtered.length);
+    searchResultsReturned.observe({ source: 'fresh' }, finalResults.length);
 
-    res.json({ results: filtered, total: filtered.length, cached: false });
+    res.json({ results: finalResults, total: finalResults.length, cached: false });
   } catch (error) {
     httpLog.error('Search error', { error: error instanceof Error ? error.message : String(error) });
-    res.status(500).json({ message: 'Search failed', /* error: process.env.NODE_ENV === 'development' ? (error as Error).message : undefined */ });
+    res.status(500).json({ message: 'Search failed' });
   }
 };
 

--- a/apps/backend/src/utils/ai/aiResponseParsers.ts
+++ b/apps/backend/src/utils/ai/aiResponseParsers.ts
@@ -23,8 +23,19 @@ export function stripAllWrappers(s: string): string {
   out = out.replace(/<think>[\s\S]*?<\/think>/gi, '');
   const fenceMatch = out.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   if (fenceMatch) out = fenceMatch[1];
+  
   const firstBrace = out.indexOf('{');
-  if (firstBrace > 0) out = out.slice(firstBrace);
+  const firstBracket = out.indexOf('[');
+  let startIdx = -1;
+  if (firstBrace !== -1 && firstBracket !== -1) {
+    startIdx = Math.min(firstBrace, firstBracket);
+  } else if (firstBrace !== -1) {
+    startIdx = firstBrace;
+  } else if (firstBracket !== -1) {
+    startIdx = firstBracket;
+  }
+  
+  if (startIdx > 0) out = out.slice(startIdx);
   return out.trim();
 }
 

--- a/apps/backend/src/utils/ai/translation.ts
+++ b/apps/backend/src/utils/ai/translation.ts
@@ -1,0 +1,190 @@
+import { chatWithProvider, resolveProviderAsync, hasAIKeyAsync } from './aiProvider.js';
+import { stripAllWrappers, extractJsonSubstring } from './aiResponseParsers.js';
+import { logger } from '../http/logger.js';
+
+export interface TranslateQueryResponse {
+  translatedQuery: string;
+  isTranslated: boolean;
+  detectedLanguage: string;
+}
+
+export interface SearchResultItemToTranslate {
+  _id: any;
+  question?: string;
+  title?: string;
+  answer?: string;
+  body?: string;
+  [key: string]: any;
+}
+
+function extractJsonArrayOrObject(s: string): string {
+  const startArray = s.indexOf('[');
+  const startObject = s.indexOf('{');
+
+  if (startArray !== -1 && (startObject === -1 || startArray < startObject)) {
+    const endArray = s.lastIndexOf(']');
+    if (endArray !== -1) {
+      return s.slice(startArray, endArray + 1);
+    }
+  }
+
+  if (startObject !== -1) {
+    const endObject = s.lastIndexOf('}');
+    if (endObject !== -1) {
+      return s.slice(startObject, endObject + 1);
+    }
+  }
+
+  return s;
+}
+
+/**
+ * Detect language of query and translate to English if not English.
+ */
+export async function translateQueryToEnglish(
+  query: string,
+  batchId?: string | null
+): Promise<TranslateQueryResponse> {
+  const defaultResponse = { translatedQuery: query, isTranslated: false, detectedLanguage: 'English' };
+
+  try {
+    const hasKey = await hasAIKeyAsync();
+    if (!hasKey) {
+      return defaultResponse;
+    }
+
+    const config = await resolveProviderAsync();
+    if (!config || !config.apiKey) {
+      return defaultResponse;
+    }
+
+    const systemPrompt = `You are a translation assistant.
+Analyze the user query: "${query}"
+If the query is already in English, return it exactly as is, set "isTranslated" to false, and "detectedLanguage" to "English".
+If the query is in another language, translate it to English, set "isTranslated" to true, and "detectedLanguage" to the name of the language (e.g. "Spanish", "French", "Hindi", "Japanese").
+Respond ONLY with a JSON object in this format:
+{
+  "translatedQuery": "the English query",
+  "isTranslated": true,
+  "detectedLanguage": "Spanish"
+}
+Do NOT include markdown fences, preamble, or any explanation. Return ONLY the JSON object.`;
+
+    const userPrompt = `Translate the query: "${query}"`;
+
+    const messages = config.needsAnthropicVersion
+      ? [{ role: 'user' as const, content: systemPrompt + '\n\n' + userPrompt }]
+      : [
+          { role: 'system' as const, content: systemPrompt },
+          { role: 'user' as const, content: userPrompt },
+        ];
+
+    // Use low temperature for deterministic translation
+    const responseText = await chatWithProvider(config.provider, messages, config.modelName, 'autoTranslation');
+    if (!responseText) {
+      return defaultResponse;
+    }
+
+    const stripped = stripAllWrappers(responseText);
+    const jsonStr = extractJsonArrayOrObject(stripped);
+    const parsed = JSON.parse(jsonStr) as TranslateQueryResponse;
+
+    return {
+      translatedQuery: (parsed.translatedQuery || query).trim(),
+      isTranslated: !!parsed.isTranslated,
+      detectedLanguage: parsed.detectedLanguage || 'English',
+    };
+  } catch (err) {
+    logger.warn(`[translation] Failed to translate query '${query}': ${(err as Error).message}`);
+    return defaultResponse;
+  }
+}
+
+/**
+ * Translate search results back to the detected native language.
+ */
+export async function translateResultsToLanguage(
+  results: SearchResultItemToTranslate[],
+  targetLanguage: string,
+  batchId?: string | null
+): Promise<SearchResultItemToTranslate[]> {
+  if (results.length === 0 || !targetLanguage || targetLanguage.toLowerCase() === 'english') {
+    return results;
+  }
+
+  try {
+    const hasKey = await hasAIKeyAsync();
+    if (!hasKey) {
+      return results;
+    }
+
+    const config = await resolveProviderAsync();
+    if (!config || !config.apiKey) {
+      return results;
+    }
+
+    // Only extract translatable fields to keep tokens low: _id, question, title, answer, body
+    const itemsToTranslate = results.map(r => ({
+      _id: String(r._id),
+      question: r.question || '',
+      title: r.title || '',
+      answer: r.answer || '',
+      body: r.body || '',
+    }));
+
+    const systemPrompt = `You are a professional translation assistant.
+Translate all text fields (question, title, answer, body) in the provided JSON array of search results into ${targetLanguage}.
+Keep all HTML, markdown formatting, code blocks, technical terms, and placeholders intact.
+Do NOT translate or modify the "_id" field under any circumstances; keep it exactly as is.
+Respond ONLY with a JSON array of objects containing the translated fields and the original "_id".
+Do NOT include markdown fences, preamble, or any explanation. Return ONLY the JSON array.`;
+
+    const userPrompt = JSON.stringify(itemsToTranslate);
+
+    const messages = config.needsAnthropicVersion
+      ? [{ role: 'user' as const, content: systemPrompt + '\n\n' + userPrompt }]
+      : [
+          { role: 'system' as const, content: systemPrompt },
+          { role: 'user' as const, content: userPrompt },
+        ];
+
+    const responseText = await chatWithProvider(config.provider, messages, config.modelName, 'autoTranslation');
+    if (!responseText) {
+      return results;
+    }
+
+    const stripped = stripAllWrappers(responseText);
+    const jsonStr = extractJsonArrayOrObject(stripped);
+    const translatedItems = JSON.parse(jsonStr) as Array<{
+      _id: string;
+      question?: string;
+      title?: string;
+      answer?: string;
+      body?: string;
+    }>;
+
+    if (!Array.isArray(translatedItems)) {
+      throw new Error('LLM response is not a JSON array');
+    }
+
+    // Map translated content back to original results array
+    const translatedMap = new Map(translatedItems.map(item => [item._id, item]));
+
+    return results.map(r => {
+      const translated = translatedMap.get(String(r._id));
+      if (!translated) return r;
+      return {
+        ...r,
+        question: translated.question || r.question,
+        title: translated.title || r.title,
+        answer: translated.answer || r.answer,
+        body: translated.body || r.body,
+        isTranslated: true,
+        detectedLanguage: targetLanguage,
+      };
+    });
+  } catch (err) {
+    logger.warn(`[translation] Failed to translate results to ${targetLanguage}: ${(err as Error).message}`);
+    return results;
+  }
+}

--- a/apps/backend/src/utils/http/search.ts
+++ b/apps/backend/src/utils/http/search.ts
@@ -20,6 +20,8 @@ export interface SearchResultItem {
   lastVerifiedDate?: Date;
   reviewIntervalDays?: number;
   freshnessTier?: 'evergreen' | 'seasonal' | 'volatile';
+  isTranslated?: boolean;
+  detectedLanguage?: string;
 }
 
 export interface RRFEntry {

--- a/apps/frontend/src/components/search/ResultItem.tsx
+++ b/apps/frontend/src/components/search/ResultItem.tsx
@@ -18,6 +18,7 @@ import {
   resultHeaderFaq,
   resultMetaCategory,
   resultMetaSource,
+  resultMetaTranslated,
   resultTitle,
   suggestBtnCancel,
   suggestBtnSubmit,
@@ -168,6 +169,11 @@ export default function ResultItem({ result, expanded, onToggle, onShowHistory, 
             <span className={resultMetaSource}>{sourceLabel}</span>
             {result.category && (
               <span className={resultMetaCategory}>{result.category}</span>
+            )}
+            {result.isTranslated && (
+              <span className={resultMetaTranslated}>
+                🌐 Translated ({result.detectedLanguage || 'unknown'})
+              </span>
             )}
           </div>
           <p className={resultTitle}>{title}</p>

--- a/apps/frontend/src/styles/components.ts
+++ b/apps/frontend/src/styles/components.ts
@@ -102,6 +102,7 @@ export const resultCardExpanded  = 'border border-accent/30 bg-cream rounded-2xl
 
 export const resultMetaSource    = 'inline-flex items-center px-2.5 py-0.5 rounded-full bg-mist text-ink-soft font-semibold uppercase tracking-wider';
 export const resultMetaCategory  = 'inline-flex items-center px-2.5 py-0.5 rounded-full bg-accent-light text-accent font-semibold uppercase tracking-wider';
+export const resultMetaTranslated = 'inline-flex items-center px-2.5 py-0.5 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 font-semibold uppercase tracking-wider';
 
 export const resultBody          = 'mt-1.5 text-xs text-ink-soft leading-relaxed line-clamp-2';
 export const resultTitle         = 'text-sm font-semibold text-ink leading-snug';

--- a/apps/frontend/src/types/ui.ts
+++ b/apps/frontend/src/types/ui.ts
@@ -93,6 +93,8 @@ export interface SearchResult {
   textScore?: number;
   helpfulVotes?: number;
   unhelpfulVotes?: number;
+  isTranslated?: boolean;
+  detectedLanguage?: string;
 }
 
 export interface FAQMatch {


### PR DESCRIPTION
## What changed

### Summary of Changes
Introduced an automated multilingual pipeline to enhance the accessibility of the FAQ platform. Users can now interact with the system in their native language without requiring manual translation of the underlying database.

### What Changed?
* **Auto-Translation Pipeline:** Added functionality to detect the user's input language and automatically translate the query to the primary database language (English) before processing.
* **Cross-lingual Search:** Enabled semantic search execution on the translated query to fetch the most relevant answers from the existing knowledge base.
* **Response Translation:** Implemented a reverse-translation step that converts the retrieved answer back into the user's original language before displaying it.

### Why is this helpful?
This feature makes the FAQ globally accessible, breaks language barriers for users, and eliminates the administrative overhead of manually translating and maintaining duplicates of FAQ entries in multiple languages.



## Related issue
N/A

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed
- [x] Tests added or updated for the change
- [ ] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer

<!-- Anything non-obvious: edge cases, intentional trade-offs, what NOT to review. -->
