### PR TITLE
Add promote to FAQ feature for Admins

### DIFF
--- a/apps/backend/src/modules/admin/admin.controller.ts
+++ b/apps/backend/src/modules/admin/admin.controller.ts
@@ -678,6 +678,107 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
   }
 };
 
+// POST /api/admin/community/:id/promote-to-faq
+//
+// Admin-discretion promotion: the admin looks at a community post's
+// question + answer and decides — on their own judgment alone — to
+// publish it as an FAQ, right now. Unlike the community-promotions
+// pipeline in promotion.service.ts (which requires quality/engagement
+// score gates, a review window, and AI validation), this path has
+// NO eligibility checks. The only hard requirement is that the post
+// actually has an answer to promote — there's nothing to publish
+// without one.
+export const promoteCommunityPostToFAQ = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const post = await CommunityPost.findById(req.params.id);
+    if (!post) {
+      res.status(404).json({ message: 'Post not found.' });
+      return;
+    }
+    // Per-program scope check — same pattern as deleteCommunityPost above.
+    if (post.batchId && req.programContext?.batchId &&
+        post.batchId.toString() !== req.programContext.batchId) {
+      res.status(404).json({ message: 'Post not found.' });
+      return;
+    }
+
+    const answer = (post.answer ?? '').trim();
+    if (!answer) {
+      res.status(400).json({ message: 'This post has no answer yet — nothing to promote.' });
+      return;
+    }
+
+    // Idempotent: don't create a duplicate FAQ if this post was already promoted.
+    const existing = await FAQ.findOne({ sourceCommunityPostId: post._id });
+    if (existing) {
+      res.status(409).json({ message: 'This post has already been promoted to an FAQ.', faq: existing });
+      return;
+    }
+
+    // Best-effort embedding — never block the promotion on it.
+    let embedding: number[] | undefined;
+    try {
+      const text = `Question: ${post.title}. Answer: ${answer}`;
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('generateEmbedding timeout (5s)')), 5000)
+      );
+      embedding = (await Promise.race([generateEmbedding(text), timeout])) as any;
+    } catch (embErr) {
+      console.warn('[admin] promoteCommunityPostToFAQ: embedding skipped:', (embErr as Error).message);
+    }
+
+    const now = new Date();
+    const faq = await FAQ.create({
+      question: sanitizeHtml(post.title),
+      answer: sanitizeHtml(answer),
+      category: 'Community',
+      tags: post.tags ?? [],
+      status: 'approved',
+      embedding,
+      batchId: post.batchId ?? null,
+      createdBy: post.author,
+      trustLevel: 'expert',              // straight to "Admin Approved" — an admin made the call directly
+      sourceType: 'community_promotion',
+      sourceCommunityPostId: post._id,
+      promotedAt: now,
+      objectionStatus: 'none',
+      promotionMetadata: {
+        upvotesAtPromotion: post.upvotes?.length ?? 0,
+        communityAnswerAuthorId: post.answerAuthorId ?? null,
+        promotedBy: req.user!._id,
+      },
+    });
+
+    // Fast-forward the post's lifecycle straight to converted_to_faq —
+    // skip the community_accepted / ai_validated / admin_accepted stages
+    // since none of those gates applied here.
+    post.lifecycle ??= { status: 'open', statusHistory: [] } as any;
+    const fromStatus = post.lifecycle.status ?? 'open';
+    post.lifecycle.statusHistory ??= [];
+    (post.lifecycle.statusHistory as any).push({
+      from: fromStatus,
+      to: 'converted_to_faq',
+      changedBy: req.user!._id,
+      changedAt: now,
+      note: 'Promoted directly to FAQ by admin (discretionary, no eligibility checks)',
+    });
+    post.lifecycle.status = 'converted_to_faq';
+    post.lifecycle.convertedToFaqAt = now;
+    await post.save();
+
+    await Promise.all([
+      invalidateCache().catch((e) => console.error('[admin] invalidateCache after promote:', e)),
+    ]);
+    invalidatePublicCaches();
+
+    await logAction(req.user!._id.toString(), 'promote_community_post_to_faq', faq._id.toString(), 'faq', faq.question);
+
+    res.json({ message: 'Post promoted to FAQ.', faq });
+  } catch (error) {
+    res.status(500).json({ message: 'Server error', error: (error as Error).message });
+  }
+};
+
 // DELETE /api/admin/community/:id
 export const deleteCommunityPost = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/apps/backend/src/modules/admin/admin.routes.ts
