### PR TITLE
docs: correct storage and rate-limiting infrastructure claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the architecture deep-dive 
 |---|---|
 | Frontend | React 18, Vite, TypeScript, Tailwind CSS, Framer Motion, Axios, Recharts, React Router 6, Vitest |
 | Backend | Node.js, Express 4, TypeScript (ESM), Mongoose 8, JWT, bcryptjs, Helmet, CORS, Morgan, Multer, Zod, express-rate-limit, dotenv, OpenAI SDK, Vitest |
-| Database & Storage | MongoDB Atlas (with Vector Search), Upstash Redis (optional), LRU cache, Cloudinary |
+| Database & Storage | MongoDB Atlas (with Vector Search), Google Cloud Storage for new uploads, LRU cache, legacy Cloudinary pass-through support |
 | Search & AI | Xenova/transformers (768-dim local embeddings), Atlas Vector Search, $text search, Reciprocal Rank Fusion |
 | AI Providers | Anthropic, OpenAI, XAI, MiniMax (per-pipeline configurable) |
 | DevOps | Sentry, Ngrok (local webhook tunnel), Twilio (SMS), SMTP, Vitest |
@@ -90,7 +90,7 @@ For the full admin route map and per-page behaviour, see [docs/ARCHITECTURE.md](
 The user-facing app (`/`, `/faq`, `/community`, `/saved`, `/account`, `/leaderboard`) gives authenticated users full participation in the knowledge loop:
 
 - **Discover** — hybrid semantic + keyword search at `/api/search` (public), semantic suggestions at `/api/search/suggest`, category browsing
-- **Ask the community** — post creation with Zod validation, debounced duplicate detection against the FAQ base (banner + block on match), auto-normalised tags, Cloudinary image attachments
+- **Ask the community** — post creation with Zod validation, debounced duplicate detection against the FAQ base (banner + block on match), auto-normalised tags, image attachments
 - **Engage** — upvotes with reputation-farming prevention (reverses on removal), bookmarks at `/saved`, nested comment threads with optimistic UI, accept-answer (locks verified/expert comments from edit), edit/delete own comments, share via clipboard, report and flag-outdated
 - **Notifications** — in-app bell, SpillTheTea event stream (`post_answered`, `post_deleted`, etc.), per-event-type settings, email + SMS delivery
 - **Reputation** — points for accepted answers, badges at thresholds, expert promotion by peer vote, public leaderboard
@@ -118,7 +118,7 @@ Crowd Source FAQ/
 ## Environment Variables
 
 Required: `MONGODB_URI`, `JWT_SECRET`
-Optional: at least one AI provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` / `MINIMAX_API_KEY`), Zoom OAuth credentials, `CLOUDINARY_*`, `SENTRY_DSN`, Twilio + SMTP for notifications, `UPSTASH_REDIS_*`
+Optional: at least one AI provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` / `MINIMAX_API_KEY`), Zoom OAuth credentials, GCS-related upload settings, `SENTRY_DSN`, Twilio + SMTP for notifications, and optional legacy Cloudinary/Redis variables.
 
 See [docs/ARCHITECTURE.md#10-env-variables-reference](docs/ARCHITECTURE.md#10-env-variables-reference) for the full list.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ All routes are mounted in `server.ts`. Admin routes are prefixed `/api/admin`.
 | `zoom.ts` | `/api/zoom` | mixed | OAuth, webhook, manual upload, status |
 | `knowledge.ts` | `/api/knowledge` | protected | TranscriptKnowledge management |
 | `askAi.ts` | `/api/ask-ai` | public (quota) | RAG-powered AI assistant |
-| `upload.ts` | `/api/upload` | protected | Cloudinary signed upload URL |
+| `upload.ts` | `/api/upload` | protected | GCS signed upload URL |
 
 ### Route prefix pitfall
 
@@ -338,7 +338,7 @@ Each controller handles a set of related operations. Controllers are imported by
 | `rateLimit.ts` | `createIdentityLimiter()` — per-user/IP rate limiters |
 | `cache.ts` | In-memory LRU cache for search results |
 | `circuitBreaker.ts` | `CircuitOpenError` + circuit state for Zoom OAuth + API calls |
-| `cloudinary.ts` | `getCloudinaryConfig()` — startup validation, `generateUploadSignature()` |
+| `cloudinary.ts` | `getCloudinaryConfig()` — legacy/secondary Cloudinary helper for resource uploads; current primary uploads use GCS |
 | `crypto.ts` | `encrypt()`, `decrypt()` — AES-256-GCM for token storage |
 | `duplicateDetector.ts` | AI-powered duplicate FAQ/post detection |
 | `fileLogger.ts` | Structured file-based logging (rotating) |
@@ -664,7 +664,9 @@ The cooldown duration is a singleton admin setting (`AppSetting.goldenCooldownHo
 | `ZOOM_WEBHOOK_SECRET_TOKEN` | Yes (prod) | Webhook HMAC verification |
 | `ZOOM_TOPIC_BLACKLIST` | No | CSV regex — skip matching meetings |
 
-### Cloudinary
+### Cloudinary (legacy/secondary)
+
+Legacy/secondary storage path; new avatar and post uploads use GCS via signed URLs.
 
 | Variable | Required | Purpose |
 |---|---|---|
@@ -685,7 +687,9 @@ The cooldown duration is a singleton admin setting (`AppSetting.goldenCooldownHo
 | `EMAIL_USER` | SMTP user |
 | `EMAIL_PASS` | SMTP password |
 
-### Upstash Redis (optional — search cache)
+### Upstash Redis (optional / legacy scaffolding)
+
+Optional legacy/secondary config; Redis is not currently active. Rate limiting falls back to the default in-memory store, and search-result caching uses an in-process LRU cache (see cache.ts) rather than Redis/Upstash.
 
 | Variable | Purpose |
 |---|---|


### PR DESCRIPTION
## What was stale
README.md and docs/ARCHITECTURE.md described Cloudinary and Upstash Redis
as the current/primary storage and rate-limiting infrastructure. Verified
against actual code:
- New avatar/post uploads use GCS via signed URLs (useGcsUpload.ts);
  Cloudinary is legacy/secondary — still used for pass-through of old
  URLs and some admin resource-upload flows, not fully decommissioned
- Redis is not active for rate limiting (rateLimitRedis.ts returns
  undefined, falls back to in-memory store) or for search caching
  (cache.ts was migrated from Upstash Redis + ioredis to an in-process
  LRU cache; stale "Redis" comments remain in search.controller.ts as
  leftover references, not active behavior)

docs/CLOUDINARY_TO_GCS_MIGRATION.md was already accurate and left untouched.

## Fix
Minimal wording corrections in README.md and docs/ARCHITECTURE.md at each
location mentioning Cloudinary/GCS/Redis/Upstash — no structural changes,
no new sections.

## How this was found
Found via manual review, not from an assigned GitHub issue.

## Testing
Docs-only change, no code touched, no tests affected.