### PR TITLE
feat: add new FAQs for Monsoonship, CodersHigh, and lost endorsements

### DIFF
--- a/apps/backend/src/faqs.json
+++ b/apps/backend/src/faqs.json
@@ -6,6 +6,34 @@
       "question": "What is the Yaksha research internship?",
       "answer": "Yaksha is a two-month research internship program.",
       "category": "General Info"
+    },
+    {
+      "id": "2",
+      "section": "Internship",
+      "category": "Monsoonship Restart",
+      "question": "If I am restarting the internship and completed the CSFAQ project with a team previously, do I need to redo it?",
+      "answer": "Yes, you must complete the CSFAQ project again. For the Monsoonship restart, the CSFAQ project is an individual assignment, so you do not need to form a team. If you have any questions regarding project requirements or the submission process, you can join the Samagama Support Zoom breakout session daily at 4:00 PM for clarification."
+    },
+    {
+      "id": "3",
+      "section": "Community",
+      "category": "CodersHigh",
+      "question": "What is CodersHigh?",
+      "answer": "CodersHigh is a community where members practice coding and occasionally study linear algebra together during evening Zoom meetings. The meeting link is shared through the official CodersHigh WhatsApp group and is distinct from the daily standup Zoom link. Participation in these sessions is completely optional."
+    },
+    {
+      "id": "4",
+      "section": "Community",
+      "category": "CodersHigh",
+      "question": "How can I join the CodersHigh community?",
+      "answer": "To join CodersHigh, you can contact Jatin or the CliqMe team on Discourse to request an invite link to the official WhatsApp channel."
+    },
+    {
+      "id": "5",
+      "section": "Endorsements",
+      "category": "Verification",
+      "question": "What should I do if I have lost my previous project endorsements?",
+      "answer": "To regain your endorsements up to Module 5, you must attend a Zoom breakout room and complete a viva (oral examination). Due to issues with inauthentic verifications, only Jatin and designated mentors explicitly selected by him are authorized to verify your work and re-endorse you."
     }
   ]
 }


### PR DESCRIPTION
## What changed

This PR adds new foundational FAQ entries regarding the Monsoonship restart, CodersHigh community guidelines, and endorsement policies to the system's core data pipeline (`apps/backend/src/faqs.json`). This ensures the AI semantic search engine has up-to-date and accurate information to serve new interns.

## Related issue

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [x] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

This PR strictly contains JSON data additions to the knowledge base. No core application logic or API routes were modified.
