### PR TITLE
fix(search): honor configurable thresholds in applySearchThreshold

### DIFF
--- a/apps/backend/src/modules/program/app-setting.model.ts
+++ b/apps/backend/src/modules/program/app-setting.model.ts
@@ -21,7 +21,7 @@
 
 import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
 
-export type SettingKey = 'goldenCooldownHours' | 'goldenPenaltyMultiplier' | 'zoomPassScore' | 'zoomQuestionCount' | 'zoomTranscript' | 'zoomUrl' | 'zoomTitle' | 'zoomDescription' | 'zoomDuration' | 'zoomActive' | 'zoomDailyResetTime' | 'autoAnswerApproveThreshold' | 'autoAnswerSuggestThreshold' | 'autoAnswerMinConfidence' | 'autoAnswerBatchSize' | 'autoAnswerMinAgeHours' | 'autoAnswerAskHumanThreshold' | 'autoAnswerCooldownMinutes' | 'faqDuplicateThreshold' | 'teeMockupUrl' | 'teeMockupBackUrl';
+export type SettingKey = 'goldenCooldownHours' | 'goldenPenaltyMultiplier' | 'zoomPassScore' | 'zoomQuestionCount' | 'zoomTranscript' | 'zoomUrl' | 'zoomTitle' | 'zoomDescription' | 'zoomDuration' | 'zoomActive' | 'zoomDailyResetTime' | 'autoAnswerApproveThreshold' | 'autoAnswerSuggestThreshold' | 'autoAnswerMinConfidence' | 'autoAnswerBatchSize' | 'autoAnswerMinAgeHours' | 'autoAnswerAskHumanThreshold' | 'autoAnswerCooldownMinutes' | 'faqDuplicateThreshold' | 'teeMockupUrl' | 'teeMockupBackUrl'| 'searchTextThreshold' | 'searchVectorThreshold';
 
 export interface IAppSetting extends Document<string> {
   /** Always 'singleton' — there is only one settings document. */
@@ -52,6 +52,8 @@ export interface IAppSetting extends Document<string> {
     autoAnswerBatchSize?: number;
     autoAnswerMinAgeHours?: number;
     faqDuplicateThreshold?: number;
+    searchTextThreshold?: number;
+    searchVectorThreshold?: number;
     teeMockupUrl?: string;
     teeMockupBackUrl?: string;
   };
@@ -94,6 +96,8 @@ const appSettingSchema = new MongooseSchema<IAppSetting>(
       autoAnswerAskHumanThreshold: { type: Number, default: 0.30, min: 0, max: 1 },
       autoAnswerCooldownMinutes: { type: Number, default: 60, min: 1, max: 1440 },
       faqDuplicateThreshold: { type: Number, default: 0.82, min: 0, max: 1 },
+      searchTextThreshold: { type: Number, default: 0, min: 0, max: 1 },
+      searchVectorThreshold: { type: Number, default: 0.80, min: 0, max: 1 },
       teeMockupUrl: { type: String, default: '' },
       teeMockupBackUrl: { type: String, default: '' }
     },

--- a/apps/backend/src/modules/search/search.controller.ts
+++ b/apps/backend/src/modules/search/search.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '../../utils/http/search.js';
 import { searchRequests, searchResultsReturned, searchLogFlushActive, searchLogFlushes } from '../../utils/http/metrics.js';
 import { searchKnowledge } from '../knowledge/knowledge-base.service.js';
-
+import AppSetting from '../program/app-setting.model.js';
 // Cache configuration: Store up to 500 recent queries for 1 hour to reduce DB/AI loads
 const searchCache = new LRUCache<string, SearchResultItem[]>({
   max: 500,
@@ -318,7 +318,11 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
     const merged = computeRRF(allVec, allTxt);
 
     // 5. Apply threshold filters to remove irrelevant garbage results
-    const filtered = applySearchThreshold(merged).slice(0, 5); // Return only the absolute top 5 results
+    // Fetch configurable thresholds from AppSetting (falls back to defaults if not set)
+    const settingsDoc = await AppSetting.findById('singleton').lean();
+    const textThreshold = settingsDoc?.settings?.searchTextThreshold;
+    const vectorThreshold = settingsDoc?.settings?.searchVectorThreshold;
+    const filtered = applySearchThreshold(merged, { textThreshold, vectorThreshold }).slice(0, 5);
 
     // 5b. TranscriptKnowledge fallback — if FAQ + Community returned nothing,
     // try the auto-extracted Zoom knowledge base. Zero-human data path:

--- a/apps/backend/src/utils/http/search.ts
+++ b/apps/backend/src/utils/http/search.ts
@@ -77,11 +77,20 @@ export function computeRRF(
 
 /**
  * Applies the platform's threshold filter to remove irrelevant results.
- * A document is kept if it has any keyword match (textScore > 0) OR
- * a strong semantic match (vectorScore > 0.80).
+ * A document is kept if it has any keyword match (textScore > textThreshold) OR
+ * a strong semantic match (vectorScore > vectorThreshold).
+ * Thresholds default to 0 (text) and 0.80 (vector) if not provided —
+ * these can be overridden via AppSetting (searchTextThreshold / searchVectorThreshold).
  */
-export function applySearchThreshold(results: SearchResultItem[]): SearchResultItem[] {
+export function applySearchThreshold(
+  results: SearchResultItem[],
+  thresholds?: { textThreshold?: number; vectorThreshold?: number }
+): SearchResultItem[] {
+  const textThreshold = thresholds?.textThreshold ?? 0;
+  const vectorThreshold = thresholds?.vectorThreshold ?? 0.80;
   return results.filter(
-    (doc) => (doc.textScore && doc.textScore > 0) || (doc.vectorScore && doc.vectorScore > 0.80)
+    (doc) =>
+      (doc.textScore && doc.textScore > textThreshold) ||
+      (doc.vectorScore && doc.vectorScore > vectorThreshold)
   );
 }


### PR DESCRIPTION
## What changed

 Makes `applySearchThreshold` (apps/backend/src/utils/http/search.ts) accept configurable `textThreshold` and `vectorThreshold` parameters instead of hardcoding `vectorScore > 0.80`. Adds `searchTextThreshold` and `searchVectorThreshold` fields to `AppSetting`, and wires the search controller to fetch and pass these values. Falls back to existing defaults (0 / 0.80) when no custom value is set. 

## Related issue

<!--
Closes #168 
-->

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [x] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [x] `cd apps/backend && npx tsc --noEmit` exits 0
- [x] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

Backward-compatible: `applySearchThreshold` still works without a second argument (existing callers unaffected). Frontend was not touched — this only wires the backend threshold pipeline. Only tested via `npm test`, not a manual API call. 
