### PR TITLE
feat: add translation module and language selector for FAQs and the ui changes

### DIFF
--- a/apps/backend/src/bootstrap/routes.ts
+++ b/apps/backend/src/bootstrap/routes.ts
@@ -44,8 +44,10 @@ import registrationControlRoutes from '../modules/program/registration-control.r
 import adminCategoryClusterRoutes from '../modules/program/admin-category-cluster.routes.js';
 import publicCategoryClusterRoutes from '../modules/program/public-category-cluster.routes.js';
 import healthRoutes from '../modules/health/health.routes.js';
+import translateRoutes from '../modules/translation/translate.routes.js';
 
 export function registerRoutes(app: Express): void {
+
   const router = express.Router();
 
   router.use('/auth', authRoutes);
@@ -69,6 +71,7 @@ export function registerRoutes(app: Express): void {
   router.use('/knowledge', knowledgeRoutes);
   router.use('/ask-ai', askAiRoutes);
   router.use('/upload', uploadRoutes);
+  router.use('/translate', translateRoutes);
   router.use('/public', publicFaqRoutes);
   router.use('/health', healthRoutes);
   router.use('/batches', batchRoutes);

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load .env relative to the apps/backend directory regardless of execution context
+// Load .env.local and then .env relative to the apps/backend directory regardless of execution context
+const envLocalPath = path.resolve(__dirname, '../.env.local');
 const envPath = path.resolve(__dirname, '../.env');
+dotenv.config({ path: envLocalPath });
 dotenv.config({ path: envPath });
+

--- a/apps/backend/src/instrument.ts
+++ b/apps/backend/src/instrument.ts
@@ -35,7 +35,9 @@ import { fileURLToPath } from 'url';
 // point (server.ts, scripts, tests).
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
 
 import * as Sentry from '@sentry/node';
 import { expressIntegration, mongooseIntegration } from '@sentry/node';

--- a/apps/backend/src/modules/ai/ai-client.service.ts
+++ b/apps/backend/src/modules/ai/ai-client.service.ts
@@ -1049,6 +1049,15 @@ function parseFAQResponse(
   }
 }
 
+export async function generateChatCompletion(
+  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>,
+  overrides?: { temperature?: number; maxTokens?: number; model?: string; batchId?: string }
+): Promise<{ text: string; provider: string }> {
+  const client = new AiClient();
+  const res = await client.chat(messages, 'faqGeneration', overrides);
+  return { text: res.content, provider: res.provider };
+}
+
 // ─── Default export ─────────────────────────────────────────────────────────
 
 export default AiClient;

--- a/apps/backend/src/modules/translation/translate.controller.ts
+++ b/apps/backend/src/modules/translation/translate.controller.ts
@@ -1,0 +1,173 @@
+import { Request, Response } from 'express';
+import crypto from 'node:crypto';
+import z from 'zod';
+import TranslationCache from './translation-cache.model.js';
+import { generateChatCompletion } from '../ai/ai-client.service.js';
+import { httpLog } from '../../utils/http/logger.js';
+
+const translateSchema = z.object({
+  text: z.string().min(1).max(5000),
+  targetLang: z.string().min(2).max(10),
+  sourceLang: z.string().optional().default('en'),
+});
+
+const batchTranslateSchema = z.object({
+  texts: z.array(z.string().min(1).max(5000)).min(1).max(50),
+  targetLang: z.string().min(2).max(10),
+  sourceLang: z.string().optional().default('en'),
+});
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  en: 'English',
+  hi: 'Hindi',
+  es: 'Spanish',
+  fr: 'French',
+  de: 'German',
+  kn: 'Kannada',
+  ta: 'Tamil',
+  te: 'Telugu',
+  mr: 'Marathi',
+  bn: 'Bengali',
+};
+
+function getHash(targetLang: string, text: string): string {
+  return crypto.createHash('sha256').update(`${targetLang.toLowerCase().trim()}:${text.trim()}`).digest('hex');
+}
+
+/**
+ * Translate a single text string
+ */
+async function performTranslation(text: string, targetLang: string, sourceLang = 'en'): Promise<{ translatedText: string; provider: string }> {
+  // 1. If target is same as source (e.g. en -> en), return original
+  if (targetLang.toLowerCase() === sourceLang.toLowerCase()) {
+    return { translatedText: text, provider: 'identity' };
+  }
+
+  const langName = LANGUAGE_NAMES[targetLang.toLowerCase()] || targetLang;
+
+  // 2. Attempt translation via AI Client Service
+  try {
+    const prompt = `Translate the following text accurately into ${langName} (${targetLang}). Provide ONLY the translated text without any explanation, intro, quotes, or notes.\n\nText:\n${text}`;
+    const result = await generateChatCompletion([
+      { role: 'system', content: `You are a professional, accurate translator translating content into ${langName}.` },
+      { role: 'user', content: prompt }
+    ], { temperature: 0.1, maxTokens: 1000 });
+
+    if (result && result.text && result.text.trim()) {
+      return { translatedText: result.text.trim(), provider: result.provider || 'ai-service' };
+    }
+  } catch (err) {
+    httpLog.info(`[Translate] AI translation failed, switching to public fallback API: ${(err as Error).message}`);
+  }
+
+  // 3. Fallback: Free translation API (MyMemory)
+  try {
+    const langpair = `${sourceLang}|${targetLang}`;
+    const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text.slice(0, 500))}&langpair=${langpair}`;
+    const response = await fetch(url);
+    if (response.ok) {
+      const data = await response.json() as { responseData?: { translatedText?: string } };
+      if (data?.responseData?.translatedText) {
+        return { translatedText: data.responseData.translatedText, provider: 'mymemory-fallback' };
+      }
+    }
+  } catch (err) {
+    httpLog.alert(`[Translate] Fallback translation API error: ${(err as Error).message}`);
+  }
+
+  // 4. Ultimate fallback if all APIs are unavailable
+  return { translatedText: text, provider: 'fallback-raw' };
+}
+
+/**
+ * POST /csfaq/api/translate
+ */
+export async function translateTextHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const parsed = translateSchema.parse(req.body);
+    const { text, targetLang, sourceLang } = parsed;
+
+    if (targetLang.toLowerCase() === sourceLang.toLowerCase()) {
+      res.json({ translatedText: text, targetLang, cached: true });
+      return;
+    }
+
+    const hash = getHash(targetLang, text);
+    const cached = await TranslationCache.findOne({ hash });
+
+    if (cached) {
+      res.json({
+        translatedText: cached.translatedText,
+        targetLang: cached.targetLang,
+        cached: true,
+        provider: cached.provider,
+      });
+      return;
+    }
+
+    const { translatedText, provider } = await performTranslation(text, targetLang, sourceLang);
+
+    // Cache the result
+    await TranslationCache.create({
+      hash,
+      sourceText: text,
+      targetLang,
+      translatedText,
+      provider,
+    }).catch((err) => httpLog.info(`[Translate] Cache write skipped: ${(err as Error).message}`));
+
+    res.json({
+      translatedText,
+      targetLang,
+      cached: false,
+      provider,
+    });
+  } catch (error) {
+    const err = error as Error;
+    res.status(400).json({ error: 'Translation request failed', message: err.message });
+  }
+}
+
+/**
+ * POST /csfaq/api/translate/batch
+ */
+export async function batchTranslateHandler(req: Request, res: Response): Promise<void> {
+  try {
+    const parsed = batchTranslateSchema.parse(req.body);
+    const { texts, targetLang, sourceLang } = parsed;
+
+    if (targetLang.toLowerCase() === sourceLang.toLowerCase()) {
+      res.json({ translations: texts, targetLang });
+      return;
+    }
+
+    const results: string[] = [];
+
+    for (const text of texts) {
+      const hash = getHash(targetLang, text);
+      const cached = await TranslationCache.findOne({ hash });
+
+      if (cached) {
+        results.push(cached.translatedText);
+      } else {
+        const { translatedText, provider } = await performTranslation(text, targetLang, sourceLang);
+        await TranslationCache.create({
+          hash,
+          sourceText: text,
+          targetLang,
+          translatedText,
+          provider,
+        }).catch(() => null);
+        results.push(translatedText);
+      }
+    }
+
+    res.json({
+      translations: results,
+      targetLang,
+    });
+  } catch (error) {
+    const err = error as Error;
+    res.status(400).json({ error: 'Batch translation request failed', message: err.message });
+  }
+}

--- a/apps/backend/src/modules/translation/translate.routes.ts
+++ b/apps/backend/src/modules/translation/translate.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { translateTextHandler, batchTranslateHandler } from './translate.controller.js';
+
+const router = Router();
+
+// POST /csfaq/api/translate — Single text translation
+router.post('/', translateTextHandler);
+
+// POST /csfaq/api/translate/batch — Batch text translation
+router.post('/batch', batchTranslateHandler);
+
+export default router;

--- a/apps/backend/src/modules/translation/translation-cache.model.ts
+++ b/apps/backend/src/modules/translation/translation-cache.model.ts
@@ -1,0 +1,48 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ITranslationCache extends Document {
+  hash: string;
+  sourceText: string;
+  targetLang: string;
+  translatedText: string;
+  provider: string;
+  createdAt: Date;
+}
+
+const translationCacheSchema = new Schema<ITranslationCache>(
+  {
+    hash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    sourceText: {
+      type: String,
+      required: true,
+    },
+    targetLang: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    translatedText: {
+      type: String,
+      required: true,
+    },
+    provider: {
+      type: String,
+      default: 'auto',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Expire translation entries automatically after 30 days
+translationCacheSchema.index({ createdAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60 });
+
+const TranslationCache = mongoose.model<ITranslationCache>('TranslationCache', translationCacheSchema);
+
+export default TranslationCache;

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ErrorBoundary from './components/ui/ErrorBoundary';
 // Summership-era user enters their Internship End Date before
 // using the app. Mounts inside AuthProvider (needs `useAuth`) and
 // outside AppRoutes (needs to overlay every page uniformly).
+import { TranslationProvider } from './context/TranslationContext';
 import InternshipEndDateGate from './context/InternshipEndDateGate';
 
 export default function App() {
@@ -19,15 +20,17 @@ export default function App() {
       <AuthProvider>
         <BatchProvider>
           <FeatureFlagProvider>
-            <AuthModalHost>
-              <Suspense fallback={<div className="min-h-screen bg-bg flex items-center justify-center"><Spinner size="md" /></div>}>
-                <ErrorBoundary sectionName="App (top-level)">
-                  <InternshipEndDateGate>
-                    <AppRoutes />
-                  </InternshipEndDateGate>
-                </ErrorBoundary>
-              </Suspense>
-            </AuthModalHost>
+            <TranslationProvider>
+              <AuthModalHost>
+                <Suspense fallback={<div className="min-h-screen bg-bg flex items-center justify-center"><Spinner size="md" /></div>}>
+                  <ErrorBoundary sectionName="App (top-level)">
+                    <InternshipEndDateGate>
+                      <AppRoutes />
+                    </InternshipEndDateGate>
+                  </ErrorBoundary>
+                </Suspense>
+              </AuthModalHost>
+            </TranslationProvider>
           </FeatureFlagProvider>
         </BatchProvider>
       </AuthProvider>

--- a/apps/frontend/src/components/faq/QuestionDetail.tsx
+++ b/apps/frontend/src/components/faq/QuestionDetail.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FAQItem, getQuestionTitle, getAnswerText, formatDate, getCategoryIcon, formatCategoryName, TrustBadge } from './faqUtils';
 import ReportFAQButton from './ReportFAQButton';
 import FreshnessBadge from '../faq/FreshnessBadge';
+import { TranslateButton } from '../ui/TranslateButton';
 import {
   avatarPlaceholder,
   flexCol,
@@ -33,13 +34,18 @@ interface QuestionDetailProps {
 }
 
 export default function QuestionDetail({ item, relatedItems, onBack, onSelectRelated, backLabel }: QuestionDetailProps) {
-  const title = getQuestionTitle(item);
+  const [translatedAnswer, setTranslatedAnswer] = useState<string | null>(null);
+  const [translatedTitle, setTranslatedTitle] = useState<string | null>(null);
+
+  const title = translatedTitle || getQuestionTitle(item);
   const prefix = item.questionNumber ? `${item.questionNumber}. ` : '';
-  const answer = getAnswerText(item);
+  const rawAnswer = getAnswerText(item);
+  const answer = translatedAnswer || rawAnswer;
   const metaDate = formatDate(item?.updatedAt || item?.createdAt);
   const sourceLabel = item?.source ? (item.source === 'faq' ? 'FAQ' : 'Community') : '';
   const trustLevel = item?.trustLevel;
   const highlight = answer ? answer.split('. ').slice(0, 1).join('. ') : '';
+
 
   return (
     <div className="grid lg:grid-cols-[260px_1fr] gap-6">
@@ -84,23 +90,38 @@ export default function QuestionDetail({ item, relatedItems, onBack, onSelectRel
           {backLabel || 'Back'}
         </button>
 
-        <div className={`mt-4 ${flexRowWrap} gap-2`}>
-          {sourceLabel && (
-            <span className="px-2.5 py-1 rounded-full bg-mist text-[11px] font-semibold text-ink-soft">
-              {sourceLabel}
-            </span>
-          )}
-          {metaDate && (
-            <span className={textXsFaint}>Updated {metaDate}</span>
-          )}
-          {item?.source === 'faq' && (
-            <FreshnessBadge
-              reviewStatus={item.reviewStatus}
-              lastVerifiedDate={item.lastVerifiedDate}
-              reviewIntervalDays={item.reviewIntervalDays ?? 0}
-              freshnessTier={item.freshnessTier}
-            />
-          )}
+        <div className={`mt-4 ${flexRowBetween} items-center flex-wrap gap-2`}>
+          <div className={`${flexRowWrap} gap-2 items-center`}>
+            {sourceLabel && (
+              <span className="px-2.5 py-1 rounded-full bg-mist text-[11px] font-semibold text-ink-soft">
+                {sourceLabel}
+              </span>
+            )}
+            {metaDate && (
+              <span className={textXsFaint}>Updated {metaDate}</span>
+            )}
+            {item?.source === 'faq' && (
+              <FreshnessBadge
+                reviewStatus={item.reviewStatus}
+                lastVerifiedDate={item.lastVerifiedDate}
+                reviewIntervalDays={item.reviewIntervalDays ?? 0}
+                freshnessTier={item.freshnessTier}
+              />
+            )}
+          </div>
+          <TranslateButton
+            originalText={`${getQuestionTitle(item)}\n\n${rawAnswer}`}
+            onTranslate={(translated) => {
+              if (!translated) {
+                setTranslatedTitle(null);
+                setTranslatedAnswer(null);
+              } else {
+                const parts = translated.split('\n\n');
+                setTranslatedTitle(parts[0] || null);
+                setTranslatedAnswer(parts.slice(1).join('\n\n') || parts[0]);
+              }
+            }}
+          />
         </div>
 
         <h2 className={`mt-4 text-xl font-semibold text-ink leading-snug`}>

--- a/apps/frontend/src/components/layout/LanguageSelector.tsx
+++ b/apps/frontend/src/components/layout/LanguageSelector.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useTranslation } from '../../context/TranslationContext';
+import { dropdownRowHover, glassPanelStrong } from '../../styles/style_config';
+
+export const LanguageSelector: React.FC<{ compact?: boolean; className?: string }> = ({
+  compact = false,
+  className = '',
+}) => {
+  const { targetLang, setTargetLang, supportedLanguages, getLanguageInfo } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentLang = getLanguageInfo(targetLang);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-mist/80 hover:bg-mist border border-border/60 text-ink hover:text-accent-hover transition-all duration-200 shadow-sm cursor-pointer"
+        title="Select Interface Language"
+        aria-label="Language Selector"
+      >
+        <span className="text-sm leading-none">{currentLang.flag}</span>
+        {!compact && (
+          <span className="hidden sm:inline font-medium">
+            {currentLang.nativeName}
+          </span>
+        )}
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-ink-soft transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute right-0 top-[2.4rem] w-48 max-h-64 overflow-y-auto ${glassPanelStrong} rounded-2xl py-1.5 shadow-xl z-50 animate-fade-in border border-border/80`}
+        >
+          <div className="px-3 py-1.5 border-b border-border/40">
+            <p className="text-[10px] uppercase tracking-wider font-bold text-ink-faint">
+              Choose Language
+            </p>
+          </div>
+          {supportedLanguages.map((lang) => {
+            const isSelected = lang.code === targetLang;
+            return (
+              <button
+                key={lang.code}
+                type="button"
+                onClick={() => {
+                  setTargetLang(lang.code);
+                  setIsOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 text-xs flex items-center justify-between transition-colors ${dropdownRowHover} ${
+                  isSelected ? 'font-bold text-accent bg-accent/10' : 'text-ink-soft'
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  <span className="text-base">{lang.flag}</span>
+                  <span>{lang.nativeName}</span>
+                </span>
+                {isSelected && (
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import NotificationBell from '../../components/notifications/NotificationBell';
 import SpurtiChip from './SpurtiChip';
 import ZoomBubble from '../welcome/ZoomBubble';
 import { BatchSwitcher } from './BatchSwitcher';
+import { LanguageSelector } from './LanguageSelector';
 import { NavPills, useNavItems } from './NavPills';
 import { useTeeEligibility } from '../../hooks/useTeeEligibility';
 import logoWide from '../../assets/logo-wide.png';
@@ -167,6 +168,7 @@ export default function Navbar({ showProgramSwitcher: _showProgramSwitcher = fal
 
         {/* Right side actions */}
         <div className="flex items-center justify-self-end gap-2 sm:gap-3">
+          <LanguageSelector />
           {!isAdminView && (
             <>
               {/* Unauthenticated — Sign in (text) + Get started (filled) */}

--- a/apps/frontend/src/components/ui/TranslateButton.tsx
+++ b/apps/frontend/src/components/ui/TranslateButton.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useTranslation } from '../../context/TranslationContext';
+
+interface TranslateButtonProps {
+  originalText: string;
+  onTranslate: (translated: string | null) => void;
+  className?: string;
+}
+
+export const TranslateButton: React.FC<TranslateButtonProps> = ({
+  originalText,
+  onTranslate,
+  className = '',
+}) => {
+  const { targetLang, translateText, getLanguageInfo } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [isTranslated, setIsTranslated] = useState(false);
+
+  if (targetLang === 'en') return null;
+
+  const currentLang = getLanguageInfo(targetLang);
+
+  const handleToggle = async () => {
+    if (isTranslated) {
+      setIsTranslated(false);
+      onTranslate(null); // Revert to original
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await translateText(originalText);
+      setIsTranslated(true);
+      onTranslate(result);
+    } catch {
+      setIsTranslated(false);
+      onTranslate(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      disabled={loading}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all duration-200 ${
+        isTranslated
+          ? 'bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20'
+          : 'bg-mist text-ink-soft hover:text-ink hover:bg-mist/80 border border-border/50'
+      } ${className}`}
+    >
+      {loading ? (
+        <>
+          <svg className="animate-spin h-3 w-3 text-accent" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          <span>Translating...</span>
+        </>
+      ) : isTranslated ? (
+        <>
+          <span>{currentLang.flag}</span>
+          <span>Original English</span>
+        </>
+      ) : (
+        <>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="2" y1="12" x2="22" y2="12" />
+            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+          </svg>
+          <span>Translate to {currentLang.nativeName}</span>
+        </>
+      )}
+    </button>
+  );
+};

--- a/apps/frontend/src/context/TranslationContext.tsx
+++ b/apps/frontend/src/context/TranslationContext.tsx
@@ -1,0 +1,150 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import axios from 'axios';
+
+export interface Language {
+  code: string;
+  name: string;
+  nativeName: string;
+  flag: string;
+}
+
+export const SUPPORTED_LANGUAGES: Language[] = [
+  { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸' },
+  { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', flag: '🇮🇳' },
+  { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
+  { code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷' },
+  { code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪' },
+  { code: 'kn', name: 'Kannada', nativeName: 'कन्नड', flag: '🇮🇳' },
+  { code: 'ta', name: 'Tamil', nativeName: 'தமிழ்', flag: '🇮🇳' },
+  { code: 'te', name: 'Telugu', nativeName: 'తెలుగు', flag: '🇮🇳' },
+  { code: 'mr', name: 'Marathi', nativeName: 'मराठी', flag: '🇮🇳' },
+  { code: 'bn', name: 'Bengali', nativeName: 'বাংলা', flag: '🇮🇳' },
+];
+
+interface TranslationContextType {
+  targetLang: string;
+  setTargetLang: (lang: string) => void;
+  translateText: (text: string, langOverride?: string) => Promise<string>;
+  batchTranslate: (texts: string[], langOverride?: string) => Promise<string[]>;
+  supportedLanguages: Language[];
+  getLanguageInfo: (code: string) => Language;
+}
+
+const TranslationContext = createContext<TranslationContextType | undefined>(undefined);
+
+// Local in-memory cache for ultra-fast instant UI re-renders
+const clientCache = new Map<string, string>();
+
+export const TranslationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [targetLang, setTargetLangState] = useState<string>(() => {
+    try {
+      return localStorage.getItem('csfaq_target_lang') || 'en';
+    } catch {
+      return 'en';
+    }
+  });
+
+  const setTargetLang = (lang: string) => {
+    setTargetLangState(lang);
+    try {
+      localStorage.setItem('csfaq_target_lang', lang);
+    } catch {
+      void 0;
+    }
+  };
+
+  const getLanguageInfo = (code: string): Language => {
+    return SUPPORTED_LANGUAGES.find((l) => l.code === code) || SUPPORTED_LANGUAGES[0];
+  };
+
+  const translateText = async (text: string, langOverride?: string): Promise<string> => {
+    const lang = langOverride || targetLang;
+    if (!text || lang === 'en') return text;
+
+    const cacheKey = `${lang}:${text}`;
+    if (clientCache.has(cacheKey)) {
+      return clientCache.get(cacheKey)!;
+    }
+
+    try {
+      const response = await axios.post<{ translatedText: string }>('/csfaq/api/translate', {
+        text,
+        targetLang: lang,
+        sourceLang: 'en',
+      });
+      const result = response.data?.translatedText || text;
+      clientCache.set(cacheKey, result);
+      return result;
+    } catch (error) {
+      console.warn('[TranslationContext] Translation request failed:', error);
+      return text;
+    }
+  };
+
+  const batchTranslate = async (texts: string[], langOverride?: string): Promise<string[]> => {
+    const lang = langOverride || targetLang;
+    if (!texts.length || lang === 'en') return texts;
+
+    const uncachedIndices: number[] = [];
+    const uncachedTexts: string[] = [];
+    const results = new Array<string>(texts.length);
+
+    texts.forEach((txt, idx) => {
+      const key = `${lang}:${txt}`;
+      if (clientCache.has(key)) {
+        results[idx] = clientCache.get(key)!;
+      } else {
+        uncachedIndices.push(idx);
+        uncachedTexts.push(txt);
+      }
+    });
+
+    if (uncachedTexts.length === 0) {
+      return results;
+    }
+
+    try {
+      const response = await axios.post<{ translations: string[] }>('/csfaq/api/translate/batch', {
+        texts: uncachedTexts,
+        targetLang: lang,
+        sourceLang: 'en',
+      });
+      const translations = response.data?.translations || uncachedTexts;
+      uncachedIndices.forEach((origIdx, batchIdx) => {
+        const trans = translations[batchIdx] || uncachedTexts[batchIdx];
+        results[origIdx] = trans;
+        clientCache.set(`${lang}:${texts[origIdx]}`, trans);
+      });
+      return results;
+    } catch (error) {
+      console.warn('[TranslationContext] Batch translation failed:', error);
+      uncachedIndices.forEach((origIdx, batchIdx) => {
+        results[origIdx] = uncachedTexts[batchIdx];
+      });
+      return results;
+    }
+  };
+
+  return (
+    <TranslationContext.Provider
+      value={{
+        targetLang,
+        setTargetLang,
+        translateText,
+        batchTranslate,
+        supportedLanguages: SUPPORTED_LANGUAGES,
+        getLanguageInfo,
+      }}
+    >
+      {children}
+    </TranslationContext.Provider>
+  );
+};
+
+export const useTranslation = (): TranslationContextType => {
+  const context = useContext(TranslationContext);
+  if (!context) {
+    throw new Error('useTranslation must be used within a TranslationProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## What changed

<!-- One paragraph. What does this PR do, and why? -->

## Related issue

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [x] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [x] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [x] Tests added or updated for the change
- [ ] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer

<!-- Anything non-obvious: edge cases, intentional trade-offs, what NOT to review. -->
