### PR TITLE
fix: remove unsupported HTML upload option from admin document picker

### DIFF
--- a/apps/frontend/src/admin/pages/AdminContextSources.tsx
+++ b/apps/frontend/src/admin/pages/AdminContextSources.tsx
@@ -631,9 +631,6 @@ export function WebUrlView({ bare = false }: { bare?: boolean } = {}) {
 /**
  * UploadDocumentView — file-upload form + list for `DocumentAsset`.
  * Self-contained: owns its own state, fetches `/admin/documents`.
- * v1.83 — `.html` / `.htm` added to the accept= list; uploads will
- * still be rejected by the backend until ALLOWED_MIME in
- * adminDocuments.controller.ts is extended (tracked as a TODO).
  */
 export function UploadDocumentView({ bare = false }: { bare?: boolean } = {}) {
   const [items, setItems] = useState<DocumentRow[]>([]);
@@ -704,7 +701,7 @@ export function UploadDocumentView({ bare = false }: { bare?: boolean } = {}) {
     } catch (e) {
       const status = (e as { response?: { status?: number } })?.response?.status;
       let msg = friendlyError(e, 'Upload failed.');
-      if (status === 400) msg = 'That file type is not supported. Use PDF, TXT, MD, CSV, HTML, or HTM.';
+      if (status === 400) msg = 'That file type is not supported. Use PDF, TXT, MD, or CSV.';
       else if (status === 422) msg = 'We could not extract any text from that file.';
       setUploadError(msg);
     } finally {
@@ -810,12 +807,7 @@ export function UploadDocumentView({ bare = false }: { bare?: boolean } = {}) {
         <input
           id="context-doc-file"
           type="file"
-          // v1.83 — accept HTML too. Backend ALLOWED_MIME set does NOT
-          // yet include `text/html` / `application/xhtml+xml`; a
-          // follow-up backend PR will add extraction support. Until
-          // then an HTML upload returns 400 and the existing error
-          // path displays "unsupported file type".
-          accept=".pdf,.txt,.md,.csv,.html,.htm"
+          accept=".pdf,.txt,.md,.csv"
           onChange={handleFileChange}
           disabled={uploadPending}
           aria-label="Document file"
@@ -924,7 +916,7 @@ export function UploadDocumentView({ bare = false }: { bare?: boolean } = {}) {
   return (
     <AdminCard
       title="Documents"
-      subtitle="Upload a PDF, TXT, MD, CSV, HTML, or HTM. Text is extracted and indexed for retrieval."
+      subtitle="Upload a PDF, TXT, MD, or CSV. Text is extracted and indexed for retrieval."
     >
       {body}
     </AdminCard>

--- a/apps/frontend/src/admin/pages/__tests__/AdminContextSources.test.tsx
+++ b/apps/frontend/src/admin/pages/__tests__/AdminContextSources.test.tsx
@@ -373,6 +373,7 @@ describe('AdminContextSources', () => {
 
     const file = new File(['hello world'], 'uploaded.pdf', { type: 'application/pdf' });
     const fileInput = screen.getByTestId('documents-file-input') as HTMLInputElement;
+    expect(fileInput.accept).toBe('.pdf,.txt,.md,.csv');
     fireEvent.change(fileInput, { target: { files: [file] } });
 
     // Selected-file hint surfaces.


### PR DESCRIPTION
## What was broken
The admin document-upload UI in `AdminContextSources.tsx` advertised HTML
(`.html`/`.htm`) as an accepted file type — in the file picker's `accept`
attribute, the upload subtitle text, and the error message — but the
backend has never supported it. The multer filter and controller validation
in `admin-documents.routes.ts` / `adminDocuments.controller.ts` only allow
PDF/TXT/Markdown/CSV, so any HTML upload was silently rejected with a 400.

Git blame confirms this wasn't accidental: the original commit's comment
explicitly says HTML support "will still be rejected by the backend until
ALLOWED_MIME... is extended (tracked as a TODO)" — planned follow-up work
that was never completed.

## Fix
Removed HTML/HTM from the upload-specific UI only:
- File input `accept` attribute (`.pdf,.txt,.md,.csv,.html,.htm` → `.pdf,.txt,.md,.csv`)
- Upload card subtitle text
- Upload error message
- The now-resolved TODO comment above the input

The separate "Paste text or HTML" feature (pasting raw text/HTML directly,
not file upload) is untouched — that's a different feature path with its
own handling and was intentionally left as-is.

## Why this approach
Considered two options: (A) remove HTML from the frontend to match backend
reality, or (B) implement real backend HTML parsing/extraction. Went with
(A) because (B) would require new parsing logic, security hardening
(sanitization, since HTML is untrusted input), and test coverage — a
reasonable future feature, but not a fit for a bug-fix PR. (A) directly
closes the mismatch with no functional risk.

## How this was found
Found via manual code review, not from an assigned GitHub issue.

## Testing
- Updated `AdminContextSources.test.tsx` to assert the file input's
  `accept` value is now `.pdf,.txt,.md,.csv`
- Manually tested: `.html`/`.htm` no longer selectable in the file picker,
  subtitle/error text read correctly, PDF/TXT upload still works unchanged
- `pnpm exec tsc --noEmit` — clean, no errors
- `pnpm test` — `AdminContextSources.test.tsx` passes (9/9). 3 unrelated
  test suites (`api.test.ts`, `PremiumTee.test.ts`,
  `GoldenTicketDetailPage.test.tsx`) fail on `main` as well, due to a
  pre-existing tooling error (`jsTokens is not a function`) unrelated to
  this change.