### PR TITLE
Community Moderation & Important Links UI

### DIFF
--- a/apps/frontend/src/components/community/important-links/CategoryFilter.tsx
+++ b/apps/frontend/src/components/community/important-links/CategoryFilter.tsx
@@ -1,0 +1,59 @@
+/**
+ * CategoryFilter.tsx — Reusable, controlled category filter pill bar.
+ *
+ * Frontend filtering only: this component holds no data and calls no API.
+ * It just renders "All" + one pill per category and reports the selected
+ * value via `onChange`. The parent (ImportantLinksTab) owns the actual
+ * `links.filter(...)` logic.
+ *
+ * Styled with plain Tailwind utilities that match the pill conventions
+ * already used elsewhere in the app (rounded-full pills, accent-tinted
+ * active state) rather than reusing `NavPills`, which is hard-wired to
+ * `react-router-dom` `NavLink`s and app-level routes — not a fit for a
+ * same-page, non-navigating filter.
+ */
+
+import React from 'react';
+import { IMPORTANT_LINK_CATEGORIES, type LinkCategory } from './types';
+
+export type CategoryFilterValue = LinkCategory | 'All';
+
+export interface CategoryFilterProps {
+  /** Defaults to the standard Important Links category set. */
+  categories?: readonly LinkCategory[];
+  selected: CategoryFilterValue;
+  onChange: (category: CategoryFilterValue) => void;
+  className?: string;
+}
+
+export default function CategoryFilter({
+  categories = IMPORTANT_LINK_CATEGORIES,
+  selected,
+  onChange,
+  className = '',
+}: CategoryFilterProps) {
+  const options: CategoryFilterValue[] = ['All', ...categories];
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`}>
+      {options.map((option) => {
+        const isActive = option === selected;
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            aria-pressed={isActive}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+              isActive
+                ? 'bg-accent text-accent-text border-accent'
+                : 'bg-card text-ink-soft border-border hover:border-accent/40 hover:text-ink'
+            }`}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/community/important-links/CopyLinkButton.tsx
+++ b/apps/frontend/src/components/community/important-links/CopyLinkButton.tsx
@@ -1,0 +1,72 @@
+/**
+ * CopyLinkButton.tsx — Reusable "copy URL to clipboard" button with a
+ * success toast.
+ *
+ * Reuses the existing `Button` primitive rather than a bespoke <button>,
+ * and mirrors the exact toast visual already used in `CommunityPage.tsx`
+ * (fixed bottom-center, `bg-card border border-border shadow-float`) so
+ * this doesn't introduce a second toast style into the app. No shared
+ * `Toast` component exists yet in the codebase to import, so the toast
+ * markup lives here, self-contained, matching that established pattern.
+ *
+ * No API calls — `navigator.clipboard` only.
+ */
+
+import React, { useState } from 'react';
+import Button from '../../ui/Button';
+
+export interface CopyLinkButtonProps {
+  url: string;
+  size?: 'sm' | 'md';
+  label?: string;
+  className?: string;
+}
+
+export default function CopyLinkButton({
+  url,
+  size = 'sm',
+  label = 'Copy Link',
+  className = '',
+}: CopyLinkButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Fallback for browsers/contexts without clipboard API permission.
+      const textarea = document.createElement('textarea');
+      textarea.value = url;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size={size}
+        onClick={handleCopy}
+        className={className}
+        title="Copy link to clipboard"
+      >
+        <span aria-hidden="true">🔗</span>
+        <span>{label}</span>
+      </Button>
+
+      {copied && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] px-4 py-2.5 bg-card border border-border rounded-xl text-xs text-ink font-medium shadow-float pointer-events-none">
+          ✅ Link copied to clipboard
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/components/community/important-links/ImportantLinksTab.tsx
+++ b/apps/frontend/src/components/community/important-links/ImportantLinksTab.tsx
@@ -1,0 +1,107 @@
+/**
+ * ImportantLinksTab.tsx — Top-level Important Links tab.
+ *
+ * Composes:
+ *  - `CategoryFilter` for frontend-only category filtering
+ *  - `LinkCard` grid for display
+ *  - `ManageLinksModal` (admin-only) for Add/Edit/Delete
+ *
+ * No backend, no API calls, no routing here. `links` is supplied by the
+ * parent (whoever owns fetching data later); this component only holds
+ * transient UI state — the selected category filter and whether the
+ * manage modal is open — and forwards Add/Edit/Delete intent upward via
+ * `onAddLink` / `onEditLink` / `onDeleteLink`.
+ *
+ * Admin gating mirrors the pattern used in `AdminControls`
+ * (community/moderation): pass `isAdmin` explicitly, or let it fall back
+ * to `useAuth()`.
+ */
+
+import React, { useMemo, useState } from 'react';
+import Button from '../../ui/Button';
+import { useIsCommunityAdmin } from '../moderation/useIsCommunityAdmin';
+import { textHeaderMd, textBodyFaint } from '../../../styles/style_config';
+import CategoryFilter, { type CategoryFilterValue } from './CategoryFilter';
+import LinkCard from './LinkCard';
+import ManageLinksModal from './ManageLinksModal';
+import type { ImportantLink, ImportantLinkDraft } from './types';
+
+export interface ImportantLinksTabProps {
+  links: ImportantLink[];
+  isAdmin?: boolean;
+  /** Naming matches ManageLinksModal's onAdd/onEdit/onDelete — this component is a thin pass-through to it. */
+  onAdd: (draft: ImportantLinkDraft) => void;
+  onEdit: (id: string, draft: ImportantLinkDraft) => void;
+  onDelete: (id: string) => void;
+  onOpenLink?: (link: ImportantLink) => void;
+  /** Passed through to ManageLinksModal while a parent-owned save is in flight. */
+  saving?: boolean;
+  className?: string;
+}
+
+export default function ImportantLinksTab({
+  links,
+  isAdmin,
+  onAdd,
+  onEdit,
+  onDelete,
+  onOpenLink,
+  saving = false,
+  className = '',
+}: ImportantLinksTabProps) {
+  const resolvedIsAdmin = useIsCommunityAdmin(isAdmin);
+
+  const [selectedCategory, setSelectedCategory] = useState<CategoryFilterValue>('All');
+  const [manageOpen, setManageOpen] = useState(false);
+
+  const filteredLinks = useMemo(
+    () =>
+      selectedCategory === 'All'
+        ? links
+        : links.filter((link) => link.category === selectedCategory),
+    [links, selectedCategory]
+  );
+
+  return (
+    <div className={`space-y-5 ${className}`}>
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className={textHeaderMd}>Important Links</h2>
+          <p className={textBodyFaint}>Quick access to docs, tools, and resources.</p>
+        </div>
+        {resolvedIsAdmin && (
+          <Button type="button" variant="secondary" size="sm" onClick={() => setManageOpen(true)}>
+            <span aria-hidden="true">⚙️</span>
+            <span>Manage Links</span>
+          </Button>
+        )}
+      </div>
+
+      <CategoryFilter selected={selectedCategory} onChange={setSelectedCategory} />
+
+      {filteredLinks.length === 0 ? (
+        <p className="text-sm text-ink-faint text-center py-10">
+          No links in this category yet.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredLinks.map((link) => (
+            <LinkCard key={link.id} link={link} onOpen={onOpenLink} />
+          ))}
+        </div>
+      )}
+
+      {resolvedIsAdmin && (
+        <ManageLinksModal
+          open={manageOpen}
+          links={links}
+          onAdd={onAdd}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onClose={() => setManageOpen(false)}
+          saving={saving}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/community/important-links/LinkCard.tsx
+++ b/apps/frontend/src/components/community/important-links/LinkCard.tsx
@@ -1,0 +1,69 @@
+/**
+ * LinkCard.tsx — Reusable card for a single Important Link.
+ *
+ * Reuses:
+ *  - `Card` (ui/Card) for the shell
+ *  - `Badge` (ui/Badge) for the category chip
+ *  - `StatusBadge` (community/moderation, status="official") for the
+ *    Official badge — built in the Community Moderation module, reused
+ *    here rather than re-implementing badge logic
+ *  - `Button` (ui/Button) for the Open action
+ *  - `CopyLinkButton` for the Copy Link action
+ *
+ * Pure/presentational — no API calls. `onOpen` is optional; if omitted,
+ * the Open button falls back to `window.open(url, '_blank', 'noopener,noreferrer')`.
+ */
+
+import React from 'react';
+import Card from '../../ui/Card';
+import Badge from '../../ui/Badge';
+import Button from '../../ui/Button';
+import StatusBadge from '../moderation/StatusBadge';
+import CopyLinkButton from './CopyLinkButton';
+import { textBodyFaint, textHeaderSm } from '../../../styles/style_config';
+import type { ImportantLink } from './types';
+
+export interface LinkCardProps {
+  link: ImportantLink;
+  /** Optional override for the Open action (e.g. to log analytics before navigating). */
+  onOpen?: (link: ImportantLink) => void;
+  className?: string;
+}
+
+export default function LinkCard({ link, onOpen, className = '' }: LinkCardProps) {
+  const handleOpen = () => {
+    if (onOpen) {
+      onOpen(link);
+      return;
+    }
+    window.open(link.url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Card variant="elevated" className={`p-5 flex flex-col gap-3 ${className}`}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span className="text-2xl leading-none flex-shrink-0" aria-hidden="true">
+            {link.icon}
+          </span>
+          <h3 className={`${textHeaderSm} truncate`}>{link.title}</h3>
+        </div>
+        {link.isOfficial && <StatusBadge status="official" />}
+      </div>
+
+      <p className={`${textBodyFaint} line-clamp-2`}>{link.description}</p>
+
+      <div>
+        <Badge variant="accent">{link.category}</Badge>
+      </div>
+
+      <div className="flex items-center gap-2 pt-1 mt-auto">
+        <Button type="button" variant="primary" size="sm" onClick={handleOpen}>
+          <span aria-hidden="true">↗️</span>
+          <span>Open</span>
+        </Button>
+        <CopyLinkButton url={link.url} />
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/community/important-links/ManageLinksModal.tsx
+++ b/apps/frontend/src/components/community/important-links/ManageLinksModal.tsx
@@ -1,0 +1,284 @@
+/**
+ * ManageLinksModal.tsx — Admin-only Add/Edit/Delete modal for Important
+ * Links.
+ *
+ * Callbacks only: this component makes NO API calls. `onAdd` / `onEdit` /
+ * `onDelete` are invoked with plain data and it's entirely up to the
+ * caller what happens next (call an API, update local state, etc). The
+ * modal only keeps the transient UI state needed to drive its own form
+ * (which link is being edited, the current draft values, which row's
+ * delete confirmation is open) — none of that is persisted data.
+ *
+ * Reuses:
+ *  - `Modal` (admin/components/common/Modal) for the shell
+ *  - `Input` (ui/Input) for text fields
+ *  - `Button` (ui/Button) for actions
+ *  - `DeleteConfirmationDialog` (community/moderation) for delete
+ *    confirmation — same reusable dialog built for Community Moderation
+ *  - `textAreaBase` style token for the description field
+ *  - `IMPORTANT_LINK_CATEGORIES` for the category <select>
+ */
+
+import React, { useState } from 'react';
+import Modal from '../../../admin/components/common/Modal';
+import Input from '../../ui/Input';
+import Button from '../../ui/Button';
+import DeleteConfirmationDialog from '../moderation/DeleteConfirmationDialog';
+import { textAreaBase } from '../../../styles/style_config';
+import {
+  IMPORTANT_LINK_CATEGORIES,
+  type ImportantLink,
+  type ImportantLinkDraft,
+} from './types';
+
+const EMPTY_DRAFT: ImportantLinkDraft = {
+  icon: '🔗',
+  title: '',
+  description: '',
+  category: 'Other',
+  url: '',
+  isOfficial: false,
+};
+
+export interface ManageLinksModalProps {
+  open: boolean;
+  links: ImportantLink[];
+  onAdd: (draft: ImportantLinkDraft) => void;
+  onEdit: (id: string, draft: ImportantLinkDraft) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+  /** Disables inputs/buttons while a parent-owned persistence call is in flight. */
+  saving?: boolean;
+}
+
+type ViewMode = 'list' | 'form';
+
+export default function ManageLinksModal({
+  open,
+  links,
+  onAdd,
+  onEdit,
+  onDelete,
+  onClose,
+  saving = false,
+}: ManageLinksModalProps) {
+  const [view, setView] = useState<ViewMode>('list');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<ImportantLinkDraft>(EMPTY_DRAFT);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const resetToList = () => {
+    setView('list');
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+  };
+
+  const startAdd = () => {
+    setDraft(EMPTY_DRAFT);
+    setEditingId(null);
+    setView('form');
+  };
+
+  const startEdit = (link: ImportantLink) => {
+    const { id, ...rest } = link;
+    setDraft(rest);
+    setEditingId(id);
+    setView('form');
+  };
+
+  const handleFieldChange = <K extends keyof ImportantLinkDraft>(
+    field: K,
+    value: ImportantLinkDraft[K]
+  ) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId) {
+      onEdit(editingId, draft);
+    } else {
+      onAdd(draft);
+    }
+    resetToList();
+  };
+
+  const handleClose = () => {
+    resetToList();
+    onClose();
+  };
+
+  const linkPendingDelete = links.find((l) => l.id === confirmDeleteId) ?? null;
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={view === 'list' ? 'Manage Important Links' : editingId ? 'Edit Link' : 'Add Link'}
+        maxWidth="max-w-lg"
+      >
+        {view === 'list' ? (
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Button type="button" variant="primary" size="sm" onClick={startAdd}>
+                <span aria-hidden="true">➕</span>
+                <span>Add New Link</span>
+              </Button>
+            </div>
+
+            {links.length === 0 ? (
+              <p className="text-sm text-ink-faint text-center py-6">
+                No important links yet.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border max-h-96 overflow-y-auto">
+                {links.map((link) => (
+                  <li
+                    key={link.id}
+                    className="flex items-center justify-between gap-3 py-3"
+                  >
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="text-lg flex-shrink-0" aria-hidden="true">
+                        {link.icon}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-ink truncate">{link.title}</p>
+                        <p className="text-xs text-ink-faint truncate">{link.category}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => startEdit(link)}
+                        title="Edit"
+                      >
+                        ✏️
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-danger hover:bg-danger-light"
+                        onClick={() => setConfirmDeleteId(link.id)}
+                        title="Delete"
+                      >
+                        🗑️
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="flex justify-end pt-2">
+              <Button type="button" variant="secondary" size="sm" onClick={handleClose}>
+                Close
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              id="link-icon"
+              label="Icon"
+              value={draft.icon}
+              onChange={(e) => handleFieldChange('icon', e.target.value)}
+              placeholder="🔗"
+              maxLength={4}
+              disabled={saving}
+            />
+            <Input
+              id="link-title"
+              label="Title"
+              value={draft.title}
+              onChange={(e) => handleFieldChange('title', e.target.value)}
+              placeholder="Link title"
+              disabled={saving}
+              required
+            />
+
+            <div>
+              <label htmlFor="link-description" className="block text-xs font-medium text-ink-soft mb-1.5">
+                Description
+              </label>
+              <textarea
+                id="link-description"
+                value={draft.description}
+                onChange={(e) => handleFieldChange('description', e.target.value)}
+                rows={3}
+                placeholder="What this link is for"
+                className={textAreaBase}
+                disabled={saving}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="link-category" className="block text-xs font-medium text-ink-soft mb-1.5">
+                Category
+              </label>
+              <select
+                id="link-category"
+                value={draft.category}
+                onChange={(e) => handleFieldChange('category', e.target.value as ImportantLinkDraft['category'])}
+                disabled={saving}
+                className="w-full px-4 py-2.5 rounded-xl border border-border bg-card text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/25 focus:border-accent transition-all duration-200 ease-smooth"
+              >
+                {IMPORTANT_LINK_CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <Input
+              id="link-url"
+              label="URL"
+              type="url"
+              value={draft.url}
+              onChange={(e) => handleFieldChange('url', e.target.value)}
+              placeholder="https://..."
+              disabled={saving}
+              required
+            />
+
+            <label className="flex items-center gap-2 text-sm text-ink-soft">
+              <input
+                type="checkbox"
+                checked={draft.isOfficial ?? false}
+                onChange={(e) => handleFieldChange('isOfficial', e.target.checked)}
+                disabled={saving}
+                className="rounded border-border"
+              />
+              Mark as Official
+            </label>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="secondary" size="sm" onClick={resetToList} disabled={saving}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" size="sm" loading={saving}>
+                Save
+              </Button>
+            </div>
+          </form>
+        )}
+      </Modal>
+
+      {linkPendingDelete && (
+        <DeleteConfirmationDialog
+          title="Delete this link?"
+          description={`"${linkPendingDelete.title}" will be removed from Important Links.`}
+          onConfirm={() => {
+            onDelete(linkPendingDelete.id);
+            setConfirmDeleteId(null);
+          }}
+          onCancel={() => setConfirmDeleteId(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/components/community/important-links/index.ts
+++ b/apps/frontend/src/components/community/important-links/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Important Links — reusable UI components.
+ *
+ * Additive-only barrel: new components in this module should be exported
+ * here rather than requiring changes to files outside this folder.
+ */
+
+export { default as ImportantLinksTab } from './ImportantLinksTab';
+export type { ImportantLinksTabProps } from './ImportantLinksTab';
+
+export { default as LinkCard } from './LinkCard';
+export type { LinkCardProps } from './LinkCard';
+
+export { default as ManageLinksModal } from './ManageLinksModal';
+export type { ManageLinksModalProps } from './ManageLinksModal';
+
+export { default as CategoryFilter } from './CategoryFilter';
+export type { CategoryFilterProps, CategoryFilterValue } from './CategoryFilter';
+
+export { default as CopyLinkButton } from './CopyLinkButton';
+export type { CopyLinkButtonProps } from './CopyLinkButton';
+
+export {
+  IMPORTANT_LINK_CATEGORIES,
+  type LinkCategory,
+  type ImportantLink,
+  type ImportantLinkDraft,
+} from './types';

--- a/apps/frontend/src/components/community/important-links/types.ts
+++ b/apps/frontend/src/components/community/important-links/types.ts
@@ -1,0 +1,33 @@
+/**
+ * types.ts — Shared types for the Important Links module.
+ *
+ * No backend / API types here on purpose — this module only defines the
+ * shape the UI expects. Whoever wires up persistence can map their API
+ * response onto `ImportantLink` (or vice versa).
+ */
+
+export const IMPORTANT_LINK_CATEGORIES = [
+  'Documentation',
+  'GitHub',
+  'Zoom',
+  'Submission',
+  'Learning',
+  'Other',
+] as const;
+
+export type LinkCategory = (typeof IMPORTANT_LINK_CATEGORIES)[number];
+
+export interface ImportantLink {
+  id: string;
+  /** Emoji or short glyph, consistent with the emoji-icon convention already used across the app (📌 ⭐ 🚩 etc). */
+  icon: string;
+  title: string;
+  description: string;
+  category: LinkCategory;
+  url: string;
+  /** Drives the "Official" badge on the card. */
+  isOfficial?: boolean;
+}
+
+/** Payload shape for creating/editing a link — no `id`, that's assigned by whoever persists it. */
+export type ImportantLinkDraft = Omit<ImportantLink, 'id'>;

--- a/apps/frontend/src/components/community/moderation/AdminControls.tsx
+++ b/apps/frontend/src/components/community/moderation/AdminControls.tsx
@@ -1,0 +1,116 @@
+/**
+ * AdminControls.tsx — Reusable admin/moderator action bar for Community
+ * Moderation (Pin / Verify / Edit / Delete).
+ *
+ * - Renders nothing for non-admin/non-moderator users.
+ * - Renders nothing itself; each action button only appears if the caller
+ *   passes the matching callback prop. This lets the same component be
+ *   reused for "pin only" surfaces (e.g. a compact card) and "full control"
+ *   surfaces (e.g. a detail view) without conditional wrapping at the
+ *   call site.
+ * - No internal state, no API calls — every action is delegated to the
+ *   parent via props, matching the pattern already used by
+ *   ThreadBookmarkButton (`isBookmarked` + `onToggle`).
+ * - Reuses the existing `Button` primitive (ghost/sm) rather than
+ *   introducing new button styling.
+ */
+
+import React from 'react';
+import Button from '../../ui/Button';
+import { useAuth } from '../../../hooks/useAuth';
+
+export interface AdminControlsProps {
+  /**
+   * Explicitly control visibility. If omitted, the component falls back
+   * to checking the logged-in user's role via `useAuth()` (admin or
+   * moderator). Passing this prop lets callers who already resolved the
+   * role (e.g. inside an admin-only page) skip the extra check.
+   */
+  isAdmin?: boolean;
+
+  /** Current pin/verify state, used only to flip button labels. */
+  isPinned?: boolean;
+  isVerified?: boolean;
+
+  /** Only rendered when the matching callback is supplied. */
+  onPin?: () => void;
+  onVerify?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export default function AdminControls({
+  isAdmin,
+  isPinned = false,
+  isVerified = false,
+  onPin,
+  onVerify,
+  onEdit,
+  onDelete,
+  size = 'sm',
+  className = '',
+}: AdminControlsProps) {
+  const { user } = useAuth();
+  const resolvedIsAdmin =
+    isAdmin ?? (user?.role === 'admin' || user?.role === 'moderator');
+
+  if (!resolvedIsAdmin) return null;
+  if (!onPin && !onVerify && !onEdit && !onDelete) return null;
+
+  return (
+    <div className={`inline-flex items-center gap-1.5 ${className}`}>
+      {onPin && (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={onPin}
+          title={isPinned ? 'Unpin' : 'Pin'}
+        >
+          <span aria-hidden="true">📌</span>
+          <span>{isPinned ? 'Unpin' : 'Pin'}</span>
+        </Button>
+      )}
+      {onVerify && (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={onVerify}
+          title={isVerified ? 'Unverify' : 'Verify'}
+        >
+          <span aria-hidden="true">⭐</span>
+          <span>{isVerified ? 'Unverify' : 'Verify'}</span>
+        </Button>
+      )}
+      {onEdit && (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={onEdit}
+          title="Edit"
+        >
+          <span aria-hidden="true">✏️</span>
+          <span>Edit</span>
+        </Button>
+      )}
+      {onDelete && (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={onDelete}
+          title="Delete"
+          className="text-danger hover:bg-danger-light"
+        >
+          <span aria-hidden="true">🗑️</span>
+          <span>Delete</span>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/community/moderation/DeleteConfirmationDialog.tsx
+++ b/apps/frontend/src/components/community/moderation/DeleteConfirmationDialog.tsx
@@ -1,0 +1,71 @@
+/**
+ * DeleteConfirmationDialog.tsx — Generic, reusable confirmation dialog.
+ *
+ * Not specific to "delete" mechanically — it just renders a title,
+ * description, and Confirm/Cancel buttons — but named for its primary
+ * use case in the Community Moderation module (confirming destructive
+ * moderator actions).
+ *
+ * Reuses the existing admin `Modal` shell (overlay, escape-to-close,
+ * scroll lock, animation) instead of re-implementing dialog chrome, and
+ * the existing `Button` primitive for actions. The component itself owns
+ * no state and makes no API calls — `onConfirm` / `onCancel` are the only
+ * way it communicates back to the caller, which decides what "confirm"
+ * actually does (e.g. call an API, then unmount this dialog).
+ *
+ * The caller is responsible for conditionally rendering this component
+ * (there is no `open` prop by design, per spec) — render it only while
+ * the confirmation is active.
+ */
+
+import React from 'react';
+import Modal from '../../../admin/components/common/Modal';
+import Button from '../../ui/Button';
+
+export interface DeleteConfirmationDialogProps {
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** Optional label overrides for the action buttons. */
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Optional loading state so the caller can disable buttons mid-request. */
+  loading?: boolean;
+}
+
+export default function DeleteConfirmationDialog({
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  loading = false,
+}: DeleteConfirmationDialogProps) {
+  return (
+    <Modal open onClose={onCancel} title={title} maxWidth="max-w-sm">
+      <p className="text-sm text-ink-soft mb-5">{description}</p>
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={onCancel}
+          disabled={loading}
+        >
+          {cancelLabel}
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          onClick={onConfirm}
+          loading={loading}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/frontend/src/components/community/moderation/EditReminderModal.tsx
+++ b/apps/frontend/src/components/community/moderation/EditReminderModal.tsx
@@ -1,0 +1,130 @@
+/**
+ * EditReminderModal.tsx — Reusable, fully-controlled edit form modal
+ * (Title / Description / Category) for the Community Moderation module.
+ *
+ * Fully controlled: this component holds NO internal form state. Field
+ * values come in via `values`, every keystroke is reported to the caller
+ * via `onFieldChange`, and Save/Cancel are pure callbacks. The caller
+ * owns validation, persistence (API calls), and closing the modal — this
+ * component only renders the form and reports intent.
+ *
+ * Reuses the existing admin `Modal` shell, the `Input` primitive for
+ * single-line fields, the shared `textAreaBase` style token (already used
+ * by FlagOutdatedButton) for the description textarea, and the `Button`
+ * primitive for actions — no new form-control styling introduced.
+ */
+
+import React from 'react';
+import Modal from '../../../admin/components/common/Modal';
+import Input from '../../ui/Input';
+import Button from '../../ui/Button';
+import { textAreaBase } from '../../../styles/style_config';
+
+export interface EditReminderFormValues {
+  title: string;
+  description: string;
+  category: string;
+}
+
+export type EditReminderField = keyof EditReminderFormValues;
+
+export interface EditReminderModalProps {
+  open: boolean;
+  values: EditReminderFormValues;
+  /** Fired on every field change; caller updates `values` and re-renders. */
+  onFieldChange: (field: EditReminderField, value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  /** Optional per-field validation messages, rendered under each input. */
+  errors?: Partial<Record<EditReminderField, string>>;
+  /** Optional list of suggested categories, rendered as a datalist. */
+  categoryOptions?: string[];
+  /** Disables inputs/buttons and shows a loading state on Save. */
+  saving?: boolean;
+}
+
+export default function EditReminderModal({
+  open,
+  values,
+  onFieldChange,
+  onSave,
+  onCancel,
+  errors,
+  categoryOptions,
+  saving = false,
+}: EditReminderModalProps) {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave();
+  };
+
+  return (
+    <Modal open={open} onClose={onCancel} title="Edit Reminder" maxWidth="max-w-md">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          id="reminder-title"
+          label="Title"
+          value={values.title}
+          onChange={(e) => onFieldChange('title', e.target.value)}
+          error={errors?.title}
+          disabled={saving}
+          placeholder="Reminder title"
+        />
+
+        <div>
+          <label
+            htmlFor="reminder-description"
+            className="block text-xs font-medium text-ink-soft mb-1.5"
+          >
+            Description
+          </label>
+          <textarea
+            id="reminder-description"
+            value={values.description}
+            onChange={(e) => onFieldChange('description', e.target.value)}
+            disabled={saving}
+            rows={4}
+            placeholder="Reminder description"
+            className={textAreaBase}
+          />
+          {errors?.description && (
+            <p className="mt-1.5 text-xs text-danger">{errors.description}</p>
+          )}
+        </div>
+
+        <Input
+          id="reminder-category"
+          label="Category"
+          value={values.category}
+          onChange={(e) => onFieldChange('category', e.target.value)}
+          error={errors?.category}
+          disabled={saving}
+          placeholder="e.g. Deadlines"
+          list={categoryOptions?.length ? 'reminder-category-options' : undefined}
+        />
+        {categoryOptions?.length ? (
+          <datalist id="reminder-category-options">
+            {categoryOptions.map((option) => (
+              <option key={option} value={option} />
+            ))}
+          </datalist>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onCancel}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="sm" loading={saving}>
+            Save
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/frontend/src/components/community/moderation/StatusBadge.tsx
+++ b/apps/frontend/src/components/community/moderation/StatusBadge.tsx
@@ -1,0 +1,65 @@
+/**
+ * StatusBadge.tsx — Generic, reusable status badge for Community Moderation.
+ *
+ * Wraps the existing `components/ui/Badge` primitive instead of introducing
+ * a parallel badge implementation. Callers pass a `status` key and this
+ * component resolves the icon, label, and color variant. An optional
+ * `label` prop lets a caller override the display text (e.g. localisation)
+ * without touching the icon/variant mapping.
+ *
+ * Pure/presentational — no data fetching, no side effects, no callbacks.
+ */
+
+import React from 'react';
+import Badge from '../../ui/Badge';
+
+export type StatusBadgeType =
+  | 'support'
+  | 'pinned'
+  | 'verified'
+  | 'official'
+  | 'important'
+  | 'new';
+
+interface StatusConfig {
+  label: string;
+  icon: string;
+  variant: 'success' | 'warning' | 'info' | 'accent';
+}
+
+const STATUS_CONFIG: Record<StatusBadgeType, StatusConfig> = {
+  support:   { label: 'Support',  icon: '🛟', variant: 'info' },
+  pinned:    { label: 'Pinned',   icon: '📌', variant: 'accent' },
+  verified:  { label: 'Verified', icon: '⭐', variant: 'success' },
+  official:  { label: 'Official', icon: '🏛', variant: 'accent' },
+  important: { label: 'Important', icon: '❗', variant: 'warning' },
+  new:       { label: 'New',      icon: '🆕', variant: 'info' },
+};
+
+export interface StatusBadgeProps {
+  /** Which status this badge represents. Drives icon + color automatically. */
+  status: StatusBadgeType;
+  /** Override the default label text (icon/color stay tied to `status`). */
+  label?: string;
+  /** Hide the leading icon. Defaults to showing it. */
+  showIcon?: boolean;
+  className?: string;
+}
+
+export default function StatusBadge({
+  status,
+  label,
+  showIcon = true,
+  className = '',
+}: StatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+
+  if (!config) return null;
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {showIcon && <span aria-hidden="true">{config.icon}</span>}
+      <span>{label ?? config.label}</span>
+    </Badge>
+  );
+}

--- a/apps/frontend/src/components/community/moderation/index.ts
+++ b/apps/frontend/src/components/community/moderation/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Community Moderation — reusable UI components.
+ *
+ * This barrel is additive-only: new components in this module should be
+ * exported here rather than requiring changes to files outside this folder.
+ */
+
+export { default as AdminControls } from './AdminControls';
+export type { AdminControlsProps } from './AdminControls';
+
+export { default as StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps, StatusBadgeType } from './StatusBadge';
+
+export { default as DeleteConfirmationDialog } from './DeleteConfirmationDialog';
+export type { DeleteConfirmationDialogProps } from './DeleteConfirmationDialog';
+
+export { default as EditReminderModal } from './EditReminderModal';
+export type {
+  EditReminderModalProps,
+  EditReminderFormValues,
+  EditReminderField,
+} from './EditReminderModal';

--- a/apps/frontend/src/components/community/moderation/useIsCommunityAdmin.ts
+++ b/apps/frontend/src/components/community/moderation/useIsCommunityAdmin.ts
@@ -1,0 +1,20 @@
+/**
+ * useIsCommunityAdmin.ts — Shared role-resolution hook.
+ *
+ * Extracted after review: the same `isAdmin ?? (role === 'admin' ||
+ * role === 'moderator')` fallback was duplicated in both `AdminControls`
+ * and `ImportantLinksTab`. Centralising it here means any future change
+ * to who counts as a community admin (e.g. adding a new role) happens
+ * in one place.
+ *
+ * Usage: pass an explicit `isAdmin` override when the caller already
+ * resolved the role (e.g. an admin-only page); omit it to fall back to
+ * the logged-in user's role via `useAuth()`.
+ */
+
+import { useAuth } from '../../../hooks/useAuth';
+
+export function useIsCommunityAdmin(isAdmin?: boolean): boolean {
+  const { user } = useAuth();
+  return isAdmin ?? (user?.role === 'admin' || user?.role === 'moderator');
+}

--- a/apps/frontend/src/components/community/shared/CommunityToast.tsx
+++ b/apps/frontend/src/components/community/shared/CommunityToast.tsx
@@ -1,0 +1,37 @@
+/**
+ * CommunityToast.tsx — Shared success/info toast.
+ *
+ * Extracted after review: this exact fixed-bottom-center toast markup
+ * already existed inline in `CommunityPage.tsx`, and was being copied a
+ * second time into `CopyLinkButton`. Rather than let a third copy appear
+ * the next time someone needs a toast, it's factored out here so
+ * `CopyLinkButton` (and any future component in this module) can share
+ * one implementation.
+ *
+ * `CommunityPage.tsx`'s own pre-existing toast was left as-is — it's
+ * outside this module's ownership and changing it wasn't requested, so
+ * touching it would be an unrelated change. Whoever owns that file can
+ * migrate it to this component later if useful.
+ *
+ * `role="status"` + `aria-live="polite"` ensure screen-reader users get
+ * the confirmation, not just sighted users.
+ */
+
+import React from 'react';
+
+export interface CommunityToastProps {
+  message: string;
+  className?: string;
+}
+
+export default function CommunityToast({ message, className = '' }: CommunityToastProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] px-4 py-2.5 bg-card border border-border rounded-xl text-xs text-ink font-medium shadow-float pointer-events-none ${className}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/community/shared/SegmentedTabs.tsx
+++ b/apps/frontend/src/components/community/shared/SegmentedTabs.tsx
@@ -1,0 +1,54 @@
+/**
+ * SegmentedTabs.tsx — Small reusable segmented pill-tab control.
+ *
+ * The Discussions/Important Links toggle needed the exact
+ * `bg-mist rounded-xl` pill-group markup that already exists inline in
+ * `CommunityPage.tsx` for its status filter (All/Unanswered/Open).
+ * Rather than hand-copy that markup a second time, it's componentised
+ * here for the new toggle.
+ *
+ * The pre-existing status-filter pills in `CommunityPage.tsx` were
+ * intentionally left untouched rather than migrated to this component —
+ * that block predates this module, isn't part of its scope, and
+ * refactoring it would be an unrelated change that only increases merge
+ * risk with whoever owns that filter. Flagged here as a follow-up
+ * de-duplication opportunity for that file's owner, not done unilaterally.
+ */
+
+import React from 'react';
+
+export interface SegmentedTabOption<T extends string> {
+  key: T;
+  label: string;
+}
+
+export interface SegmentedTabsProps<T extends string> {
+  options: SegmentedTabOption<T>[];
+  value: T;
+  onChange: (key: T) => void;
+  className?: string;
+}
+
+export default function SegmentedTabs<T extends string>({
+  options,
+  value,
+  onChange,
+  className = '',
+}: SegmentedTabsProps<T>) {
+  return (
+    <div className={`flex gap-1 p-1 bg-mist rounded-xl w-fit ${className}`}>
+      {options.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onChange(key)}
+          aria-pressed={value === key}
+          className={`px-4 py-1.5 rounded-lg text-xs font-medium transition-all duration-200
+            ${value === key ? 'bg-card text-ink shadow-subtle' : 'text-ink-soft hover:text-ink'}`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/community/shared/index.ts
+++ b/apps/frontend/src/components/community/shared/index.ts
@@ -1,0 +1,5 @@
+export { default as CommunityToast } from './CommunityToast';
+export type { CommunityToastProps } from './CommunityToast';
+
+export { default as SegmentedTabs } from './SegmentedTabs';
+export type { SegmentedTabOption, SegmentedTabsProps } from './SegmentedTabs';

--- a/apps/frontend/src/pages/CommunityPage.tsx
+++ b/apps/frontend/src/pages/CommunityPage.tsx
@@ -14,6 +14,11 @@ import type { Post } from '../types/ui';
 
 import CreatePostDialog from '../components/community/CreatePostDialog';
 import { buttonCommunityAsk } from '../styles/style_config';
+// Community Pinboard integration — reusable components only, no backend/API/routing changes.
+import AdminControls from '../components/community/moderation/AdminControls';
+import StatusBadge from '../components/community/moderation/StatusBadge';
+import { ImportantLinksTab, type ImportantLink } from '../components/community/important-links';
+import { SegmentedTabs } from '../components/community/shared';
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 export default function CommunityPage() {
@@ -54,6 +59,12 @@ export default function CommunityPage() {
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [createPrefillTitle, setCreatePrefillTitle] = useState('');
+
+  // Community Pinboard — Important Links tab. Local UI state only; no
+  // backend/API wired up yet (out of scope for this integration pass).
+  const [activeView, setActiveView] = useState<'discussions' | 'links'>('discussions');
+  const [importantLinks, setImportantLinks] = useState<ImportantLink[]>([]);
+  const [linksSectionPinned, setLinksSectionPinned] = useState(true);
 
   // Backend uses cursor-based pagination. The previous version sent `?page=2`
   // which the backend silently ignored — so every "Load more" call returned
@@ -241,6 +252,21 @@ export default function CommunityPage() {
     setSelectedPostId(null);
   };
 
+  // Important Links — local-only handlers (no API). ManageLinksModal and
+  // ImportantLinksTab only ever call back with plain data; persistence is
+  // intentionally out of scope for this integration pass.
+  const handleAddLink = (draft: Omit<ImportantLink, 'id'>) => {
+    setImportantLinks((prev) => [...prev, { ...draft, id: crypto.randomUUID() }]);
+  };
+
+  const handleEditLink = (id: string, draft: Omit<ImportantLink, 'id'>) => {
+    setImportantLinks((prev) => prev.map((l) => (l.id === id ? { ...draft, id } : l)));
+  };
+
+  const handleDeleteLink = (id: string) => {
+    setImportantLinks((prev) => prev.filter((l) => l.id !== id));
+  };
+
   const handleShareCommunity = async () => {
     const url = window.location.origin + '/csfaq/community';
     try { await navigator.clipboard.writeText(url); } catch { /* ignore */ }
@@ -347,6 +373,30 @@ export default function CommunityPage() {
           </div>
         </div>
 
+        {/* Community Pinboard — Discussions / Important Links toggle. */}
+        <div className="flex items-center gap-3 mb-4 flex-wrap">
+          <SegmentedTabs
+            options={[
+              { key: 'discussions', label: 'Discussions' },
+              { key: 'links', label: 'Important Links' },
+            ]}
+            value={activeView}
+            onChange={setActiveView}
+          />
+
+          {activeView === 'links' && (
+            <div className="flex items-center gap-2">
+              {linksSectionPinned && <StatusBadge status="pinned" />}
+              <AdminControls
+                isPinned={linksSectionPinned}
+                onPin={() => setLinksSectionPinned((p) => !p)}
+              />
+            </div>
+          )}
+        </div>
+
+        {activeView === 'discussions' && (
+        <>
         <CommunityHealth />
 
         {!loading && total > 0 && (
@@ -493,6 +543,17 @@ export default function CommunityPage() {
               )
             )}
           </div>
+        )}
+        </>
+        )}
+
+        {activeView === 'links' && (
+          <ImportantLinksTab
+            links={importantLinks}
+            onAdd={handleAddLink}
+            onEdit={handleEditLink}
+            onDelete={handleDeleteLink}
+          />
         )}
 
         <div className="h-12" />


### PR DESCRIPTION
## What this adds
- AdminControls, StatusBadge, DeleteConfirmationDialog, EditReminderModal (community/moderation)
- LinkCard, CopyLinkButton, CategoryFilter, ManageLinksModal, ImportantLinksTab (community/important-links)
- CommunityToast, SegmentedTabs, useIsCommunityAdmin (community/shared, community/moderation)
- Integrated into CommunityPage.tsx via a Discussions / Important Links toggle

## Scope
- Frontend UI only — no backend, no API, no routing changes
- Important Links data is currently local state (empty by default) — ready for backend wiring by whoever owns that

## Tested
- pnpm typecheck: pass
- pnpm lint: no errors/warnings in new files
- Manually verified: tab toggle, category filtering, empty states, admin-gated controls, copy-to-clipboard toast, Add/Edit/Delete flow in Manage Links