### PR TITLE
fix: make hybrid search vector threshold configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ The hybrid search pipeline (vector + keyword + RRF) lives in `apps/backend/src/m
 
 - `POST /api/search` is **public** (no `protect`). The frontend SearchBar sends no JWT.
 - The LRU cache is in-memory and per-instance — does not survive restarts. Upstash Redis is the multi-instance cache when configured.
-- `applySearchThreshold` accepts a `thresholds` parameter but currently ignores it; filtering is hardcoded to `textScore > 0 || vectorScore >= 0.80`.
+- `applySearchThreshold` accepts an optional `minVectorScore` parameter; if omitted, it defaults to the configured `search.hybrid.minScore` and filtering checks `textScore > 0 || vectorScore > threshold`.
 
 ## Documentation
 

--- a/apps/backend/config.default.yaml
+++ b/apps/backend/config.default.yaml
@@ -73,7 +73,7 @@ search:
     keywordWeight: 0.4
     rrfK: 60                           # RRF constant
     maxResults: 20
-    minScore: 0.3
+    minScore: 0.80                     # vector-only threshold for applySearchThreshold
   embedding:
     model: "mixedbread-ai/mxbai-embed-large-v1"
     dimensions: 1024

--- a/apps/backend/src/__tests__/backend.test.ts
+++ b/apps/backend/src/__tests__/backend.test.ts
@@ -7,6 +7,7 @@ import type { NextFunction, Request, Response } from 'express';
 // Imports from backend components
 import { signUploadParams, isOurCloudinaryAsset, uploadSignatureToCloudinary, type CloudinaryConfig } from '../integrations/cloudinary/cloudinary.js';
 import { computeRRF, applySearchThreshold } from '../utils/http/search.js';
+import { loadConfig } from '../config/loader.js';
 import { authorize, type AuthedRequest } from '../middleware/authShared.js';
 import { matcher, moderateText } from '../config/moderationEngine.js';
 
@@ -243,6 +244,13 @@ describe('computeRRF', () => {
 // 4. Search: applySearchThreshold Tests
 // ==========================================
 describe('applySearchThreshold', () => {
+  it('should load default search minScore as 0.80 from config (canary test)', () => {
+    // This canary test proves that the actual YAML + Zod pipeline correctly defaults to 0.80.
+    // If someone changes config.default.yaml or schema.ts without checking this, it will fail.
+    const config = loadConfig();
+    expect(config.search.hybrid.minScore).toBe(0.80);
+  });
+
   it('should return all results when no scores are set (both scores falsy)', () => {
     const results = [
       { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1 },
@@ -259,7 +267,7 @@ describe('applySearchThreshold', () => {
     expect(filtered).toHaveLength(1);
   });
 
-  it('should include a result if vectorScore > 0.80 even when textScore is 0', () => {
+  it('should include a result if vectorScore > default threshold (0.80) even when textScore is 0', () => {
     const results = [
       { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.85 } as any,
     ];
@@ -267,7 +275,7 @@ describe('applySearchThreshold', () => {
     expect(filtered).toHaveLength(1);
   });
 
-  it('should include a result when BOTH textScore > 0 AND vectorScore > 0.80', () => {
+  it('should include a result when BOTH textScore > 0 AND vectorScore > default threshold (0.80)', () => {
     const results = [
       { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0.4, vectorScore: 0.9 } as any,
     ];
@@ -275,12 +283,39 @@ describe('applySearchThreshold', () => {
     expect(filtered).toHaveLength(1);
   });
 
-  it('should exclude a result when textScore is 0 AND vectorScore is below 0.80', () => {
+  it('should exclude a result when textScore is 0 AND vectorScore is below default threshold (0.80)', () => {
     const results = [
       { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.75 } as any,
     ];
     const filtered = applySearchThreshold(results);
     expect(filtered).toHaveLength(0);
+  });
+
+  it('should exclude a result when using custom high threshold (0.90)', () => {
+    const results = [
+      { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.85 } as any,
+    ];
+    // With default 0.80 it would pass, with custom 0.90 it should be excluded
+    const filtered = applySearchThreshold(results, 0.90);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('should include a result when using custom low threshold (0.50)', () => {
+    const results = [
+      { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.60 } as any,
+    ];
+    // With default 0.80 it would fail, with custom 0.50 it should be included
+    const filtered = applySearchThreshold(results, 0.50);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('should include a result based on textScore independently of a high vector threshold', () => {
+    const results = [
+      { _id: { toString: () => 'a' } as any, source: 'faq' as const, score: 1, textScore: 0.5, vectorScore: 0.50 } as any,
+    ];
+    // Vector score 0.50 fails the 0.99 threshold, but textScore 0.5 is > 0 so it should pass
+    const filtered = applySearchThreshold(results, 0.99);
+    expect(filtered).toHaveLength(1);
   });
 
   it('should exclude a result when only textScore > 0 but textScore is very small', () => {

--- a/apps/backend/src/config/schema.ts
+++ b/apps/backend/src/config/schema.ts
@@ -66,7 +66,7 @@ export const ConfigSchema = z.object({
       keywordWeight: z.number().default(0.4),
       rrfK: z.number().default(60),
       maxResults: z.number().default(20),
-      minScore: z.number().default(0.3),
+      minScore: z.number().default(0.80),
     }),
     embedding: z.object({
       model: z.string().default('mixedbread-ai/mxbai-embed-large-v1'),

--- a/apps/backend/src/utils/http/search.ts
+++ b/apps/backend/src/utils/http/search.ts
@@ -1,4 +1,5 @@
 import { Types } from 'mongoose';
+import { loadConfig } from '../../config/loader.js';
 
 export type ResultSource = 'faq' | 'community' | 'knowledge';
 
@@ -78,10 +79,12 @@ export function computeRRF(
 /**
  * Applies the platform's threshold filter to remove irrelevant results.
  * A document is kept if it has any keyword match (textScore > 0) OR
- * a strong semantic match (vectorScore > 0.80).
+ * a strong semantic match (vectorScore > configured threshold).
+ * Threshold defaults to `search.hybrid.minScore` from configuration.
  */
-export function applySearchThreshold(results: SearchResultItem[]): SearchResultItem[] {
+export function applySearchThreshold(results: SearchResultItem[], minVectorScore?: number): SearchResultItem[] {
+  const threshold = minVectorScore ?? loadConfig().search.hybrid.minScore;
   return results.filter(
-    (doc) => (doc.textScore && doc.textScore > 0) || (doc.vectorScore && doc.vectorScore > 0.80)
+    (doc) => (doc.textScore && doc.textScore > 0) || (doc.vectorScore && doc.vectorScore > threshold)
   );
 }

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -282,9 +282,9 @@ computeRRF(allVec, allTxt)
   Sort descending by rrfScore
         │
         ▼
-applySearchThreshold(results)
-  Kept if: textScore > 0  OR  vectorScore ≥ 0.80
-  (Note: `thresholds` param is accepted but IGNORED — filtering is hardcoded)
+applySearchThreshold(results, minVectorScore?)
+  Kept if: textScore > 0  OR  vectorScore > search.hybrid.minScore (default 0.80)
+  Override via config.default.yaml → search.hybrid.minScore, or pass explicit minVectorScore
         │
         ▼
 slice(0, 5) → setCachedResults → bufferSearchLog → log → return JSON

--- a/docs/context.md
+++ b/docs/context.md
@@ -85,7 +85,7 @@ crowd-source-faq/
 - **Hybrid search** merges vector similarity + keyword text search via **Reciprocal Rank Fusion** (RRF_K=60)
 - User types query → backend generates embedding via **`@xenova/transformers` `Xenova/multi-qa-mpnet-base-dot-v1`** (768-dim, singleton pipeline in Node.js)
 - 4 parallel queries: FAQ vector, community vector, FAQ text, community text
-- Results filtered by threshold: `textScore > 0 || vectorScore > 0.80`
+- Results filtered by threshold: `textScore > 0 || vectorScore > search.hybrid.minScore (default 0.80, configurable)`
 - Returns top 5 merged + ranked results
 - In-memory LRU cache (500 items, 1-hour TTL) for repeated queries
 - **SearchLog** records every query for analytics: `{ query, resultsCount, topResultId, topResultSource }`

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -43,7 +43,7 @@ Governs IP-based request throttles using `express-rate-limit`:
 - `hybrid.vectorWeight`: Relative weight of vector rankings in RRF merging (default `0.6`).
 - `hybrid.keywordWeight`: Relative weight of keyword text rankings in RRF merging (default `0.4`).
 - `hybrid.rrfK`: The constant $k$ used to damp Reciprocal Rank Fusion ranks (default `60`).
-- `hybrid.minScore`: Minimum score similarity threshold below which results are discarded (default `0.3`).
+- `hybrid.minScore`: Minimum vector score similarity threshold below which results are discarded (default `0.80`).
 - `embedding.model`: Hugging Face model key used for local embedding generation (default `mixedbread-ai/mxbai-embed-large-v1`).
 - `embedding.dimensions`: The number of vector dimensions (default `1024`).
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -42,7 +42,7 @@ This page lists common configuration issues, connection errors, and integration 
 
 ### Search Returns 0 Results
 - **Index Missing**: MongoDB Atlas Vector Search requires a vector index named exactly `vector_index` on the `embedding` field. Verify the index is active in your MongoDB Atlas dashboard.
-- **Min Score Threshold**: The default minimum score threshold is `0.3`. If query embeddings do not match documents above this similarity score, they are filtered out. You can adjust `search.hybrid.minScore` in your YAML config.
+- **Min Score Threshold**: The default minimum vector score threshold is `0.80`. If query embeddings do not match documents above this similarity score, they are filtered out. You can adjust `search.hybrid.minScore` in your YAML config.
 - **Text Index Missing**: Traditional keyword search requires text indexes on the `faqs` and `communityposts` collections. If the text index is missing, search queries will log warnings and fall back to vector-only results.
 
 ---


### PR DESCRIPTION
The vector similarity threshold for hybrid search is no longer hardcoded to 0.80. It now reads from \search.hybrid.minScore\ in the global config system.

Note for reviewers/deployers: The configuration is loaded and cached as a singleton at boot. Changing \minScore\ in the YAML configuration requires a server restart to take effect.


## What changed

<!-- One paragraph. What does this PR do, and why? -->

## Related issue

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [ ] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer

<!-- Anything non-obvious: edge cases, intentional trade-offs, what NOT to review. -->
