### PR TITLE
fix(frontend): show program switcher dropdown when logged out

### DIFF
--- a/apps/frontend/src/components/layout/BatchSwitcher.tsx
+++ b/apps/frontend/src/components/layout/BatchSwitcher.tsx
@@ -7,7 +7,7 @@
 // existing topbar pill buttons.
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useBatch } from '../../context/BatchContext';
 import {
   topbarCreateButton,
@@ -79,13 +79,13 @@ export function BatchSwitcher({
     // Nothing to switch to yet — render an empty "Pick a program" pill
     // that links to the portal picker.
     return (
-      <a
-        href="/explore/select"
+      <Link
+        to="/programs"
         className={`${topbarPill} ${className}`}
       >
         <LayersIcon className="text-accent" />
         <span>Pick a program</span>
-      </a>
+      </Link>
     );
   }
 

--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -169,21 +169,24 @@ export default function Navbar({ showProgramSwitcher: _showProgramSwitcher = fal
         <div className="flex items-center justify-self-end gap-2 sm:gap-3">
           {!isAdminView && (
             <>
-              {/* Unauthenticated — Sign in (text) + Get started (filled) */}
+              {/* Unauthenticated — Program switcher + Sign in (text) + Get started (filled) */}
               {!isAuthenticated && (
-                <div className="hidden lg:flex items-center gap-2">
-                  <button
-                    onClick={() => openModal('signin')}
-                    className="px-3 py-1.5 text-sm font-medium text-ink-soft hover:text-ink transition-colors"
-                  >
-                    Sign in
-                  </button>
-                  <button
-                    onClick={() => openModal('register')}
-                    className={`${btnBase} ${btnPrimary} text-sm`}
-                  >
-                    Get started
-                  </button>
+                <div className="flex items-center gap-2">
+                  <BatchSwitcher showCreateLink={false} className="hidden md:inline-flex" />
+                  <div className="hidden lg:flex items-center gap-2">
+                    <button
+                      onClick={() => openModal('signin')}
+                      className="px-3 py-1.5 text-sm font-medium text-ink-soft hover:text-ink transition-colors"
+                    >
+                      Sign in
+                    </button>
+                    <button
+                      onClick={() => openModal('register')}
+                      className={`${btnBase} ${btnPrimary} text-sm`}
+                    >
+                      Get started
+                    </button>
+                  </div>
                 </div>
               )}
 
@@ -193,9 +196,7 @@ export default function Navbar({ showProgramSwitcher: _showProgramSwitcher = fal
                   <ZoomBubble />
                   {/* Spurti Points chip */}
                   <SpurtiChip />
-                  {isAuthenticated && (
-                    <BatchSwitcher showCreateLink={user?.role === 'admin'} className="hidden md:inline-flex" />
-                  )}
+                  <BatchSwitcher showCreateLink={user?.role === 'admin'} className="hidden md:inline-flex" />
 
                   {/* v1.87 — Sign My Tee pill. Shown ONLY when the
                       BE says the user is inside the rolling 3-day
@@ -375,14 +376,12 @@ export default function Navbar({ showProgramSwitcher: _showProgramSwitcher = fal
         }`}
       >
         <div className="px-6 py-4 flex flex-col gap-1">
-          {isAuthenticated && (
-            <div className="px-4 py-2 border-b border-border/40 mb-2">
-              <p className="text-[10px] uppercase tracking-wider font-semibold text-ink-faint mb-1.5">
-                Current Program
-              </p>
-              <BatchSwitcher showCreateLink={user?.role === 'admin'} compact className="w-full" />
-            </div>
-          )}
+          <div className="px-4 py-2 border-b border-border/40 mb-2">
+            <p className="text-[10px] uppercase tracking-wider font-semibold text-ink-faint mb-1.5">
+              Current Program
+            </p>
+            <BatchSwitcher showCreateLink={user?.role === 'admin'} compact className="w-full" />
+          </div>
           {allNavItems.map(({ label, to }) => (
             <NavLink
               key={to}


### PR DESCRIPTION
## Description
This PR resolves an issue where the program/batch switcher dropdown was hidden from visitors who were not logged in.

## Changes Made
- **Navbar & Mobile Sheet** (`apps/frontend/src/components/layout/Navbar.tsx`):
  - Render `<BatchSwitcher />` on `md+` desktop screens for unauthenticated users alongside *Sign in* & *Get started* buttons.
  - Unconditionally render the `BatchSwitcher` in the mobile sheet so the current program selector is accessible to all visitors.
- **Client Routing** (`apps/frontend/src/components/layout/BatchSwitcher.tsx`):
  - Replaced fallback `<a href="/explore/select">` with `<Link to="/programs">` for smooth SPA navigation under the `/csfaq/` base path.

## Verification
- Typecheck (`tsc --noEmit`): Passed (0 errors).
- Frontend Unit Tests: All 14 test suites (132 tests) passed.
- Tested in browser: Program dropdown is visible and interactive while logged out.
