### PR TITLE
chore: remove signature save debug logging

### DIFF
--- a/apps/frontend/src/components/tee/SignatureTool.tsx
+++ b/apps/frontend/src/components/tee/SignatureTool.tsx
@@ -130,7 +130,6 @@ export default function SignatureTool({
   const [signingFace, setSigningFace] = useState<'front' | 'back'>('back');
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [originalSize, setOriginalSize] = useState<number>(0);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -326,9 +325,6 @@ export default function SignatureTool({
 
   const finishDraw = () => {
     const dataUrl = canvasRef.current!.toDataURL('image/png');
-    const base64Str = dataUrl.split(',')[1];
-    const originalBytesSize = base64Str ? Math.floor(base64Str.length * 0.75) : 0;
-    setOriginalSize(originalBytesSize);
 
     const defaultX = signingFace === 'front' ? 0.3 : 0.7;
     setPendingSig({ id: `tmp-${Date.now()}`, dataUrl, face: signingFace, x: defaultX, y: 0.55, scale: 0.6, rotation: 0 });
@@ -352,7 +348,6 @@ export default function SignatureTool({
     
     setError(null);
     setSelectedFile(file);
-    setOriginalSize(file.size);
     return true;
   };
 
@@ -381,14 +376,6 @@ export default function SignatureTool({
     setPhase('submitting');
     try {
       const signatureBlob = dataURLtoBlob(pendingSig.dataUrl);
-      const payloadSize = signatureBlob.size;
-      const contentType = 'multipart/form-data';
-
-      console.log('Original file size:', originalSize);
-      console.log('Payload size:', payloadSize);
-      console.log('Content-Type:', contentType);
-      console.log('Content-Length:', payloadSize);
-
       const formData = new FormData();
       formData.append('signerName', signerName.trim());
       formData.append('face', pendingSig.face ?? 'back');

--- a/apps/frontend/src/components/tee/__tests__/SignatureTool.test.tsx
+++ b/apps/frontend/src/components/tee/__tests__/SignatureTool.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: {
+    div: ({ children, ...props }: { children: React.ReactNode }) => (
+      <div {...(props as Record<string, unknown>)}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock('../../../utils/sigRemover', () => ({
+  removeSignatureBackground: vi.fn().mockResolvedValue('data:image/png;base64,c2lnbmF0dXJl'),
+}));
+
+vi.mock('../PremiumTee', () => ({
+  default: () => <div data-testid="premium-tee" />,
+}));
+
+vi.mock('../../../utils/api', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+import api from '../../../utils/api';
+import SignatureTool from '../SignatureTool';
+
+const mockApi = api as unknown as {
+  post: ReturnType<typeof vi.fn>;
+};
+
+describe('SignatureTool', () => {
+  it('submits an uploaded signature and reports the saved overlay', async () => {
+    const onSigned = vi.fn();
+    mockApi.post.mockResolvedValue({
+      data: {
+        signature: {
+          id: 'signature-1',
+          signerDataUrl: 'data:image/png;base64,c2F2ZWQ=',
+          face: 'back',
+          x: 0.7,
+          y: 0.55,
+          scale: 0.6,
+          rotation: 0,
+        },
+      },
+    });
+
+    const { container } = render(
+      <SignatureTool
+        shareId="share-1"
+        shirtColor="navy"
+        textColor="cream"
+        nameOnBack="Test Tee"
+        existingSignatures={[]}
+        defaultSignerName="Test Signer"
+        onCancel={vi.fn()}
+        onSigned={onSigned}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /upload/i }));
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, {
+      target: { files: [new File(['signature'], 'signature.png', { type: 'image/png' })] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Use this signature →' }));
+
+    await screen.findByRole('button', { name: 'Save signature' });
+    fireEvent.click(screen.getByRole('button', { name: 'Save signature' }));
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalledWith(
+      '/tee/share/share-1/sign',
+      expect.any(FormData),
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    ));
+    await waitFor(() => expect(onSigned).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'signature-1',
+      dataUrl: 'data:image/png;base64,c2F2ZWQ=',
+    })));
+  });
+});

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+URL.createObjectURL = vi.fn(() => 'blob:signature-preview');
+URL.revokeObjectURL = vi.fn();


### PR DESCRIPTION
## What was there
`SignatureTool.tsx` had leftover development debug logging that ran every time a
user saved a signature. It logged the original file size, the outgoing payload
size, and request content-type/content-length details straight to the browser
console:

console.log('Original file size:', originalSize);
console.log('Payload size:', payloadSize);
console.log('Content-Type:', contentType);
console.log('Content-Length:', payloadSize);

This looked like instrumentation left over from development that was never
cleaned up before the feature shipped — it exposed internal request details
in the production console on every signature save.

## Fix
- Removed all 4 `console.log` statements
- Removed the `originalSize` state variable, which existed only to feed these
  logs and had no other use in the component
- No functional/behavioral change — the signature save flow works exactly as
  before, just without the console noise

## How this was found
Found via manual code review of the Tee signature flow, not from an assigned
GitHub issue.

## Testing
- Added `SignatureTool.test.tsx` covering the upload-and-save flow to confirm
  behavior is unaffected by this cleanup
- Manually tested locally: drew/uploaded a signature, saved it, confirmed the
  request still succeeds and the debug logs no longer appear in console
- `pnpm exec tsc --noEmit` passes
- `pnpm test` — new `SignatureTool.test.tsx` passes. Note: 3 unrelated test
  suites (`api.test.ts`, `PremiumTee.test.ts`, `GoldenTicketDetailPage.test.tsx`)
  fail on `main` as well, due to a pre-existing tooling error
  (`jsTokens is not a function`) unrelated to this change.