### PR TITLE
feat(faq): add satisfaction rating with admin visibility

### DIFF
--- a/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
@@ -1,0 +1,55 @@
+import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
+
+export interface IFaqSatisfactionRating extends Document {
+  faqId: Types.ObjectId;
+  userId?: Types.ObjectId;
+  guestId?: string;
+  rating: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const faqSatisfactionRatingSchema = new MongooseSchema(
+  {
+    faqId: {
+      type: MongooseSchema.Types.ObjectId,
+      ref: 'FAQ',
+      required: true,
+    },
+
+    userId: {
+      type: MongooseSchema.Types.ObjectId,
+      ref: 'User',
+    },
+
+    guestId: {
+      type: String,
+    },
+
+    rating: {
+      type: Number,
+      required: true,
+      min: 1,
+      max: 5,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+faqSatisfactionRatingSchema.index(
+  { faqId: 1, userId: 1 },
+  { unique: true, sparse: true }
+);
+
+faqSatisfactionRatingSchema.index(
+  { faqId: 1, guestId: 1 },
+  { unique: true, sparse: true }
+);
+
+export default mongoose.model<IFaqSatisfactionRating>(
+  'FaqSatisfactionRating',
+  faqSatisfactionRatingSchema,
+  'yaksha_faq_satisfaction_ratings'
+);

--- a/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
@@ -2,8 +2,8 @@ import mongoose, { Document, Schema as MongooseSchema, Types } from 'mongoose';
 
 export interface IFaqSatisfactionRating extends Document {
   faqId: Types.ObjectId;
-  userId?: Types.ObjectId;
-  guestId?: string;
+  userId: Types.ObjectId | null;
+  guestId: string | null;
   rating: number;
   createdAt: Date;
   updatedAt: Date;
@@ -20,10 +20,12 @@ const faqSatisfactionRatingSchema = new MongooseSchema(
     userId: {
       type: MongooseSchema.Types.ObjectId,
       ref: 'User',
+      default: null,
     },
 
     guestId: {
       type: String,
+      default: null,
     },
 
     rating: {
@@ -40,12 +42,18 @@ const faqSatisfactionRatingSchema = new MongooseSchema(
 
 faqSatisfactionRatingSchema.index(
   { faqId: 1, userId: 1 },
-  { unique: true, sparse: true }
+  {
+    unique: true,
+    partialFilterExpression: { userId: { $type: 'objectId' } },
+  }
 );
 
 faqSatisfactionRatingSchema.index(
   { faqId: 1, guestId: 1 },
-  { unique: true, sparse: true }
+  {
+    unique: true,
+    partialFilterExpression: { guestId: { $type: 'string' } },
+  }
 );
 
 export default mongoose.model<IFaqSatisfactionRating>(

--- a/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction-rating.model.ts
@@ -59,5 +59,5 @@ faqSatisfactionRatingSchema.index(
 export default mongoose.model<IFaqSatisfactionRating>(
   'FaqSatisfactionRating',
   faqSatisfactionRatingSchema,
-  'yaksha_faq_satisfaction_ratings'
+  'yaksha_faq_satisfaction_rating'
 );

--- a/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
@@ -1,0 +1,41 @@
+import { Types } from 'mongoose';
+
+import FAQ from './faq.model';
+import FaqSatisfactionRating from './faq-satisfaction-rating.model';
+
+async function recomputeSatisfaction(
+  faqId: Types.ObjectId | string
+) {
+  const result = await FaqSatisfactionRating.aggregate([
+    {
+      $match: {
+        faqId: new Types.ObjectId(faqId),
+      },
+    },
+    {
+      $group: {
+        _id: '$faqId',
+        satisfactionAvg: { $avg: '$rating' },
+        satisfactionCount: { $sum: 1 },
+      },
+    },
+  ]);
+
+  const stats = result[0];
+
+  if (!stats) {
+    await FAQ.findByIdAndUpdate(faqId, {
+      satisfactionAvg: null,
+      satisfactionCount: 0,
+    });
+
+    return;
+  }
+
+  await FAQ.findByIdAndUpdate(faqId, {
+    satisfactionAvg: stats.satisfactionAvg,
+    satisfactionCount: stats.satisfactionCount,
+  });
+}
+
+export { recomputeSatisfaction };

--- a/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
@@ -1,7 +1,11 @@
+import { type Request, type Response } from 'express';
 import { Types } from 'mongoose';
 
 import FAQ from './faq.model.js';
 import FaqSatisfactionRating from './faq-satisfaction-rating.model.js';
+import { setGuestCookieIfMissing } from './public-faq.controller.js';
+import { assertSameProgram } from '../../utils/db/scopedQuery.js';
+import { adminLog } from '../../utils/http/logger.js';
 
 async function recomputeSatisfaction(
   faqId: Types.ObjectId | string
@@ -39,3 +43,105 @@ async function recomputeSatisfaction(
 }
 
 export { recomputeSatisfaction };
+
+type SatisfactionIdentity =
+  | { userId: Types.ObjectId }
+  | { guestId: string };
+
+interface SatisfactionResponse {
+  satisfactionAvg: number | null;
+  satisfactionCount: number;
+  yourRating: number | null;
+}
+
+function getSatisfactionIdentity(req: Request, res: Response): SatisfactionIdentity {
+  if (req.user?._id) {
+    return { userId: req.user._id as Types.ObjectId };
+  }
+
+  return { guestId: setGuestCookieIfMissing(req, res) };
+}
+
+async function getSatisfactionResponse(
+  faqId: Types.ObjectId,
+  identity: SatisfactionIdentity,
+): Promise<SatisfactionResponse> {
+  const [faq, rating] = await Promise.all([
+    FAQ.findById(faqId).select('satisfactionAvg satisfactionCount').lean(),
+    FaqSatisfactionRating.findOne({ faqId, ...identity }).select('rating').lean(),
+  ]);
+
+  return {
+    satisfactionAvg: faq?.satisfactionAvg ?? null,
+    satisfactionCount: faq?.satisfactionCount ?? 0,
+    yourRating: rating?.rating ?? null,
+  };
+}
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: number }).code === 11000;
+}
+
+/** POST /api/faq/:id/satisfaction — create or update the caller's rating. */
+export async function submitSatisfaction(req: Request<{ id: string }>, res: Response): Promise<void> {
+  try {
+    const faq = await FAQ.findById(req.params.id).select('_id batchId');
+    if (!faq) {
+      res.status(404).json({ message: 'FAQ not found.' });
+      return;
+    }
+    if (assertSameProgram(faq, req.programContext, res)) return;
+
+    const identity = getSatisfactionIdentity(req, res);
+    const rating = (req.body as { rating: number }).rating;
+    const filter = { faqId: faq._id, ...identity };
+
+    try {
+      await FaqSatisfactionRating.findOneAndUpdate(
+        filter,
+        { $set: { rating } },
+        { upsert: true, new: true, runValidators: true, setDefaultsOnInsert: true },
+      );
+    } catch (error) {
+      // A simultaneous first rating may race on the unique identity index.
+      // Once the competing insert exists, retry as a normal update.
+      if (!isDuplicateKeyError(error)) throw error;
+      await FaqSatisfactionRating.findOneAndUpdate(
+        filter,
+        { $set: { rating } },
+        { new: true, runValidators: true },
+      );
+    }
+
+    await recomputeSatisfaction(faq._id);
+    res.json(await getSatisfactionResponse(faq._id, identity));
+  } catch (error) {
+    adminLog.error('[faqSatisfaction] submit failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ message: 'Unable to save satisfaction rating.' });
+  }
+}
+
+/** GET /api/faq/:id/satisfaction — aggregate and the caller's prior rating. */
+export async function getSatisfaction(req: Request<{ id: string }>, res: Response): Promise<void> {
+  try {
+    const faq = await FAQ.findById(req.params.id).select('_id batchId');
+    if (!faq) {
+      res.status(404).json({ message: 'FAQ not found.' });
+      return;
+    }
+    if (assertSameProgram(faq, req.programContext, res)) return;
+
+    const identity = getSatisfactionIdentity(req, res);
+    res.json(await getSatisfactionResponse(faq._id, identity));
+  } catch (error) {
+    adminLog.error('[faqSatisfaction] fetch failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ message: 'Unable to load satisfaction rating.' });
+  }
+}

--- a/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
+++ b/apps/backend/src/modules/faq/faq-satisfaction.controller.ts
@@ -1,7 +1,7 @@
 import { Types } from 'mongoose';
 
-import FAQ from './faq.model';
-import FaqSatisfactionRating from './faq-satisfaction-rating.model';
+import FAQ from './faq.model.js';
+import FaqSatisfactionRating from './faq-satisfaction-rating.model.js';
 
 async function recomputeSatisfaction(
   faqId: Types.ObjectId | string

--- a/apps/backend/src/modules/faq/faq.model.ts
+++ b/apps/backend/src/modules/faq/faq.model.ts
@@ -28,6 +28,10 @@ export interface IFAQ extends Document {
   views: number;
   helpfulVotes: number;
   unhelpfulVotes: number;
+  
+  satisfactionAvg: number | null;
+  satisfactionCount: number;
+
   createdBy: Types.ObjectId | null;
   reports: Array<{
     reportedBy: Types.ObjectId;
@@ -139,6 +143,14 @@ const faqSchema = new MongooseSchema(
       default: 0,
     },
     unhelpfulVotes: {
+      type: Number,
+      default: 0,
+    },
+    satisfactionAvg: {
+      type: Number,
+      default: null,
+    },
+    satisfactionCount: {
       type: Number,
       default: 0,
     },

--- a/apps/backend/src/modules/faq/faq.routes.ts
+++ b/apps/backend/src/modules/faq/faq.routes.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { getAllFAQs, getFAQById, getRecentFAQs, createFAQ, updateFAQ, deleteFAQ, checkFAQMatch, getPaginatedFAQs, submitFeedback, reportFAQ, getFAQHistory, createFAQSuggestion, getFAQCategories } from './faq.controller.js';
 import { flagFAQ, voteReview } from './freshness.controller.js';
+import { getSatisfaction, submitSatisfaction } from './faq-satisfaction.controller.js';
 import { protect, authorize } from '../../middleware/auth.js';
+import { protectOptional } from '../../middleware/protectOptional.js';
 import { validateObjectId } from '../../middleware/validateObjectId.js';
-import { validateBody, createFAQSchema, updateFAQSchema, flagFAQSchema, voteReviewSchema } from '../../utils/auth/validation.js';
+import { validateBody, createFAQSchema, updateFAQSchema, flagFAQSchema, voteReviewSchema, submitSatisfactionSchema } from '../../utils/auth/validation.js';
 
 const router = Router();
 
@@ -31,6 +33,8 @@ router.post('/check-match', protect, checkFAQMatch);
 // ids return a clean 400.
 router.get('/:id', validateObjectId('id'), getFAQById);
 router.get('/:id/history', validateObjectId('id'), getFAQHistory);
+router.get('/:id/satisfaction', protectOptional, validateObjectId('id'), getSatisfaction);
+router.post('/:id/satisfaction', protectOptional, validateObjectId('id'), validateBody(submitSatisfactionSchema), submitSatisfaction);
 
 router.post('/', protect, authorize('admin', 'moderator'), validateBody(createFAQSchema), createFAQ);
 router.put('/:id', protect, authorize('admin', 'moderator'), validateObjectId('id'), validateBody(updateFAQSchema), updateFAQ);

--- a/apps/backend/src/modules/faq/public-faq.controller.ts
+++ b/apps/backend/src/modules/faq/public-faq.controller.ts
@@ -41,7 +41,7 @@ export function invalidatePublicCaches(): void {
 
 // ─── Cookie helpers ──────────────────────────────────────────────────────────
 
-function setGuestCookieIfMissing(req: Request, res: Response): string {
+export function setGuestCookieIfMissing(req: Request, res: Response): string {
   // Express parses cookies; the frontend will get one minted on first hit.
   const existing = (req as Request & { cookies?: Record<string, string> }).cookies?.[GUEST_COOKIE];
   if (existing && /^[a-z0-9-]{8,64}$/i.test(existing)) {

--- a/apps/backend/src/utils/auth/validation.ts
+++ b/apps/backend/src/utils/auth/validation.ts
@@ -108,6 +108,12 @@ export const voteReviewSchema = z.object({
   suggestion:  z.string().max(300, 'Suggestion must be 300 characters or less').optional(),
 });
 
+// One discrete satisfaction signal per FAQ. Do not coerce strings here:
+// the API contract accepts JSON numbers only, preventing ambiguous inputs.
+export const submitSatisfactionSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+});
+
 // ─── Community ──────────────────────────────────────────────────────────────────
 export const createPostSchema = z.object({
   title: z.string().min(10, 'Title must be at least 10 characters').max(300),

--- a/apps/frontend/src/admin/pages/AdminFAQs.tsx
+++ b/apps/frontend/src/admin/pages/AdminFAQs.tsx
@@ -19,6 +19,7 @@ interface FAQ {
   status: 'approved' | 'pending' | 'rejected';
   views: number;
   helpfulVotes: number;
+  satisfactionAvg?: number;
   createdAt: string;
   freshnessTier?: 'evergreen' | 'seasonal' | 'volatile';
   reviewIntervalDays?: number;
@@ -139,6 +140,7 @@ export default function AdminFAQs() {
   const [categoryFilter, setCategoryFilter] = useState('');
   const [batchFilter, setBatchFilter] = useState('');
   const [sort] = useState('-createdAt');
+  const [satSortDir, setSatSortDir] = useState<'asc' | 'desc' | null>(null);
   const [editModal, setEditModal] = useState(false);
   const [editFaq, setEditFaq] = useState<FAQ | null>(null);
   const [addModal, setAddModal] = useState(false);
@@ -260,6 +262,14 @@ export default function AdminFAQs() {
     finally { setSaving(false); }
   };
 
+  const displayedFaqs = satSortDir
+    ? [...faqs].sort((a, b) => {
+        const avgA = a.satisfactionAvg ?? 0;
+        const avgB = b.satisfactionAvg ?? 0;
+        return satSortDir === 'asc' ? avgA - avgB : avgB - avgA;
+      })
+    : faqs;
+
   return (
     <div className="space-y-4 max-w-6xl">
       <AnimatePresence>{toast && <Toast toast={toast} />}</AnimatePresence>
@@ -316,13 +326,20 @@ export default function AdminFAQs() {
               <th className="admin-th">Status</th>
               <th className="admin-th text-right">Views</th>
               <th className="admin-th text-right">Votes</th>
+              <th
+                className="admin-th text-right cursor-pointer select-none"
+                onClick={() => setSatSortDir(d => d === 'desc' ? 'asc' : d === 'asc' ? null : 'desc')}
+                title="Click to sort by satisfaction"
+              >
+                Satisfaction{satSortDir === 'desc' ? ' ▼' : satSortDir === 'asc' ? ' ▲' : ''}
+              </th>
               <th className="admin-th">Date</th>
               <th className="admin-th text-right">Actions</th>
             </tr></thead>
             <tbody>
-              {loading ? <tr><td colSpan={8} className="px-3 py-6"><TableSkeleton rows={8} /></td></tr> :
-               faqs.length === 0 ? <tr><td colSpan={8} className="admin-empty">No FAQs found</td></tr> :
-               faqs.map(faq => (
+              {loading ? <tr><td colSpan={9} className="px-3 py-6"><TableSkeleton rows={8} /></td></tr> :
+               faqs.length === 0 ? <tr><td colSpan={9} className="admin-empty">No FAQs found</td></tr> :
+               displayedFaqs.map(faq => (
                 <tr key={faq._id} className="admin-tr">
                   <td className="admin-td max-w-[220px] truncate" title={faq.question}>{faq.question}</td>
                   <td className="admin-td">
@@ -338,6 +355,9 @@ export default function AdminFAQs() {
                   <td className="admin-td"><Badge status={faq.status as 'approved'|'pending'|'rejected'} /></td>
                   <td className="admin-td text-right tabular-nums text-ink-faint">{faq.views ?? 0}</td>
                   <td className="admin-td text-right tabular-nums text-ink-faint">{faq.helpfulVotes ?? 0}</td>
+                  <td className="admin-td text-right tabular-nums text-ink-faint">
+                    {faq.satisfactionAvg != null ? faq.satisfactionAvg.toFixed(1) : '—'}
+                  </td>
                   <td className="admin-td text-ink-faint">{new Date(faq.createdAt).toLocaleDateString('en-IN')}</td>
                   <td className="admin-td text-right">
                     <div className="flex items-center justify-end gap-1">

--- a/apps/frontend/src/components/explore/PublicFaqDetail.tsx
+++ b/apps/frontend/src/components/explore/PublicFaqDetail.tsx
@@ -2,6 +2,7 @@
 // Fires the view + reading tracker on mount; closes on Esc, backdrop
 // click, or the close button.
 
+import SatisfactionSlider from '../faq/SatisfactionSlider';
 import React, { useEffect, useRef, useState } from 'react';
 import { usePublicFaqById } from './usePublicFaqApi';
 import { useExploreSession, useReadingTracker, useViewTracker } from './useReadingTracker';
@@ -136,7 +137,7 @@ export function PublicFaqDetail({
               </>
             )}
           </div>
-
+          <SatisfactionSlider faqId={current._id} />
           {/* Tiny reading progress — non-intrusive, just confirms the tracker is running. */}
           <div className="flex items-center gap-2 text-[11px] text-ink-faint">
             <div className="w-20 h-1.5 rounded-full bg-mist overflow-hidden">

--- a/apps/frontend/src/components/explore/types.ts
+++ b/apps/frontend/src/components/explore/types.ts
@@ -78,3 +78,9 @@ export type TrackReadingResponse = {
   reason?: string;
   error?: string;
 };
+// ─── Satisfaction Rating (feature/faq-satisfaction) ──────────────────────
+export type FaqSatisfactionResponse = {
+  satisfactionAvg: number | null;
+  satisfactionCount: number;
+  yourRating: number | null;
+};

--- a/apps/frontend/src/components/explore/usePublicFaqApi.ts
+++ b/apps/frontend/src/components/explore/usePublicFaqApi.ts
@@ -6,6 +6,7 @@ import api from '../../utils/api';
 import type {
   CategoriesResponse,
   CategoryClustersResponse,
+  FaqSatisfactionResponse,
   PopularResponse,
   PublicFaq,
   RecentResponse,
@@ -106,6 +107,7 @@ export function usePublicFaqById(id: string | null) {
   return usePublicGet<PublicFaq>(id ? `/public/faqs/${id}` : null);
 }
 
+
 /**
  * v1.70 — Dynamic Categories hook. Fetches the AI-named category
  * clusters for the given program from /api/public/category-clusters.
@@ -160,3 +162,9 @@ export function trackPublicReading(
     }
   } catch { /* best-effort */ }
 }
+
+// ─── Satisfaction ─────────────────────────────────────────────────────────
+//
+// Unlike the tracking helpers above, this is NOT fire-and-forget: the
+// caller needs the resolved value (to update local state) and needs
+// failures to reject (so the UI can roll back an optimistic selection).

--- a/apps/frontend/src/components/faq/QuestionDetail.tsx
+++ b/apps/frontend/src/components/faq/QuestionDetail.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FAQItem, getQuestionTitle, getAnswerText, formatDate, getCategoryIcon, formatCategoryName, TrustBadge } from './faqUtils';
 import ReportFAQButton from './ReportFAQButton';
 import FreshnessBadge from '../faq/FreshnessBadge';
+import SatisfactionSlider from './SatisfactionSlider';
 import {
   avatarPlaceholder,
   flexCol,
@@ -142,7 +143,12 @@ export default function QuestionDetail({ item, relatedItems, onBack, onSelectRel
         )}
 
         {/* Report FAQ */}
-        <ReportFAQButton item={item} />
+<ReportFAQButton item={item} />
+
+{/* Satisfaction Rating */}
+{item?.source === 'faq' && (
+  <SatisfactionSlider faqId={item._id} />
+)}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/faq/QuestionList.tsx
+++ b/apps/frontend/src/components/faq/QuestionList.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useEffect, useCallback, useState } from 'react';
 import { FAQItem, getQuestionTitle, getAnswerText, formatDate, formatCategoryName, TrustBadge, SourceBadge } from './faqUtils';
 import FreshnessBadge from '../faq/FreshnessBadge';
+import SatisfactionSlider from '../faq/SatisfactionSlider';
 import {
   flexRowSm,
   skeletonLine,
@@ -88,6 +89,7 @@ export function QuestionItem({ item, isExpanded, onToggle }: QuestionItemProps) 
                 compact
               />
             )}
+            <SatisfactionSlider faqId={item._id} />
           </div>
         </div>
       </div>

--- a/apps/frontend/src/components/faq/SatisfactionSlider.tsx
+++ b/apps/frontend/src/components/faq/SatisfactionSlider.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { useFaqSatisfaction, submitFaqSatisfaction } from './useFaqSatisfaction';
+import {
+  emojiRatingBase,
+  emojiRatingIdle,
+  emojiRatingSelected,
+  inlineSuccessBanner,
+  flexRow,
+  stackXs,
+  textLabelXsBold,
+} from '../../styles/style_config';
+
+interface SatisfactionSliderProps {
+  faqId: string;
+}
+
+// Fixed 1–5 mapping the backend expects. Order matters — index 0 is the
+// lowest rating (1), index 4 is the highest (5).
+const EMOJI_OPTIONS: { emoji: string; value: number; label: string }[] = [
+  { emoji: '😕', value: 1, label: 'Poor' },
+  { emoji: '😐', value: 2, label: 'Okay' },
+  { emoji: '🙂', value: 3, label: 'Good' },
+  { emoji: '😊', value: 4, label: 'Great' },
+  { emoji: '🤩', value: 5, label: 'Excellent' },
+];
+
+export default function SatisfactionSlider({ faqId }: SatisfactionSliderProps) {
+  const { data } = useFaqSatisfaction(faqId);
+  const [yourRating, setYourRating] = useState<number | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [showThanks, setShowThanks] = useState(false);
+
+  // Sync the viewer's existing rating once the GET resolves.
+  useEffect(() => {
+    if (data?.yourRating != null) {
+      setYourRating(data.yourRating);
+    }
+  }, [data?.yourRating]);
+
+  const handleSelect = async (value: number) => {
+    if (submitting) return;
+    const previous = yourRating;
+
+    // Optimistic update — highlight immediately, per requirements.
+    setYourRating(value);
+    setShowThanks(false);
+    setSubmitting(true);
+
+    try {
+      const res = await submitFaqSatisfaction(faqId, value);
+      setYourRating(res.yourRating);
+      setShowThanks(true);
+    } catch (e) {
+      console.error('Satisfaction submit failed:', e);
+      // Restore the previous rating on failure, per requirements.
+      setYourRating(previous);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={`mt-6 pt-5 border-t border-border ${stackXs}`}>
+      <p className={textLabelXsBold}>Was this answer helpful?</p>
+      <div className={`mt-2 ${flexRow} gap-2`}>
+        {EMOJI_OPTIONS.map(({ emoji, value, label }) => (
+          <button
+            key={value}
+            type="button"
+            title={`${emoji} ${label}`}
+            aria-label={label}
+            disabled={submitting}
+            onClick={() => handleSelect(value)}
+            className={`${emojiRatingBase} ${yourRating === value ? emojiRatingSelected : emojiRatingIdle}`}
+          >
+            {emoji}
+          </button>
+        ))}
+      </div>
+      {showThanks && (
+        <p className={`mt-2 ${inlineSuccessBanner} inline-block`}>Thanks for your feedback!</p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/faq/faqUtils.tsx
+++ b/apps/frontend/src/components/faq/faqUtils.tsx
@@ -24,6 +24,9 @@ export interface FAQItem {
   lastVerifiedDate?: string;
   reviewIntervalDays?: number;
   freshnessTier?: 'evergreen' | 'seasonal' | 'volatile';
+  // Satisfaction system — required for the emoji feedback widget
+  satisfactionAvg?: number | null;
+  satisfactionCount?: number;
   [key: string]: unknown;
 }
 

--- a/apps/frontend/src/components/faq/useFaqSatisfaction.ts
+++ b/apps/frontend/src/components/faq/useFaqSatisfaction.ts
@@ -1,0 +1,19 @@
+import api from '../../utils/api';
+import { usePublicGet } from '../explore/usePublicFaqApi';
+import type { FaqSatisfactionResponse } from '../explore/types';
+
+export function useFaqSatisfaction(faqId: string | null) {
+  return usePublicGet<FaqSatisfactionResponse>(
+    faqId ? `/faq/${faqId}/satisfaction` : null
+  );
+}
+export async function submitFaqSatisfaction(
+  faqId: string,
+  rating: number,
+): Promise<FaqSatisfactionResponse> {
+  const res = await api.post<FaqSatisfactionResponse>(
+    `/faq/${faqId}/satisfaction`,
+    { rating },
+  );
+  return res.data;
+}

--- a/apps/frontend/src/styles/components.ts
+++ b/apps/frontend/src/styles/components.ts
@@ -128,6 +128,15 @@ export const votePillAccentIdle  = 'border-border text-ink-soft hover:border-acc
 export const votePillDanger      = 'border-danger/40 bg-danger-light text-danger';
 export const votePillDangerIdle  = 'border-border text-ink-soft hover:border-danger/30 hover:text-danger';
 
+export const emojiRatingBase =
+  'flex items-center justify-center w-9 h-9 rounded-full text-lg leading-none transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed';
+
+export const emojiRatingIdle =
+  'grayscale opacity-60 hover:grayscale-0 hover:opacity-100 hover:scale-110';
+
+export const emojiRatingSelected =
+  'grayscale-0 opacity-100 scale-110 bg-accent/10 ring-2 ring-accent/40';
+
 export const tierPillBase        = 'flex-1 py-2 px-3 rounded-xl border text-xs font-medium transition-all';
 export const tierPillAccent      = 'border-accent/40 bg-accent/10 text-accent';
 export const tierPillDanger      = 'border-danger/40 bg-danger-light text-danger';

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -33,6 +33,12 @@ const getRequestTTL = (url: string | undefined, method: string | undefined): num
     }
     return 0;
   }
+
+  // Satisfaction responses include identity-specific `yourRating` data.
+  // Never cache them under the shared FAQ cache window.
+  if (url.includes('/satisfaction')) {
+    return 0;
+  }
   
   // Match URL against config
   for (const [key, ttl] of Object.entries(CACHE_CONFIGS)) {

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,23 @@
+# Progress — FAQ Satisfaction Rating
+
+**Branch:** `feature/faq-satisfaction`
+**Feature:** Lets users (guest or authenticated) rate an FAQ's helpfulness on a 1–5 scale; ratings aggregate into `satisfactionAvg` / `satisfactionCount` on the FAQ, surfaced to admins.
+
+## Status by area
+
+| Area | Owner | Status |
+|---|---|---|
+| Data model (`FaqSatisfactionRating` schema, aggregate fields, `recomputeSatisfaction()`) | Enumula Umamaheshwari | ✅ Done |
+| Backend API (`GET`/`POST /faq/:id/satisfaction`, guest + auth support, validation) | Manan Agarwal | ✅ Done |
+| Frontend rating slider (public FAQ page, both integration points) | Atul Raj | ✅ Done |
+| Rating slider UI (5-level emoji rating, optimistic updates) | Hemanjani Harika Kutani | ✅ Done |
+| Admin surface — sortable `satisfactionAvg` column | Kshethragna Mikkineni | ✅ Done |
+| Backend Vitest tests (new rating, upsert-on-resubmit, guest vs. authenticated, `protectOptional` 401 case, aggregate math) | Kshethragna Mikkineni | ⏳ In progress |
+| Playwright e2e test (`tests/e2e/`) | Kshethragna Mikkineni | ⏳ In progress |
+| `docs/reference/openapi.yaml` update | Kshethragna Mikkineni | ⏳ In progress |
+| `docs/reference/database-schema.md` update | Kshethragna Mikkineni | ⏳ In progress |
+| Final PR quality pass (tsc clean, tests passing, docs updated) | Kshethragna Mikkineni | ⏳ Pending |
+
+## Notes
+- Admin-side sorting is client-side for now — no server-side index exists yet on `satisfactionAvg`.
+- Documentation handoff identified by the API implementer: OpenAPI contract, database schema, architecture/route-reference updates, and this progress file — all owned by the admin/testing/docs role above.


### PR DESCRIPTION
## What changed
Adds a FAQ satisfaction rating system: users (guest or authenticated) rate
an FAQ's helpfulness on a 1–5 scale, ratings aggregate into satisfactionAvg
and satisfactionCount on the FAQ, and admins can view and sort by this
average in the admin FAQ table. Built by a 5-person team across the data
model, backend API, frontend rating UI, and admin surface.

## Related issue
Closes #202

## Type of change
- [x] Feature

## Area affected
- [x] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [x] Admin / Train tab (`/admin/*`)
- [x] Docs

## CI verification
- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer
This is a **draft PR**, opened early per repo convention, from a shared
branch with 5 contributors. Current status:
- Done: data model + aggregate helper, backend API (GET/POST satisfaction),
  frontend rating slider, admin sortable satisfactionAvg column
- In progress: backend Vitest tests, Playwright e2e test,
  docs/reference/openapi.yaml and docs/reference/database-schema.md updates
- Admin-side sorting is client-side only — no server index exists yet on
  satisfactionAvg; flagged as a possible follow-up, not blocking.
- Will request review and move out of draft once the above are complete and
  all CI verification boxes above are checked.