### PR TITLE
fix(search): make vector similarity threshold configurable via AppSet…

### DIFF
--- a/apps/backend/src/__tests__/backend.test.ts
+++ b/apps/backend/src/__tests__/backend.test.ts
@@ -314,6 +314,36 @@ describe('applySearchThreshold', () => {
     const filtered = applySearchThreshold(results);
     expect(filtered.map((r: any) => r._id.toString())).toEqual(['c', 'a', 'b']);
   });
+
+  it('should allow configurable vector threshold: vectorScore 0.5 excluded by default, included when threshold=0.4', () => {
+    const results = [
+      { _id: { toString: () => 'x' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.5 } as any,
+    ];
+    const defaultFiltered = applySearchThreshold(results);
+    expect(defaultFiltered).toHaveLength(0); // default 0.8 excludes 0.5
+    const customFiltered = applySearchThreshold(results, 0.4);
+    expect(customFiltered).toHaveLength(1); // custom threshold includes 0.5
+  });
+
+  it('should allow configurable vector threshold: vectorScore 0.9 included by default, excluded when threshold=0.95', () => {
+    const results = [
+      { _id: { toString: () => 'y' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.9 } as any,
+    ];
+    const defaultFiltered = applySearchThreshold(results);
+    expect(defaultFiltered).toHaveLength(1); // default includes 0.9
+    const customFiltered = applySearchThreshold(results, 0.95);
+    expect(customFiltered).toHaveLength(0); // custom threshold excludes 0.9
+  });
+
+  it('regression: calling applySearchThreshold(results) without second arg behaves as before (default 0.8)', () => {
+    const results = [
+      { _id: { toString: () => 'z' } as any, source: 'faq' as const, score: 1, textScore: 0, vectorScore: 0.85 } as any,
+    ];
+    const noArg = applySearchThreshold(results);
+    const explicitArg = applySearchThreshold(results, 0.8);
+    expect(noArg).toHaveLength(1);
+    expect(explicitArg).toHaveLength(1);
+  });
 });
 
 // ==========================================

--- a/apps/backend/src/modules/community/community-search.controller.ts
+++ b/apps/backend/src/modules/community/community-search.controller.ts
@@ -3,6 +3,7 @@ import CommunityPost, { ICommunityPost } from './community-post.model.js';
 import { generateQueryEmbedding } from '../../utils/ai/embeddings.js';
 import { Request, Response } from 'express';
 import { computeRRF, applySearchThreshold, type SearchResultItem } from '../../utils/http/search.js';
+import { readSetting } from '../program/app-setting.model.js';
 // v1.69 — Phase 3h: program-scope the community search.
 import { withProgramScope } from '../../utils/db/scopedQuery.js';
 import { communityLog } from '../../utils/http/logger.js';
@@ -124,7 +125,16 @@ export const searchCommunityPosts = async (req: Request, res: Response): Promise
 
     const merged = computeRRF(vectorResults, textResults);
 
-    const filtered = applySearchThreshold(merged)
+    // Read configured threshold (per-program override supported)
+    let configuredThreshold = 0.8;
+    try {
+      configuredThreshold = await readSetting('searchVectorThreshold', 0.8, batchIdParam);
+    } catch (err) {
+      communityLog.warn(`[communitySearch] Failed to read searchVectorThreshold setting: ${(err as Error).message}`);
+      configuredThreshold = 0.8;
+    }
+
+    const filtered = applySearchThreshold(merged, configuredThreshold)
       .slice(0, 20);
 
     const ids = filtered.map((d) => d._id);

--- a/apps/backend/src/modules/program/app-setting.model.ts
+++ b/apps/backend/src/modules/program/app-setting.model.ts
@@ -21,7 +21,7 @@
 
 import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
 
-export type SettingKey = 'goldenCooldownHours' | 'goldenPenaltyMultiplier' | 'zoomPassScore' | 'zoomQuestionCount' | 'zoomTranscript' | 'zoomUrl' | 'zoomTitle' | 'zoomDescription' | 'zoomDuration' | 'zoomActive' | 'zoomDailyResetTime' | 'autoAnswerApproveThreshold' | 'autoAnswerSuggestThreshold' | 'autoAnswerMinConfidence' | 'autoAnswerBatchSize' | 'autoAnswerMinAgeHours' | 'autoAnswerAskHumanThreshold' | 'autoAnswerCooldownMinutes' | 'faqDuplicateThreshold' | 'teeMockupUrl' | 'teeMockupBackUrl';
+export type SettingKey = 'goldenCooldownHours' | 'goldenPenaltyMultiplier' | 'zoomPassScore' | 'zoomQuestionCount' | 'zoomTranscript' | 'zoomUrl' | 'zoomTitle' | 'zoomDescription' | 'zoomDuration' | 'zoomActive' | 'zoomDailyResetTime' | 'autoAnswerApproveThreshold' | 'autoAnswerSuggestThreshold' | 'autoAnswerMinConfidence' | 'autoAnswerBatchSize' | 'autoAnswerMinAgeHours' | 'autoAnswerAskHumanThreshold' | 'autoAnswerCooldownMinutes' | 'faqDuplicateThreshold' | 'searchVectorThreshold' | 'teeMockupUrl' | 'teeMockupBackUrl';
 
 export interface IAppSetting extends Document<string> {
   /** Always 'singleton' — there is only one settings document. */
@@ -52,6 +52,8 @@ export interface IAppSetting extends Document<string> {
     autoAnswerBatchSize?: number;
     autoAnswerMinAgeHours?: number;
     faqDuplicateThreshold?: number;
+    /** Semantic vector similarity threshold used by search; 0..1 */
+    searchVectorThreshold?: number;
     teeMockupUrl?: string;
     teeMockupBackUrl?: string;
   };
@@ -94,6 +96,7 @@ const appSettingSchema = new MongooseSchema<IAppSetting>(
       autoAnswerAskHumanThreshold: { type: Number, default: 0.30, min: 0, max: 1 },
       autoAnswerCooldownMinutes: { type: Number, default: 60, min: 1, max: 1440 },
       faqDuplicateThreshold: { type: Number, default: 0.82, min: 0, max: 1 },
+      searchVectorThreshold: { type: Number, default: 0.8, min: 0, max: 1 },
       teeMockupUrl: { type: String, default: '' },
       teeMockupBackUrl: { type: String, default: '' }
     },

--- a/apps/backend/src/modules/program/app-settings.controller.ts
+++ b/apps/backend/src/modules/program/app-settings.controller.ts
@@ -116,6 +116,12 @@ export async function adminUpdateSetting(req: Request, res: Response): Promise<v
       res.status(400).json({ message: `${key} must be a string.` });
       return;
     }