+++ b/apps/backend/src/modules/admin/admin.routes.ts
@@ -17,6 +17,7 @@ import {
   getUserActivityChart,
   getCommunityPosts,
   deleteCommunityPost,
+  promoteCommunityPostToFAQ,
 } from './admin.controller.js';
 import {
   getCommunityPendingFAQs,
@@ -175,6 +176,10 @@ router.patch('/faq/:id', updateFAQ);
 router.patch('/faqs/:id', updateFAQ);
 router.delete('/faq/:id', deleteFAQ);
 router.delete('/community/:id', deleteCommunityPost);
+// Admin-discretion: instantly promote a community post's Q&A to FAQ,
+// no eligibility checks (contrast with /community-promotions/* below,
+// which is the gated auto-pipeline).
+router.post('/community/:id/promote-to-faq', promoteCommunityPostToFAQ);
 
 // FAQ promotion management (trust levels) — from promotionService
 router.get('/faqs/community-pending', getCommunityPendingFAQs);

--- a/apps/frontend/src/admin/pages/AdminCommunity.tsx
+++ b/apps/frontend/src/admin/pages/AdminCommunity.tsx
@@ -47,6 +47,7 @@ export default function AdminCommunity() {
   const [categoryFilter, setCategoryFilter] = useState('');
   const [toast, setToast] = useState<Toast | null>(null);
   const [viewPost, setViewPost] = useState<CommunityPost | null>(null);
+  const [promoting, setPromoting] = useState<string | null>(null);
   const debouncedSearch = useDebounce(search, 350);
   const showToast = (msg: string, type: Toast['type'] = 'success') => { setToast({ msg, type }); setTimeout(() => setToast(null), 3000); };
 
@@ -67,6 +68,21 @@ export default function AdminCommunity() {
   useEffect(() => { fetchPosts(); }, [fetchPosts]);
   useEffect(() => { setPage(1); }, [debouncedSearch, statusFilter, categoryFilter]);
   const handleDelete = async (id: string) => { if (!confirm('Delete this post?')) return; try { await adminApi.delete(`/admin/community/${id}`); showToast('Deleted', 'error'); fetchPosts(); } catch { showToast('Delete failed', 'error'); } };
+  const handlePromote = async (post: CommunityPost) => {
+    if (!post.answer?.trim()) { showToast('This post has no answer yet', 'warn'); return; }
+    if (!confirm(`Promote "${post.title}" to FAQ now? This publishes it immediately — no review needed.`)) return;
+    setPromoting(post._id);
+    try {
+      await adminApi.post(`/admin/community/${post._id}/promote-to-faq`);
+      showToast('Promoted to FAQ', 'success');
+      setViewPost(null);
+      fetchPosts();
+    } catch (err: any) {
+      showToast(err?.response?.data?.message || 'Promote failed', 'error');
+    } finally {
+      setPromoting(null);
+    }
+  };
 
   return (
     <div className="space-y-4 max-w-6xl">
@@ -195,6 +211,16 @@ export default function AdminCommunity() {
                   <td className="admin-td text-right" onClick={(e) => e.stopPropagation()}>
                     <div className="flex items-center justify-end gap-1">
                       <button onClick={() => setViewPost(post)} className="w-6 h-6 flex items-center justify-center rounded text-ink-faint hover:text-ink hover:bg-mist transition-colors" title="View"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+                      {post.answer?.trim() && (
+                        <button
+                          onClick={() => handlePromote(post)}
+                          disabled={promoting === post._id}
+                          className="w-6 h-6 flex items-center justify-center rounded text-ink-faint hover:text-success hover:bg-success/10 transition-colors disabled:opacity-40"
+                          title="Promote to FAQ"
+                        >
+                          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>
+                        </button>
+                      )}
                       <button onClick={() => handleDelete(post._id)} className="w-6 h-6 flex items-center justify-center rounded text-ink-faint hover:text-danger hover:bg-danger/10 transition-colors" title="Delete"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></button>
                     </div>
                   </td>
@@ -259,6 +285,15 @@ export default function AdminCommunity() {
               <span className="text-xs text-ink-faint">{new Date(viewPost.createdAt).toLocaleString('en-IN')}</span>
               <div className="flex gap-2">
                 <button onClick={() => { handleDelete(viewPost._id); setViewPost(null); }} className="px-3 py-1.5 rounded-md text-xs font-medium text-danger hover:bg-danger/10 transition-colors">Delete</button>
+                {viewPost.answer?.trim() && (
+                  <button
+                    onClick={() => handlePromote(viewPost)}
+                    disabled={promoting === viewPost._id}
+                    className="px-3 py-1.5 rounded-md text-xs font-medium text-success hover:bg-success/10 transition-colors disabled:opacity-40"
+                  >
+                    {promoting === viewPost._id ? 'Promoting…' : 'Promote to FAQ'}
+                  </button>
+                )}
                 <button onClick={() => setViewPost(null)} className={`${adminBtnGhost} px-3 py-1.5 text-xs`}>Close</button>
               </div>
             </div>


### PR DESCRIPTION
## What changed

Added a manual  "Promote to FAQ" feature for administrators. This change introduces a backend API endpoint and integrates it with the Admin Community interface, allowing admins to promote eligible community posts to the FAQ section directly from the admin panel.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [x] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

- Added the backend route and controller logic required for manual FAQ promotion.
- Integrated the feature into the Admin Community page.
- Verified that the feature is accessible from the admin interface and can invoke the promotion endpoint.
- No database schema changes or environment variable changes were introduced.