+  } else if (key === 'searchVectorThreshold') {
+    const n = Number(body.value);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      res.status(400).json({ message: 'searchVectorThreshold must be a number between 0 and 1.' });
+      return;
+    }
   } else {
     res.status(400).json({ message: `Unknown setting key: ${key}` });
     return;

--- a/apps/backend/src/modules/search/search.controller.ts
+++ b/apps/backend/src/modules/search/search.controller.ts
@@ -11,6 +11,7 @@ import {
   type SearchResultItem,
   type ResultSource,
 } from '../../utils/http/search.js';
+import { readSetting } from '../program/app-setting.model.js';
 import { searchRequests, searchResultsReturned, searchLogFlushActive, searchLogFlushes } from '../../utils/http/metrics.js';
 import { searchKnowledge } from '../knowledge/knowledge-base.service.js';
 
@@ -317,8 +318,17 @@ export const semanticSearch = async (req: Request, res: Response): Promise<void>
     // 4. Merge results using Reciprocal Rank Fusion
     const merged = computeRRF(allVec, allTxt);
 
-    // 5. Apply threshold filters to remove irrelevant garbage results
-    const filtered = applySearchThreshold(merged).slice(0, 5); // Return only the absolute top 5 results
+    // 5. Read configured vector similarity threshold (per-program override supported)
+    let configuredThreshold = 0.8;
+    try {
+      configuredThreshold = await readSetting('searchVectorThreshold', 0.8, batchIdObjectId);
+    } catch (err) {
+      httpLog.warn(`[search] Failed to read searchVectorThreshold setting: ${(err as Error).message}`);
+      configuredThreshold = 0.8;
+    }
+
+    // 6. Apply threshold filters to remove irrelevant garbage results
+    const filtered = applySearchThreshold(merged, configuredThreshold).slice(0, 5); // Return only the absolute top 5 results
 
     // 5b. TranscriptKnowledge fallback — if FAQ + Community returned nothing,
     // try the auto-extracted Zoom knowledge base. Zero-human data path:

--- a/apps/backend/src/utils/http/search.ts
+++ b/apps/backend/src/utils/http/search.ts
@@ -78,10 +78,13 @@ export function computeRRF(
 /**
  * Applies the platform's threshold filter to remove irrelevant results.
  * A document is kept if it has any keyword match (textScore > 0) OR
- * a strong semantic match (vectorScore > 0.80).
+ * a strong semantic match (vectorScore > configured threshold).
+ *
+ * @param results - array of SearchResultItem to filter
+ * @param vectorThreshold - optional numeric threshold in [0,1] to use for vectorScore comparison (default 0.80)
  */
-export function applySearchThreshold(results: SearchResultItem[]): SearchResultItem[] {
+export function applySearchThreshold(results: SearchResultItem[], vectorThreshold = 0.8): SearchResultItem[] {
   return results.filter(
-    (doc) => (doc.textScore && doc.textScore > 0) || (doc.vectorScore && doc.vectorScore > 0.80)
+    (doc) => (doc.textScore && doc.textScore > 0) || (doc.vectorScore && doc.vectorScore > vectorThreshold)
   );
 }


### PR DESCRIPTION
## What changed

This PR fixes Issue #168 by making the vector similarity threshold configurable through the existing AppSetting infrastructure instead of using a hardcoded value (`0.80`).

The search controllers now read the threshold from AppSettings and pass it to `applySearchThreshold()`, while preserving backward compatibility through the existing default value. Regression tests have also been added for configurable threshold behaviour.

## Related issue

Closes #168

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community`)
- [x] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware
- [ ] Crons / schedulers
- [ ] Observability
- [ ] Docs

## CI verification

- [x] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — unrelated existing Journey Tracks tests currently fail
- [ ] `cd apps/frontend && npx tsc --noEmit`
- [ ] `cd apps/frontend && npx vitest run`
- [ ] `pnpm run lint`
- [ ] GitHub Actions green
- [x] Tests added or updated for the change
- [x] Single logical change
- [ ] Docs updated (not required)
- [x] Rebased onto `main`

## Notes for reviewer

- Added `searchVectorThreshold` to the existing AppSetting system.
- Preserves the default threshold (`0.80`) for backward compatibility.
- Both search controllers now use the configured threshold.
- Added regression tests covering configurable threshold behaviour.