### PR TITLE
 feat: add manual FAQ curation, sorting, and voting limits

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -77,6 +77,7 @@
     "@types/range-parser": "^1.2.7",
     "@types/uuid": "^10.0.0",
     "nodemon": "^3.0.2",
+    "playwright": "^1.62.1",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "vitest": "^1.6.0"

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load .env relative to the apps/backend directory regardless of execution context
+// Load .env and .env.local relative to the apps/backend directory regardless of execution context
 const envPath = path.resolve(__dirname, '../.env');
+const localEnvPath = path.resolve(__dirname, '../.env.local');
 dotenv.config({ path: envPath });
+dotenv.config({ path: localEnvPath, override: true });

--- a/apps/backend/src/faqs.json
+++ b/apps/backend/src/faqs.json
@@ -1,11 +1,985 @@
 {
+  "source": "https://samagama.in/internship/faq",
+  "version": "v24.16.0",
+  "last_updated": "2026-07-29, IST",
+  "total_faqs": 160,
+  "sections": [
+    "1. About the internship",
+    "2. Timing and dates",
+    "3. NOC (No Objection Certificate)",
+    "4. Selection, offer letter, and certificate",
+    "5. Work and projects",
+    "6. Code of conduct — communication channels",
+    "7. Interviews Related",
+    "8. Certificate",
+    "9. Rosetta — your internship journal",
+    "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+    "11. Spurti Points",
+    "12. Yaksha Chat Related",
+    "13. ViBe Platform",
+    "14. Team Formation",
+    "15. Spurti Levels, Trophy Leagues & Feedback Survey"
+  ],
   "faqs": [
     {
-      "id": "1",
-      "section": "General",
-      "question": "What is the Yaksha research internship?",
-      "answer": "Yaksha is a two-month research internship program.",
-      "category": "General Info"
+      "id": "1.1",
+      "section": "1. About the internship",
+      "question": "What is the Vicharanashala internship?",
+      "answer": "A two-month engagement at the Vicharanashala Lab, a research lab at IIT Ropar. You will work on a real open-source project under a mentor, after a short training phase tailored to where you already are. The internship is free — we do not charge, and the work is real. It runs on one of two tracks, decided by the start date you confirm: a full-time, live-session track if your confirmed start date is on or before 15 July 2026, or an asynchronous self-paced / parallel track if it's after that (see §2.7). As of today, most new candidates land on the self-paced / parallel track."
+    },
+    {
+      "id": "1.2",
+      "section": "1. About the internship",
+      "question": "What is VINS?",
+      "answer": "VINS is the Vicharanashala Internship — an online programme open to anyone who clears our interview. The work is real open-source contribution under a mentor, the certificate is from the Vicharanashala Lab for Education Design at IIT Ropar, and the programme itself is free (we charge nothing). There is no stipend. If you are seeing a yellow VINS panel on your result page, you are selected."
+    },
+    {
+      "id": "1.3",
+      "section": "1. About the internship",
+      "question": "What are the phases of VINS, and what do the badges mean?",
+      "answer": "VINS is structured as four phases. Each one is marked by a badge — a small token of where you are in the journey. 🥉 Bronze (Phase 1) — a short training period at the start, planned around what you already know. If you arrive already comfortable with the basics, you may skip Bronze and go straight on to the project. Bronze culminates in a CSFAQ project submission — you submit the PR ID(s) you raised on the official CSFAQ repo, along with product documentation and a project report. See §10.15 for details. 🥈 Silver (Phase 2) — the main work. You contribute to a real open-source project under a Vicharanashala mentor. Finishing Bronze and Silver completes your internship and earns the certificate. 🥇 Gold (Phase 3) — a recognition awarded during Silver if your contribution stands on its own as a meaningful feature, not just a small fix. 🏆 Platinum (Phase 4) — a standing invitation to come back and visit the lab — a short trip — any time during the year after your internship ends. We help with travel through a small visit stipend. Most interns finish at Bronze + Silver, and that is exactly what the certificate is for. Gold and Platinum are extras you can pick up if your work makes the case for them. Either way, you walk away with a real open-source contribution to your name and a mentor who knows you well."
+    },
+    {
+      "id": "1.4",
+      "section": "1. About the internship",
+      "question": "Who is the internship for? Are alumni eligible?",
+      "answer": "The internship is for currently-enrolled students at any college or university — undergraduate, postgraduate, or doctoral. The NOC requirement is the practical reflection of this: we ask for institutional consent that you can commit your time to this internship. Candidates who have already graduated and are not currently enrolled in any programme are not eligible for this cycle. If you re-enrol later (higher studies, etc.), you are very welcome to apply again in a future cycle."
+    },
+    {
+      "id": "1.5",
+      "section": "1. About the internship",
+      "question": "Is this the same as IIT Ropar's official Summer Research Internship?",
+      "answer": "No. Summership 2026 is a VLED Lab initiative. The certificate is issued by the Vicharanashala Lab for Education Design, not centrally by the institute. IIT Ropar runs a separate institutional summer research internship through its own office. Do not represent Summership 2026 as equivalent to that programme."
+    },
+    {
+      "id": "1.6",
+      "section": "1. About the internship",
+      "question": "I have to attend my class tomorrow/today/some day — can I take leave?",
+      "answer": "Leave is not permitted. If you are also attending classes or exams, you will be relieved from the internship immediately and will need to join the next batch when it starts. This answer is about the standard, live-session track. If your confirmed start date is after 15 July 2026, you're on the self-paced / parallel track instead (see §2.7), which has no fixed daily attendance to conflict with class — only mandatory weekly milestones. Attending a class does not by itself trigger relief on that track, though the milestones still have to be met."
+    },
+    {
+      "id": "2.1",
+      "section": "2. Timing and dates",
+      "question": "When can I start?",
+      "answer": "You can start any time in 2026 — VINS is flexible on the start date. Which track you land on depends entirely on the date you confirm: Confirm a start date on or before 15 July 2026 → you're on the live-session track (mandatory daily Zoom, week-by-week structure — see §2.7 for the comparison). Confirm a start date after 15 July 2026 → you're on the **self-paced / parallel track** instead (four verticals, asynchronous, no mandatory live sessions). As of today, this is where most new candidates land — it is not a rare case. Whichever track, one hard rule applies to both: your internship must finish by 31 December 2026. Whatever start you pick, your end date (your start + 2 months, with up to 1 month grace) must land on or before 31 December 2026. So while there's no last date to opt in, there is absolutely a last date to finish. The live-session track's main cohort window (15 May – 15 July 2026) has now closed. It offered three things that made it materially better than a later start — cohort networking (peer discussions and lasting connections formed while going through Bronze together), concentrated TA support, and training that rolled out with live discussion rather than as a static document. These are noted here for context, not as something still available to opt into. As of today, a confirmed start date lands on or after 16 July 2026 for every new candidate, which means the self-paced / parallel track (see §2.7) is what actually applies to you — not the live-session description above."
+    },
+    {
+      "id": "2.2",
+      "section": "2. Timing and dates",
+      "question": "How long is the internship?",
+      "answer": "Two months from your chosen start date, with an optional one-month grace period if you need it. End must land on or before 31 December 2026."
+    },
+    {
+      "id": "2.3",
+      "section": "2. Timing and dates",
+      "question": "Can I start in July, August or later if I have exams now?",
+      "answer": "Yes — but only if your exams genuinely make an earlier start impossible. Wait until your exams are done, then opt in and start. Do not attempt to juggle this internship with ongoing exams. Make sure your chosen start date plus 2 months (or 3 with grace) lands on or before 31 December 2026."
+    },
+    {
+      "id": "2.4",
+      "section": "2. Timing and dates",
+      "question": "Can I start with the cohort and take a relaxation during my exam window?",
+      "answer": "No. This is not an arrangement we offer. VINS is a full-attention internship — six to ten hours a day, sometimes more. Splitting that with college exams damages both sides: the project loses momentum, the exams suffer, and the lab invests in someone who can only half-engage. We have seen this fail enough times to be firm. If your exams fall inside the cohort duration, defer your start to after your exams end, opt in then, and run the internship at full attention. The certificate and project pathway are the same. This answer is about the standard, live-session track. If your confirmed start date ends up after 15 July 2026, you'd be on the self-paced / parallel track instead (see §2.7), where this full-attention/hours expectation doesn't apply — though deferring past exams is still the right call either way. A note on consequences. If we later learn that a candidate was sitting college exams during their internship period, we reserve the right to terminate the internship or withhold the certificate at any time — including after the internship has otherwise been completed."
+    },
+    {
+      "id": "2.5",
+      "section": "2. Timing and dates",
+      "question": "Can I take leave or get an exemption during the internship for an exam scheduled in June?",
+      "answer": "The attendance rule is firm — the 55-day continuous window is a non-negotiable part of the internship, and we cannot offer an exemption for an exam during this period. The policy exists because split attention genuinely damages both your exam preparation and your internship work."
+    },
+    {
+      "id": "2.6",
+      "section": "2. Timing and dates",
+      "question": "Are orientation session recordings shared with interns, and can project or group assignments be changed after watching them?",
+      "answer": "Recordings of the sessions will not be provided. However, we may provide access to an abridged version of a talk or session if we consider it important. We do not guarantee this for every session."
+    },
+    {
+      "id": "2.7",
+      "section": "2. Timing and dates",
+      "question": "Is there a self-paced / parallel track? What if my confirmed start date is after 15 July 2026?",
+      "answer": "Yes. If you confirm a start date after 15 July 2026, you are automatically placed on the self-paced / parallel internship track instead of the standard full-time, live-session journey described elsewhere in this FAQ. On this track, your dashboard shows 4 verticals instead of the usual step-by-step timeline. All four must be completed to earn your completion certificate. Each (except Projects) carries a weekly milestone — the bare minimum you need to hit every week to stay active in the internship; falling behind puts you at risk of being excused from the programme: Standup — accumulate 3,600 cumulative minutes total, tracked live via Spurti, at your own pace. Poll correctness is measured and counted, not just participation. Weekly milestone (bare minimum): 2% — not just logged in, but actively present and responding. ViBe — complete all courses on ViBe to 100%: the Internship Onboarding course, the AI course, and the MERN course. Weekly milestone: watch at least 1 hour of course video per week (2% progress/week). SPA (Foundations of Data Science / Matrix Mystics) — a peer-endorsement system covering 53 questions across Linear Algebra modules. You start with 100 SPA points; get endorsed by a peer mentor on a question to complete it, and once you're endorsed yourself you can mentor others. Weekly milestone: 2 activities per week. Falling behind pauses SPA activity for 15 days and delays your certificate. Projects — ship at least one non-trivial contribution to the open-source project across your entire internship. No weekly milestone for this vertical — it's a one-time requirement, not a recurring one. These weekly milestones are also emailed to you directly when you start, but they're the floor, not the target — the faster you clear them, the faster you climb through the four verticals and finish the internship. For example, Standup's 3,600-minute total is just 60 one-hour sessions: attend daily and you could wrap that vertical in about 2 months. You are not required to attend live Zoom sessions on this track — the mandatory-attendance, 85% participation, and quiz-pass rules described elsewhere (§5.2, §10.4, §10.6, §10.10) apply to the standard track, not to this one. You'll also receive a differently-worded NOC form for this track — download it from your dashboard. If your confirmed start date is on or before 15 July 2026, none of this applies to you — you're on the standard track, and the rest of this FAQ governs your internship as usual. Teaming up on the Projects vertical is optional, same as the standard track. You can work on it standalone or as part of a team — see §14 (Team Formation), whose solo-or-team policy applies to self-paced candidates too."
+    },
+    {
+      "id": "3.1",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "What dates do I put on the NOC?",
+      "answer": "Default: your chosen start date → your start + 2 months (with up to 1 month grace), ensuring the end date is on or before 31 December 2026. Pick the earliest start date you can realistically make — the May–July summer window is the main cohort. If the NOC will be signed on a specific later date, pick a start date after the signature date."
+    },
+    {
+      "id": "3.2",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "Who can sign the NOC, and what format should it be in?",
+      "answer": "Any authorised signatory at your college: HOD, Acting HOD (during holidays), Principal, Dean, Director, or Training & Placement Officer. Your NOC must be in the prescribed Vicharanashala format (the printable form available on your dashboard). If it isn't, we will reject it and ask you to re-upload. Dual-degree students (an IITM BS Online Degree alongside another regular degree): your NOC must come from your home college — the institution awarding your primary degree — signed in the Vicharanashala format. It cannot come from IITM BS. IITM BS Online Degree (standalone) students, with no other degree in progress: the one exception. You may use the IITM BS office's own NOC format — pre-agreed with the IITM BS office and accepted as is — signed by any officer of the BS office."
+    },
+    {
+      "id": "3.3",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "When do I submit the NOC? Is the deadline hard?",
+      "answer": "There is no specific calendar cut-off date by which the NOC must be uploaded — but your internship cannot formally begin until your official institutional NOC has been uploaded and validated by us. So submit your signed NOC as early as possible relative to whatever start date you've confirmed. The live-session summer cohort (15 May – 15 July 2026) that used to make an early start especially valuable has now closed — for a start date today, you would be on the self-paced / parallel track (see §2.7) regardless of how early you submit. Submitting early is still the right move so your internship isn't held up, just not for the cohort-networking reason that applied to the summer window."
+    },
+    {
+      "id": "3.4",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "What format should I use? Do I need to design it myself?",
+      "answer": "No — we provide a printable NOC format. Once your result is out and you log in to samagama.in, you will see a Download blank NOC button on your dashboard. Take a printout, get it physically signed and stamped by your authorised signatory, scan it, and upload the signed PDF using the Upload signed NOC button (also on the dashboard). You do not need to draft anything yourself, and you do not need college letterhead — the format we provide is the canonical layout."
+    },
+    {
+      "id": "3.5",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "What if my college / Program Chair gives me an NOC in their own format?",
+      "answer": "A college's own NOC format is acceptable, as long as all of the required entries are present on it: The signing authority's (HOD / Dean / Program Chair / Principal) handwritten signature — this is the most important itemThe signing authority's name, designation, official email address, and phone number (we cross-check with that person to verify the signature is genuine)Your full name and the internship period (start and end dates)Your signature If your college's format does not include a place for your signature, sign clearly and prominently anywhere on the document before uploading. With those entries present, you do not need to switch to our printable format. An NOC missing any of them is incomplete and will be returned for correction."
+    },
+    {
+      "id": "3.6",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "Does it need to be signed by hand?",
+      "answer": "Yes. Three things are required, all on the NOC format we provide: The authorised signatory's handwritten signatureThe institutional rubber stamp / seal applied in the designated areaThe signatory's email address filled in the designated field — we automatically cross-check with that person to verify the signature is genuine Digital signatures are not accepted. The only path is a physically-signed printout uploaded by you from the dashboard (see §3.8)."
+    },
+    {
+      "id": "3.7",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "Can my HOD email the NOC instead of uploading it?",
+      "answer": "No. Your NOC must be uploaded by you, the student, from your dashboard — we no longer accept NOCs sent by email. We previously offered an email-forward path where your HOD emailed the NOC to us. That option has been retired. NOCs emailed to us — whether by you or by your HOD — will not be processed. The only accepted way to submit your NOC is to download the format, get it signed by the appropriate authority at your institution, and upload the signed PDF yourself from your dashboard (see §3.8). If your college gives you a signed NOC in their own format, that is fine (see §3.5) — you still upload it yourself as a PDF."
+    },
+    {
+      "id": "3.8",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "How do I download and upload the NOC?",
+      "answer": "Both happen on your dashboard at samagama.in once your result is out. You will see a NOC section with two buttons in three places (all backed by the same endpoints — use whichever is convenient): A compact pill in the dark header bar at the top of every screen.A standalone NOC card on the dashboard, between the Results card and the Talk-to-Yaksha button. A NOC section at the bottom of your full Result message itself. The two buttons: Download blank NOC — saves the printable NOC format PDF.Upload signed NOC (PDF) — opens a file picker; the file must be a PDF of at most 1 MB. Confirmation appears on the same card once the upload is received. The chat surface no longer carries any NOC affordance — please use the dashboard buttons. If you can't see the buttons, make sure you are logged in as the email that received the result, and that your result has been released."
+    },
+    {
+      "id": "3.9",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "What if my NOC is not formally verified?",
+      "answer": "NOC verification takes time — typically anywhere between an hour and one full working day from the moment you upload. Your offer letter is issued automatically once your signed institutional NOC is uploaded and validated — there is no faster route. (The earlier self-declaration / provisional-offer option was retired on 2026-05-27 and is no longer accepted.) Please upload your signed NOC as early as you can so your start is not delayed."
+    },
+    {
+      "id": "3.10",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "My online course (Masai, NPTEL, Coursera, etc.) won't issue an NOC. What do I do?",
+      "answer": "The internship is open only to candidates currently enrolled in a full-time degree programme at a recognised college or university. Online-only courses — Masai Institute, NPTEL / MOOC enrolments, Coursera, Udacity, bootcamps, and similar — do not by themselves make a candidate eligible. If you are concurrently enrolled in a full-time degree programme alongside the online course, please obtain a No Due / No Objection certificate from that college (department, Dean's office, or Principal) and upload it via the NOC upload flow on your dashboard. If your only current academic engagement is the online course and you are not concurrently enrolled in a full-time degree programme, the internship is not open to you in this cycle. We would warmly welcome you to apply again in a future cycle once you are enrolled in a full-time programme."
+    },
+    {
+      "id": "3.11",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "My HOD/college official wants written confirmation before signing my NOC. What do I show them?",
+      "answer": "Your selection is already confirmed the moment your yellow VINS (or green VISE) result panel appears on your samagama.in dashboard — that is the official confirmation of your selection, and it is what your HOD should sign your NOC on the basis of. There is no separate written confirmation letter or other proof-of-selection document issued before the NOC step — and none can be sent on request. (The selection-confirmation letter and the self-declaration / provisional-offer route have both been discontinued.) Your offer letter is issued only after your signed NOC is uploaded and validated, so it is not available beforehand. If your college will not sign without something in hand, show them your VINS result panel on the dashboard as evidence of selection — that is the confirmation we provide."
+    },
+    {
+      "id": "3.12",
+      "section": "3. NOC (No Objection Certificate)",
+      "question": "Can Prof. Sudarshan Iyengar or a faculty member from IIT Ropar sign my NOC for the internship?",
+      "answer": "Your NOC must be signed by an authorised signatory at the institution where you are enrolled as a student — such as your HOD, Dean, Principal, or Training & Placement Officer. Sudarshan Iyengar is a faculty member at IIT Ropar and is not the authorised signatory for the IIT Ropar/Masai online AIML programme. He cannot sign your NOC in a personal capacity. Regarding eligibility: the internship is open to candidates currently enrolled in a UG/PG/Diploma programme at a recognised college or university. An online-only certification course (even if offered jointly with an IIT) does not meet that requirement on its own. If you are concurrently enrolled in a full-time degree programme elsewhere, please obtain the NOC from the authorised signatory at that institution. If your only current academic enrolment is the IIT Ropar/Masai online programme, you are not eligible for this internship cycle. Please clarify your current enrolment status and we will guide you accordingly."
+    },
+    {
+      "id": "4.1",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "How do I know I am selected?",
+      "answer": "If you can see your yellow VINS result panel on samagama.in, you are selected. There is no separate selection step or confirmation email."
+    },
+    {
+      "id": "4.2",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "How do I opt into VINS?",
+      "answer": "Tell Yaksha in the chat: \"I want to take up the online internship without stipend.\" Yaksha will confirm. Opting in is the selection — no separate confirmation email is sent at that stage."
+    },
+    {
+      "id": "4.3",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "When do I get the offer letter?",
+      "answer": "Your offer letter is issued automatically once you upload your signed institutional NOC (and have confirmed your start and end dates on the dashboard, see §4.5) and we validate it — typically within an hour to one full working day of upload. There is a single offer letter on Vicharanashala letterhead; once your NOC is validated it is the operative offer for your college / employer records. (The earlier self-declaration / provisional-offer \"fast path\" was retired on 2026-05-27 and is no longer available — a signed institutional NOC is now the only way the offer letter is issued.) The offer letter lives on your dashboard at samagama.in, not in your email. When it is issued, a notification will appear in the Announcements section of samagama.in. Log in and click Download Offer Letter from the Offer Letter card on your dashboard. If you do not see it, do a hard refresh and log back in — or simply ask Yaksha in the chat on samagama.in."
+    },
+    {
+      "id": "4.4",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "Will I get a certificate?",
+      "answer": "Yes — every intern who completes the internship gets a certificate from Vicharanashala, IIT Ropar. The internship is genuinely demanding; candidates who drop out mid-way do not get a certificate. Finishing means something, because the bar is high."
+    },
+    {
+      "id": "4.5",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "How do I confirm my internship dates?",
+      "answer": "Once you have opted into VINS in the chat with Yaksha (see §4.2), log in to samagama.in. On the dashboard, you will see a yellow card titled \"🗓️ Confirm your internship dates\". The two date pickers pre-fill with sensible defaults for the current cohort. If those work for you, hit \"Save dates\". Otherwise edit them to your earliest realistic start — your end must be on or before 31 December 2026. A green confirmation appears once saved. You can edit any time from the same card. Order doesn't matter. You can save your dates before or after uploading your NOC — both paths work. The dates you enter must match the internship period your HOD signs off on in your NOC. If you need to change the period later, edit the dates on the same card and upload a fresh NOC matching the new period."
+    },
+    {
+      "id": "4.6",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "I am a minor/major in AI student, can I join the programme? I don't need a NOC as I am from IIT Ropar",
+      "answer": "Minor/Major in AI course from IIT Ropar is a certification course and there will be a different track of internship equivalent to them. Kindly write to us separately for this. For you to be part of this internship programme you should be a registered student in a UG/PG programme with some university. This internship is exclusively meant for the students only and not for working professionals."
+    },
+    {
+      "id": "4.7",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "How do I accept the offer letter?",
+      "answer": "Acceptance happens entirely on your dashboard at samagama.in — there is no email reply, and nothing to paste or post. The Offer Letter card guides you through three steps, and your offer is recorded as accepted only once all three are complete. Please finish them within 5 days of your offer being issued: Offer letter — download your offer letter, sign the *Acceptance of Offer* block at the bottom of it, and upload the signed PDF on the card. Terms & Conditions (Participation Agreement) — read each section and tick the box to confirm you have understood it. Honor Code — download the Honor Code, sign the last page, and upload the signed PDF. Each PDF upload is capped at 1 MB; to correct a file, just upload a new copy — the latest replaces the previous one. The card updates as you complete each step and shows your offer as accepted once all three are done. There is no acceptance email to send and no statement to type. If you have completed all three steps and the card has not updated after a refresh, log in to samagama.in and describe the issue to Yaksha in the chat — Yaksha will flag it for the team."
+    },
+    {
+      "id": "4.8",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "Can I change my internship dates?",
+      "answer": "Before the offer letter is issued: yes — open the Confirm Internship Dates card on your dashboard and edit the dates at any time. Your end date must be on or before 31 December 2026. If you updated your NOC to reflect new dates before the offer letter was issued, upload the revised NOC via the dashboard. After the offer letter is issued: no — dates are locked. See §4.12 for what that means and what to do instead."
+    },
+    {
+      "id": "4.9",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "My NOC is not ready but my start date is approaching. What do I do?",
+      "answer": "Get your signed institutional NOC uploaded as soon as you can. Your start date cannot be honoured until your official NOC is uploaded and validated by us — the internship formally begins only after the NOC is validated. If your NOC is not in by your chosen start date, your start simply shifts to whenever it is validated. (The earlier self-declaration / provisional-offer option was retired on 2026-05-27 and is no longer accepted, so a signed institutional NOC is the only way forward.)"
+    },
+    {
+      "id": "4.10",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "When does my internship actually begin? Will I receive a notification on the day?",
+      "answer": "Your internship begins on the start date you confirmed on the dashboard — the same date printed on your offer letter — provided your official institutional NOC has been uploaded and validated by us by then. If your validated NOC is not yet in on your start date, your start shifts to the day it is validated. There is no separate \"your internship has begun\" email, chat message, or dashboard notification on the day itself; the start date is the start date. On the morning of your start date, log in to samagama.in. Yaksha will guide you through the Day-1 steps of the Bronze phase. If your dashboard appears unchanged on that morning, do a hard refresh and re-login. If it still looks the same, describe the issue to Yaksha in the chat and Yaksha will flag it for the team. You can review or change your confirmed dates via the Confirm Internship Dates card on your dashboard (see §4.5 to set, §4.8 for date-change rules)."
+    },
+    {
+      "id": "4.11",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "Can I switch from VINS (online) to VISE (offline) after being selected?",
+      "answer": "The two tracks are finalised at the interview stage, and we do not move candidates between them. VISE has a fixed on-campus capacity planned around mentor bandwidth, hostel availability, and stipend allocation — once the shortlist is set, it stays set. VINS is not a consolation track. The project, the mentor, and the certificate are the same as VISE — what differs is the mode (online) and the absence of a fellowship. Many interns find the online format more effective. Your best path forward is to confirm your VINS start dates and get your NOC uploaded — you're already in a strong position."
+    },
+    {
+      "id": "4.12",
+      "section": "4. Selection, offer letter, and certificate",
+      "question": "Can I change my internship dates after the offer letter?",
+      "answer": "No. Once your offer letter has been issued, the dates you confirmed are final. They will not be changed at this stage. If the confirmed dates do not work for you, please follow our LinkedIn page for announcements about future cohorts: linkedin.com/company/vicharanashala"
+    },
+    {
+      "id": "5.1",
+      "section": "5. Work and projects",
+      "question": "What will I work on?",
+      "answer": "A real open-source project from Vicharanashala's portfolio — assigned based on your background and the lab's current needs. Areas range across AI/ML, web development, NLP, computer vision, agriculture-tech (Annam.AI), education-tech (ViBe), and open-source infrastructure. We do not pre-publish the exact problem; you choose to join knowing the lab will assign the project."
+    },
+    {
+      "id": "5.2",
+      "section": "5. Work and projects",
+      "question": "How many hours per day?",
+      "answer": "Plan for 6 to 10 hours a day, sometimes more during the build phase. This is a full-time internship for the two-month window. Most candidates who drop out are juggling something else — VINS expects your full attention. This applies to the standard, live-session track. If you're on the self-paced / parallel track (confirmed start date after 15 July 2026 — see §2.7), hours are flexible and self-directed instead."
+    },
+    {
+      "id": "5.3",
+      "section": "5. Work and projects",
+      "question": "Who is my mentor?",
+      "answer": "You will work with the lab's research and engineering team. The exact mentor depends on the project. The model is fluid — you will get help from a senior researcher one day, a peer the next, and someone else for a different question. That is how real open-source work happens."
+    },
+    {
+      "id": "5.4",
+      "section": "5. Work and projects",
+      "question": "Is there a stipend?",
+      "answer": "No. The internship is unpaid. Stellar performers may be recognised with a discretionary stipend at the lab's option, but this is not promised or expected."
+    },
+    {
+      "id": "5.5",
+      "section": "5. Work and projects",
+      "question": "Do I need my own laptop? Should I preload any software?",
+      "answer": "Yes — a personal laptop is required. We prefer that you bring a laptop running Linux or macOS. If you use Windows, please install a terminal that can SSH and run Unix-style commands — for example, Windows Subsystem for Linux (WSL) is a clean choice; a tool such as PuTTY also works. You will be SSH-ing into machines and using the command line as part of the work. We do not maintain a fixed software-preload list — your mentor will guide you on the specific tools needed once your project is assigned."
+    },
+    {
+      "id": "5.6",
+      "section": "5. Work and projects",
+      "question": "I am using a different email on GitHub / Zoom / Spandan / the learning platform. Is that okay?",
+      "answer": "No. Your registered email is your sole identifier across all programme platforms. Progress tracking, course completion, and certificate issuance are all tied to it. Mismatches between platforms cannot be retroactively corrected — ensure you use your registered email everywhere from day one."
+    },
+    {
+      "id": "5.7",
+      "section": "5. Work and projects",
+      "question": "When will I be assigned a mentor?",
+      "answer": "Mentors are not assigned at the start of the internship. You will be assigned a mentor when you move on to the project phase of VINS, which comes later in the timeline. Before that, you must complete the mandatory coursework of the Bronze phase (see §1.3). Once coursework is complete and you are placed on a project, your mentor will reach out. If you are looking for a Discord server, please note: we do not run a Discord server. See §6.1 for the official communication channels."
+    },
+    {
+      "id": "6.1",
+      "section": "6. Code of conduct — communication channels",
+      "question": "What are the official communication channels?",
+      "answer": "Official channels only. The Announcements section on samagama.in is how we notify you — all programme notifications are posted there (we no longer send notifications by email). Log in and check it regularly during working hours; sessions are announced at least 1 hour before they begin. To get help with a question or problem, follow this order: Zoom breakout room. During every live session there is a breakout room — use it. Talk to your peers. Most questions are resolved here. Discussion forum. For anything not resolved in the breakout, post on the discussion forum. The link was sent to you in your sign-up (registration) email when you first created your account on samagama.in, and is also posted in the Announcements section. This is where you troubleshoot and discuss with your peers and the team. Yaksha chat on samagama.in. If the forum did not resolve it, bring it to Yaksha. Explain what you tried at each prior step — without that, Yaksha cannot help you well. When Yaksha cannot answer, it will flag your query to the team directly and the reply will come back to you through the same chat window. There is no separate ticket-raising page or button — the correct way in is always through Yaksha, after the steps above, and Yaksha will flag your question to the team. (If an email from us ever tells you to type #escalate in the chat for something specific, that also works — it's an older route to the same place, not a separate system.) In a narrow set of cases where chat itself isn't getting you unblocked (see §7.1, for example), we may point you to internship@vicharanashala.ai as an absolute last resort — that is not a general-purpose alternative to the ladder above. WhatsApp support is cancelled. There is no WhatsApp troubleshooting group. Not being on WhatsApp does not put you at any disadvantage — all information goes through the channels above. Unofficial groups are strictly prohibited. Creating, joining, or operating any WhatsApp group, Telegram channel, Discord server, or any other peer-coordinated space involving interns or a subset of interns — or contacting another intern through their personal phone number — is against the code of conduct. Any complaint or report of this will lead to the immediate termination of your internship. You may connect with fellow interns over LinkedIn and email."
+    },
+    {
+      "id": "7.1",
+      "section": "7. Interviews Related",
+      "question": "My interview is not marked as complete on the dashboard — what do I do?",
+      "answer": "A data-sync issue sometimes occurs where the chat session closes but the interview record doesn't update to \"completed.\" The team will check your record and manually mark it as complete if needed. You will be unblocked within 1–2 hours. Apologies for the inconvenience. If you dont hear from us and if your interview continues to be marked incomplete please write to us on internship@vicharanashala.ai"
+    },
+    {
+      "id": "8.1",
+      "section": "8. Certificate",
+      "question": "Does Vicharanashala send a grade report or evaluation to my university for internship credit?",
+      "answer": "Vicharanashala does not send formal evaluation or grade reports to universities — that process is between you and your college. The certificate issued upon completion is the document you can submit to your college or placement office for credit. Whether your college accepts it and how they translate it into a grade is their decision. If your college specifically requires a structured evaluation form or a report on your performance, raise that with them directly — we can provide the certificate and, if earned, a letter of recommendation, but we don't have a process for sending grade reports to universities."
+    },
+    {
+      "id": "8.2",
+      "section": "8. Certificate",
+      "question": "Does the Vicharanashala internship certificate specify whether it was completed online or offline ?",
+      "answer": "The certificate you receive on completing the internship is the same for both tracks. It is issued by Vicharanashala, IIT Ropar, and does not specify whether you completed it online or on campus. The certificate records only that you completed the internship; the mode is not called out separately on the document."
+    },
+    {
+      "id": "8.3",
+      "section": "8. Certificate",
+      "question": "Will the completion certificate be a physical hardcopy or an e-certificate?",
+      "answer": "The completion certificate is issued as an e-certificate — you download it from your dashboard on samagama.in after completing both Bronze and Silver. We do not print and mail physical copies. The certificate is digitally signed and authentic, so it cannot be duplicated. It can also be verified from our database using the number on the certificate."
+    },
+    {
+      "id": "8.4",
+      "section": "8. Certificate",
+      "question": "Is there a WhatsApp group for candidates during the internship?",
+      "answer": "No. See §6.1 for the official communication channels."
+    },
+    {
+      "id": "9.1",
+      "section": "9. Rosetta — your internship journal",
+      "question": "What is Rosetta?",
+      "answer": "Rosetta is your internship journal — a 65-day document, one entry per day, every day, for the full duration of Summership 2026. You write in it daily, keep it privately, and submit it at the end of the internship as one of your completion requirements. The name comes from the Rosetta Stone — discovered in 1799, it carried the same text in three scripts and became the key to decoding an ancient language that had been silent for centuries. Not because it was grand, but because it was honest and consistent. That is what this journal is meant to be for you. Sixty-five days of honest writing will become the key to understanding your own experience — what you learned, where you struggled, what shifted in you."
+    },
+    {
+      "id": "9.2",
+      "section": "9. Rosetta — your internship journal",
+      "question": "Why does this exist? Is it just busywork?",
+      "answer": "No. It exists for two reasons. For you: Most people go through an intense experience and carry it without processing it. They finish and cannot articulate what they actually learned, what changed in them, or what they would do differently. The journal builds that articulation, one day at a time. Students who reflect regularly during a programme consistently get more out of it than those who do not — not because they work harder, but because they understand what they are doing and why. For us: When you submit Rosetta at the end, it gives us qualitative insight into your experience that no survey or evaluation can capture. We use it to understand what worked, what did not, and how to make the programme better for the next cohort. Your honest voice matters to that process."
+    },
+    {
+      "id": "9.3",
+      "section": "9. Rosetta — your internship journal",
+      "question": "What is a \"thinking routine\"?",
+      "answer": "Each day in Rosetta has a thinking routine — a short framework that gives your reflection a specific shape. Instead of staring at a blank page and writing \"today was good,\" the routine gives you a specific lens. Examples: 3-2-1 — 3 things you engaged with, 2 questions on your mind, 1 surprise.Muddy / Clear — what is sharp, and what is still foggy.What? So What? Now What? — separate facts from meaning from action. The routines rotate across the 65 days so the journal does not feel repetitive or mechanical. Some will feel easy. Some will make you stop and actually think. That is the point. You do not need to research the routine or prepare for it. Just read the description at the top of each day's entry and write."
+    },
+    {
+      "id": "9.4",
+      "section": "9. Rosetta — your internship journal",
+      "question": "How do I get my Rosetta journal?",
+      "answer": "The Rosetta template is here: Rosetta Journal — Summership 2026 Open the link, go to File → Make a copy, save it to your own Google Drive, and rename it Rosetta — [Your Name] — Summership 2026. That copy is yours for the full duration of your internship. Do not write in the shared template. Always work in your own copy."
+    },
+    {
+      "id": "9.5",
+      "section": "9. Rosetta — your internship journal",
+      "question": "How do I use it day to day?",
+      "answer": "Simple: Open your Rosetta Google Doc.Scroll to the entry for today's day number.Fill in the date at the top of the entry.Read the thinking routine name and its one-line description.Answer the three prompts in the writing boxes below.Close it and get on with your day. That is it. It should take between 10 and 20 minutes. It is not an essay. It is not a report. It is a journal."
+    },
+    {
+      "id": "9.6",
+      "section": "9. Rosetta — your internship journal",
+      "question": "How long should each entry be?",
+      "answer": "There is no minimum or maximum word count. A good entry is one that is honest and specific. Three to five sentences per prompt is usually enough. If you find yourself writing more because something genuinely needs unpacking, write more. If a day was quiet and you genuinely only have two sentences, that is fine too. What is not acceptable: one-word answers, copy-pasted text, vague non-answers like \"today was productive,\" or anything that reads like it was generated by an AI."
+    },
+    {
+      "id": "9.7",
+      "section": "9. Rosetta — your internship journal",
+      "question": "What is the one rule?",
+      "answer": "Write what is true. Not what sounds impressive. Not what you think we want to read. Not a polished summary of the day. If you hated today, write that. If you are confused and frustrated, write that. If something clicked and you are genuinely excited, write that. We will know immediately if an entry reads like an LLM wrote it. Do not do that. The journal only counts as a completion requirement if it is genuinely yours — in your voice, from your actual experience."
+    },
+    {
+      "id": "9.8",
+      "section": "9. Rosetta — your internship journal",
+      "question": "Can I use ChatGPT or any AI tool to write my entries?",
+      "answer": "No. This is the one firm rule of Rosetta. The journal is a record of your thinking, not a demonstration of what an AI can produce on your behalf. Entries that read as AI-generated will not be counted toward your completion requirement. If your entire journal reads this way, the journal will not be accepted. Use AI tools for your technical work if that is permitted in the programme. Do not use them here."
+    },
+    {
+      "id": "9.9",
+      "section": "9. Rosetta — your internship journal",
+      "question": "What if I miss a day?",
+      "answer": "Fill it in as soon as you can. Write the actual date you are filling it in, not the date of the missed entry. Be honest in the entry about the fact that you are writing it late and why. Do not leave entries blank. A late honest entry is always better than no entry. If you find yourself consistently missing entries, that is worth paying attention to. It usually means something else is going wrong. Use Yaksha in chat, or reach out to your scholar."
+    },
+    {
+      "id": "9.10",
+      "section": "9. Rosetta — your internship journal",
+      "question": "Will anyone read my journal during the internship?",
+      "answer": "No. We will not access your journal during the 65 days. You write it, you keep it, it is yours. The only time we read it is after you submit it at the end of the internship. This is intentional — we want you to write freely, without feeling observed. The journal is only useful if it is honest, and it is only honest if you are not performing for an audience."
+    },
+    {
+      "id": "9.11",
+      "section": "9. Rosetta — your internship journal",
+      "question": "Can the prompts change mid-internship?",
+      "answer": "Occasionally we may update a prompt for a specific day based on what is happening in the cohort — a major milestone, a collective challenge, or something the team wants to address directly. When this happens, we will announce it in the Announcements section on samagama.in before that day begins. Check the Announcements section before filling any entry where a change has been announced. If no announcement has been made, use the prompt as written in your document."
+    },
+    {
+      "id": "9.12",
+      "section": "9. Rosetta — your internship journal",
+      "question": "How do I submit Rosetta at the end?",
+      "answer": "On or before Day 65, share your Rosetta Google Doc with the programme coordinator's email address (shared during wrap-up week). Set the sharing permission to Viewer. Make sure: Your name is in the document title — Rosetta — [Your Name] — Summership 2026.All 65 entries have been filled in.Your cover page has your name, product, and team filled in. Rosetta submission is one of the required criteria for receiving your internship certificate. An incomplete or AI-generated journal will not be accepted."
+    },
+    {
+      "id": "9.13",
+      "section": "9. Rosetta — your internship journal",
+      "question": "I have a question about Rosetta that is not answered here. What do I do?",
+      "answer": "Ask Yaksha first. If Yaksha cannot answer it, escalate to your programme coordinator. Do not sit on a question — the journal works best when you start it right."
+    },
+    {
+      "id": "9.14",
+      "section": "9. Rosetta — your internship journal",
+      "question": "My college requires a written confirmation that the internship is self-paced and will not clash with college classes — what document can I share with them?",
+      "answer": "On the standard track, this is not a self-paced internship, but a very rigorous one that is time demanding. It is not permitted for one to be part of any other activity during this period, so no such confirmation can be issued. If your confirmed start date is after 15 July 2026, you are on the genuinely self-paced / parallel track (see §2.7) — share that section with your college as confirmation instead."
+    },
+    {
+      "id": "10.1",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "I've already completed a course (Vinternship, Pinternship, MERN, or AI) with you in an earlier cohort — am I exempt from repeating it?",
+      "answer": "Yes. If you completed the Vinternship, Pinternship, MERN, or AI course with us in an earlier cohort, you don't have to repeat it. Submit the exemption form and we'll exempt you from that course. What counts as \"completed\"? A course is treated as complete when your ViBe progress is above 95%. We've set the bar just below 100% so you're not chasing the last percentage point. We verify against your ViBe record before confirming. My progress is below 95% — can I still be exempted? No. Below 95% you'll need to finish the remaining portion on ViBe. Once you cross 95%, you're covered. I completed it somewhere else, not on ViBe with VLED — does that count? No. This exemption is only for courses you completed with us. If you're a first-timer confident in your fundamentals, the viva route is a separate option — check the coursework email for details. How will I know my exemption is approved? We verify submissions against ViBe and confirm on your dashboard. No action is needed from you after submitting. Exemption form: https://forms.gle/RWt1v22yVePyZXD79 > Note: Even if you're exempted from a course, live sessions and stand-ups remain mandatory for everyone on the standard track, regardless of exemption status. No exceptions there. The one exception overall is the self-paced / parallel track (confirmed start date after 15 July 2026 — see §2.7), which has no mandatory live sessions at all."
+    },
+    {
+      "id": "10.2",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "How do I register for the AI Fundamentals course on Vibe?",
+      "answer": "Follow these steps: Click the AI Fundamentals registration link posted in the Announcements section on samagama.in at Phase 1 launch.You'll be redirected to the Vibe sign-in page. If you don't have a Vibe account yet, create one using the same Gmail you used to register on Samagama.Log in with your credentials.After logging in, open the course registration link again in your browser — the second click after login is what enrols you.Complete the brief registration form and submit.The course will appear instantly on your Vibe dashboard, ready to watch."
+    },
+    {
+      "id": "10.3",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "I registered on Vibe with a different email than my Samagama email — is that OK?",
+      "answer": "Please use the same email on both platforms so we can match your Phase 1 progress to your internship record. The one exception: Vibe requires a Gmail address for signup. If the email you used on Samagama is not Gmail (e.g. a college email like @xyz.ac.in, @ds.study.iitm.ac.in), you may use any Gmail of yours to register on Vibe. In that case, tell Yaksha in your Samagama chat using the tag: `` #vibe-email your-gmail@gmail.com `` so we can link the records."
+    },
+    {
+      "id": "10.4",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "Are live sessions mandatory if I'm on the viva route?",
+      "answer": "Yes — live sessions are mandatory for every intern on the standard track, regardless of path. Whether you're on the coursework track, MERN-exempt (returning intern), or have cleared the viva and moved to Phase 2, you're expected to attend every live session. The exchange of knowledge across our cohort — diverse streams, varying levels of experience — is something self-paced study cannot replicate. The one exception is the self-paced / parallel track (confirmed start date after 15 July 2026 — see §2.7): live-session attendance does not apply there."
+    },
+    {
+      "id": "10.5",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "When and how do I get the Zoom link for the kickoff meeting?",
+      "answer": "This question applies to the standard, live-session track only (see §2.7). The kickoff orientation was a one-time event held for the main summer cohort at the opening of the 15 May – 15 July 2026 window, delivered through two channels — email to the registered samagama.in address, and the Yaksha chat portal. It is not a recurring event, and recordings are not shared with candidates who started after it. If you're confirming a start date today, this doesn't apply to you at all. Since the live-session window has closed, every new candidate is on the self-paced / parallel track (see §2.7), which has no live kickoff meeting, and no mandatory Zoom sessions of any kind — onboarding happens through your dashboard's four-vertical view instead. If you're an existing live-session-track intern with a Zoom access issue, log in to samagama.in and describe the issue to Yaksha in the chat — Yaksha will flag it for the team."
+    },
+    {
+      "id": "10.6",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "How do I get the link for the daily Zoom standups? Are they mandatory?",
+      "answer": "Daily Zoom standup links are posted in the Announcements section on your samagama.in dashboard — look for the announcement bell at the top of the page. You are expected to check it daily before the session. Session links are posted at least 1 hour before they begin. We do not send separate emails for daily standups. The announcement on your dashboard is the only delivery channel for the daily link. Attending the daily standups is mandatory for all interns on the standard track. This is a full-time summer internship programme, and the daily standup is the primary touchpoint where progress, blockers, and the day's plan are communicated. Missing standups is treated as missing work. Attendance and participation are tracked against strict thresholds — see §10.10. If you're on the self-paced / parallel track (confirmed start date after 15 July 2026 — see §2.7), you're exempt from live Zoom standups entirely. Instead, you complete the Standup vertical asynchronously: 3,600 cumulative minutes of standup participation (tracked live via Spurti), at your own pace. Weekly milestone (bare minimum): 2% — see §2.7. About the kickoff orientation. The kickoff orientation was held for the recommended 15 May cohort (see §10.5). Session recordings are not shared with interns who join late — see §2.6. If you joined late, you are expected to complete the orientation through a special proctored catch-up path on ViBe. The catch-up is entirely proctored and includes quizzes that check whether you have understood the content of the orientation session. Completing this catch-up is mandatory for late starters before participating in the regular standups."
+    },
+    {
+      "id": "10.7",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "How do I provide my Zoom ID, and why does it matter?",
+      "answer": "On your dashboard, just before \"Start the internship,\" you'll see a step called \"Provide your Zoom ID.\" Enter the exact email address linked to your Zoom account — the one you use (or will use) to join the daily live sessions — and save it. This matters because we match your live-session attendance and participation using this email. If the Zoom ID you provide doesn't match the email you actually join Zoom with, your attendance won't be credited to you. So enter it carefully and be sure it is genuinely your Zoom account's email."
+    },
+    {
+      "id": "10.8",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "I saved the wrong Zoom ID — can I change it?",
+      "answer": "Yes — go to your dashboard and look for the lock icon next to your Zoom ID. Click it to unlock the field, update your Zoom email, and save. If you cannot find the toggle or the field is not responding, tell Yaksha your correct Zoom email in the chat and Yaksha will flag it for the team to correct."
+    },
+    {
+      "id": "10.9",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "Can we register and start the vibe courses before our internship date formally starts?",
+      "answer": "You will receive the viBE course link only after your internship starts. You can register and start the viBE courses related to the internship only after your internship formally starts."
+    },
+    {
+      "id": "10.10",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "What are the attendance and participation rules?",
+      "answer": "These rules apply to the standard, live-session track. If you're on the self-paced / parallel track (confirmed start date after 15 July 2026 — see §2.7), none of the below applies to you — you instead complete the Standup vertical asynchronously. Attendance and participation are tracked strictly, and all of the following are measured continuously over a rolling window of the last 5 working days: Live-session attendance — at least 85%. You must be present for at least 85% of the total Zoom meeting time.Live participation — at least 85%. You must respond to the in-session polls on Spandan (see §10.16) and quizzes at least 85% of the times they are run.Quizzes — attempted, and passed. Every quiz must be attempted, and your pass percentage must be at least 50%. Because this is a rolling 5-working-day measure, it reflects your recent engagement, not a one-time average. If any one of these three falls below its threshold, you will be excused from the current batch and moved to the next batch. This is not a penalty — it simply means you rejoin in a later batch where you can give the programme the full attention it needs."
+    },
+    {
+      "id": "10.11",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "What are Spurti Points (SP)? Do they affect my internship?",
+      "answer": "Spurti Points are a platform feature that tracks your engagement with the programme. They are currently in an early beta phase — not used for any decisions about your standing. See Section 11 for the full SP FAQ."
+    },
+    {
+      "id": "10.12",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "What are the live-session (Zoom) participation and conduct rules?",
+      "answer": "Treat every live session as a professional classroom. The following rules apply, and repeated non-compliance may result in removal from a session. Video & visibility Keep your video on at all times unless explicitly permitted otherwise — participants with video off will be removed.Your face must be clearly visible — well-lit, centred in frame, and not rotated or partially cut off. A forehead-only view, poor lighting, or a sideways angle are not acceptable.Do not join from a mobile phone. Use a laptop or desktop. Audio & environment Test your microphone and video using the platform's audio-test feature before the session begins — especially if you plan to speak.Be in a reasonably quiet, well-lit space so you can be seen clearly and participate when called upon. Conduct & attire Dress code: business casuals or neat Indian casuals. Clothing inappropriate for a professional or classroom setting is not allowed.No multitasking. Talking on the phone or with people nearby, and any form of distraction or disengagement, may result in removal. Display name & profile picture Display your full name — first and last. Nicknames or partial names are not acceptable.A professional, clearly identifiable profile picture is strongly recommended. This rule is enforced starting the next session (you have until then to update your display name and picture).Use your professional email account to join wherever applicable. Breaks & reconnection For a short break (e.g. a restroom break), indicate \"BRB\" (Be Right Back) and return promptly. Prolonged absence may result in a permanent ban.Breaks are provided periodically — manage personal needs during them and avoid leaving during instructional segments.If your internet drops and you are moved to the waiting room, you will not be re-admitted. Ensure you have a stable connection — and ideally a backup — before joining. Waiting room Participants who do not follow the session guidelines may be moved to the waiting room. Zoom guidelines apply at all times except during official breaks.Do not call or message the Core Team for re-admission from the waiting room — doing so will result in an SP deduction.If you believe you were moved by mistake, see §10.14 for the dispute process. Speaking effectively Keep responses concise — aim for two to three sentences. Rehearse before unmuting, and always test your mic and video beforehand if you plan to speak. Grounds for removal or a permanent ban: video off, joining from mobile, poor visibility, unprofessional attire, disengagement, extended unexplained absence, non-compliance with display-name/picture rules, or repeated violations of session guidelines."
+    },
+    {
+      "id": "10.13",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "A poll on Spandan didn't count, or I got an error — will I lose poll credit?",
+      "answer": "Polls during live sessions run on Spandan (see §10.16), not on Zoom — so most poll issues have a quick self-fix: \"Too many requests\" when logging in: this happens when a whole class signs in from the same campus/venue Wi-Fi at once and briefly trips a safety limit. Wait about a minute and try again, or switch to mobile data.You're logged in, but can't submit an answer / it says your session expired: log out and log back in. This refreshes your session and does not affect your account or points.A question didn't show up, or you think you missed one: refresh the page — you'll rejoin automatically and catch the next question. A question that opened and closed while you were disconnected genuinely can't be answered afterward (you'll only see it in the results) — this is by design, not a bug.Your answer \"didn't count\": the most common reason is missing the second step — you must tap your option and press Submit, both before the timer ends. Selecting an option without pressing Submit means it was never sent.A poll showed 0% or \"no correct answer\": occasionally a question is set up without a marked correct answer. Your response is still recorded — there's nothing wrong on your side. If none of the above explains it — a genuine platform error at the moment you tried to submit — report it via Yaksha chat with the session date, approximate poll time, and exactly what happened. The team will cross-check session logs and manually note poll credit if a platform error is confirmed. You will not be penalised for a documented error, but must report it promptly (same day or the next morning at the latest)."
+    },
+    {
+      "id": "10.14",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "I was moved to the waiting room — what should I do if I think it was a mistake?",
+      "answer": "Zoom session guidelines are enforced throughout the session, except during official breaks. If you are not following the guidelines, you may be moved to the waiting room. You will not be re-admitted. If you believe you were moved by mistake, you can dispute it: Share a complete screen recording of the session — from the time you joined until you were moved to the waiting room — showing that you were following all guidelines.Submit it to the Core Team for review via the Discussion Forum or by raising an escalation through Yaksha. Our team will review the recording and assist you accordingly. Disputes without a recording cannot be considered."
+    },
+    {
+      "id": "10.15",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "How do I submit my Phase 1 (CSFAQ) project?",
+      "answer": "Phase 1 project submission is done through the Submit Project button on your Samagama dashboard, which appears once your internship has started. You will raise one or more Pull Requests (PRs) on the official CSFAQ repository and submit the PR ID(s) raised, along with your product documentation and project report."
+    },
+    {
+      "id": "10.16",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "What is Spandan, and how do I register and join a live poll?",
+      "answer": "Spandan (https://spandan.fun/spandan/) is our live classroom polling platform — it's what your \"poll participation\" (see §11.11) is scored from during mandatory sessions. It works alongside Zoom: Zoom carries the video/audio, Spandan carries the polls, in a separate browser tab. You can get to it two ways — both are the same site: the \"Spandan\" pill at the top of your Samagama dashboard (next to Spurti Points), or directly at https://spandan.fun/spandan/. Either way you'll see the same login/registration screen — opening it from the dashboard does not sign you in automatically. Register once, using your registered Samagama email id — not a personal email. Spandan emails a 6-digit verification code (OTP); enter it to finish. Always log in with that same email so your history and points stay together.Join a session: once the host starts the session, they'll share a room code. Choose Join, type the code exactly as given, and confirm. For sessions with a YouTube Live overflow (e.g. once Zoom capacity is full), the room code and the YouTube Live link are also posted in the Announcements section of your Samagama dashboard, usually shortly before the session starts.Answer a poll: questions appear live as the host launches them. Tap the option you think is correct, then press Submit — both steps, before the timer runs out. Selecting an option without pressing Submit does not send it.Correct answers and results are shown after the poll closes (and in the end-of-session summary), not the moment you submit — this is intentional, to keep things fair. Your answer is still recorded and scored as soon as you press Submit. If you didn't receive the OTP: check Spam/Junk/Promotions, confirm you typed your Samagama email correctly, and use Resend code (60-second wait between resends)."
+    },
+    {
+      "id": "10.17",
+      "section": "10. Phase 1 — coursework, Vibe LMS, and live sessions",
+      "question": "I think I have two Spandan accounts and my points are split — what do I do?",
+      "answer": "Always sign in with your Samagama email id, the same one every time. If you registered with a different email, or registered twice by mistake, report it via Yaksha chat so the team can help sort it out. How to submit: Raise your PR(s) on the official CSFAQ repository: github.com/vicharanashala/crowd-source-faq.Enter the PR number(s) you raised in the PR ID(s) Raised field — separate multiple PR numbers with commas (e.g. 123 or 123, 145, 167). Along with the PR ID(s) you will also need to upload: Product documentation — your Product.md or README.md (PDF or Markdown, max 10 MB).Project report — a PDF prepared using the report template shared with you (must include a Feature Spotlight section). One submission per student. Submissions cannot be changed after they are submitted, so review everything carefully before clicking Submit Project."
+    },
+    {
+      "id": "11.1",
+      "section": "11. Spurti Points",
+      "question": "What are Spurti Points?",
+      "answer": "Spurti Points, or SP, are a points layer on the platform that reflects your overall engagement with the programme. Think of SP as an indicator of your engagement — nothing more. It is not a score that defines you as a student or determines your future in the programme."
+    },
+    {
+      "id": "11.2",
+      "section": "11. Spurti Points",
+      "question": "Is SP a finished system?",
+      "answer": "No. Spurti Points are still being actively built and refined. SP is best understood as a work in progress rather than a finalised grading or evaluation system. The rules and calculations may evolve as the programme develops."
+    },
+    {
+      "id": "11.3",
+      "section": "11. Spurti Points",
+      "question": "How much importance should I give to my SP number?",
+      "answer": "Please do not read too much into the number. SP is an early beta feature. It is meant to give you a broad sense of your engagement, not to measure your performance or determine outcomes."
+    },
+    {
+      "id": "11.4",
+      "section": "11. Spurti Points",
+      "question": "Can I be terminated or excused because of low SP?",
+      "answer": "No. The programme team will not terminate, excuse, or take any decision about any intern on the basis of Spurti Points alone. SP is not used as a basis for such decisions."
+    },
+    {
+      "id": "11.5",
+      "section": "11. Spurti Points",
+      "question": "What if my SP shows as zero or even negative?",
+      "answer": "There is genuinely no cause for concern. A zero or negative SP balance does not mean you are in trouble with the programme. Because SP is in an early beta phase, the number may not always reflect your actual effort or attendance accurately."
+    },
+    {
+      "id": "11.6",
+      "section": "11. Spurti Points",
+      "question": "Does a higher SP bring any benefits?",
+      "answer": "Yes, in a positive way. Interns who build up higher Spurti Points may, from time to time, become eligible for small perks or recognition from the programme team. Think of a higher SP as a pleasant upside to aim for. SP is not used to punish you for a low number or to decide your standing — the one exception is that a mentor may deduct SP for clearly non-compliant behaviour (for example, disrupting a live session or ignoring session conduct rules). That is a deliberate response to conduct, not the same as the beta number simply being low."
+    },
+    {
+      "id": "11.7",
+      "section": "11. Spurti Points",
+      "question": "If SP does not determine outcomes, what does?",
+      "answer": "Your attendance and live participation are what the programme watches closely and tracks strictly — on the standard, live-session track. (The self-paced / parallel track, see §2.7, has no live-session attendance requirement at all.) A low SP number is not a cue to ease off. The programme has clear participation requirements that are monitored independently of SP (see §10.10 for the exact thresholds)."
+    },
+    {
+      "id": "11.8",
+      "section": "11. Spurti Points",
+      "question": "What are the participation requirements tracked strictly?",
+      "answer": "This applies to the standard, live-session track only — see §2.7 if you're on the self-paced / parallel track instead. Looking at your most recent five working days on a rolling basis, every intern (on the standard track) is expected to meet all three of the following: Stay present for at least 85% of the total live Zoom session time.Respond to at least 85% of the polls and quizzes run during the sessions.Attempt every quiz and clear each with a score of at least 50%. All three requirements apply simultaneously. Falling short on even one of them counts."
+    },
+    {
+      "id": "11.9",
+      "section": "11. Spurti Points",
+      "question": "What does \"rolling basis\" mean?",
+      "answer": "The programme does not look at a single average across the entire duration. Instead, it looks at your most recent five working days at any given point in time. As each new working day passes, the oldest day drops out and the newest day is added. This means your recent, consistent engagement is what counts — not a strong performance in one week followed by long absences. The window keeps moving forward."
+    },
+    {
+      "id": "11.10",
+      "section": "11. Spurti Points",
+      "question": "What happens if I fall below the required participation level?",
+      "answer": "(This applies to the standard, live-session track — see §2.7 for the self-paced / parallel track, which isn't subject to this.) If any one of the three participation requirements slips below the mark across your most recent five working days, you will be moved from the current batch into a later batch. This is not a termination or an excusal from the programme. It is a practical step so you can rejoin when you are able to give the programme your full attention. To rejoin, you must upload revised documents reflecting your new internship dates: Update your internship dates on the dashboard to match your new batch window.Upload a fresh NOC from your HOD covering the revised period — the dates on the NOC must match the dates on your dashboard exactly. Your previous NOC and confirmed dates are tied to the batch you were excused from and cannot be carried forward. A new offer letter will be issued once your revised documents are verified."
+    },
+    {
+      "id": "11.11",
+      "section": "11. Spurti Points",
+      "question": "How are Spurti Points calculated?",
+      "answer": "Every intern starts with a base of 100 SP credited on their official internship start date. SP is then earned through two live-session activities — attendance and poll participation — scored independently for every mandatory morning session: A. Attendance Time present (% of session window)SP earned90% or more+10 SP 75% – 89%+5 SP 50% – 74%+3 SP Below 50%0 SP B. Poll participation (on Spandan — see §10.16) Polls answered (% of polls launched)SP earned90% or more+10 SP 75% – 89%+5 SP 50% – 74%+3 SP Below 50%0 SP A few things to note: Both A and B are scored per session and summed across all mandatory sessions attended since your start date.There is no penalty for absence — missing a session earns 0 for that day, not a deduction.Only the mandatory standup / orientation session (the one flagged mandatory in that day's announcement — 9:00–11:00 AM IST through 15 July 2026, 8:00–9:00 PM IST from 16 July 2026 onward) counts. Breakouts, weekend specials, NPTEL/special sessions, and other non-mandatory sessions (including the optional evening motivation/stand-up session) do not contribute to A or B.SP is updated daily. You can see your current balance and a full transaction history on the portal at samagama.in. Important: SP is a reward and recognition feature — it is not used by the programme team to judge your engagement, and it plays no role in excusal decisions. Excusal is determined from raw Zoom attendance logs, independently of SP. A low or zero SP number has no bearing on your standing in the programme."
+    },
+    {
+      "id": "11.12",
+      "section": "11. Spurti Points",
+      "question": "Can the programme team award or deduct SP directly?",
+      "answer": "Yes. In addition to the automatic daily rubric, programme team members can manually award or deduct Spurti Points at their discretion. This is used to: Recognise good behaviour — helping peers, exceptional contributions during sessions, or going above and beyond programme expectations.Acknowledge cohort-protocol adherence — following session etiquette, forum norms, or other community guidelines exceptionally well.Apply conduct deductions — as a deliberate response to disruptive or non-compliant behaviour (for example, repeatedly violating session conduct rules or pestering the core team unnecessarily). Every manual award or deduction is permanently logged in the SP ledger with the awarding team member's identity and a justification note. You can see all entries — including manual ones — in your SP transaction history on the portal. This does not change the excusal threshold. Excusal is determined solely from raw Zoom attendance logs. A manual SP deduction cannot lead to excusal; it is a recognition/conduct signal, not a standing decision."
+    },
+    {
+      "id": "12.1",
+      "section": "12. Yaksha Chat Related",
+      "question": "I'm unable to type in the chat after clicking 'Interact with Yaksha' — what should I do?",
+      "answer": "The chat input is only active after you have clicked the \"Interact with Yaksha\" button. If you are still unable to type, scroll up to the top of the page — the button may be above the visible area. Click it once, and the chat field will become active."
+    },
+    {
+      "id": "13.1",
+      "section": "13. ViBe Platform",
+      "question": "How do I log in to ViBe?",
+      "answer": "Link for the website: https://vibe.vicharanashala.ai/authSign up as a student with the registered mail ID into the ViBe platform.To log in to the ViBe platform, follow the steps below carefully: ``` Log in to the ViBe platform as a student from registered email IDCheck the \"Notifications\" tab in the Top right side of the Dashboard.Accept the course invite sent for your respective MERN Course. ``` ⚠️ Logging in with a different email ID may result in access issues or missing course visibility."
+    },
+    {
+      "id": "13.2",
+      "section": "13. ViBe Platform",
+      "question": "Invite accepted but shows \"No course enrolled\"?",
+      "answer": "If you see \"No course enrolled\": Make sure you are logged in with the correct registered email ID.Check if your college email has multiple aliases and try the correct one.Log out and log in again once.Use personal wifi instead of college wifi as there might be some network restrictions of access.If the issue continues, please follow these steps: Step 1: Allow Third-Party Cookies Enable Cookies in Chrome: Open chrome://settings/cookies. Turn OFF \"Block third-party cookies\" and turn ON \"Allow all cookies.\"Add Site Exception: Scroll to \"Sites that can always use cookies\" and click \"Add.\" Paste .vicharanashala.ai and ensure \"Including third-party cookies\"* is enabled.Restart browser. Step 2: Fix DNS (Most Important) Change your laptop DNS to Google DNS.Go to: Control Panel → Network → Active Network → Properties → IPv4.Shortcut: Win + R → ncpa.cpl → right-click properties.Set Preferred DNS to 8.8.8.8 and Alternate DNS to 8.8.4.4.Save. Step 3: Flush Old DNS Cache (it's safe) Open Command Prompt as Admin.Run the following commands:ipconfig /flushdnsipconfig /releaseipconfig /renewRestart WiFi."
+    },
+    {
+      "id": "13.3",
+      "section": "13. ViBe Platform",
+      "question": "Why are videos stuck or repeating?",
+      "answer": "This may happen due to ViBe's monitored learning system. Common reasons include: Videos must be watched fully and in sequence (no skipping).Camera and microphone permissions must be enabled.Poor lighting or high background noise can affect playback.Switching tabs or staying idle may restart the video. ✅ For smooth playback, stay on the ViBe tab, keep your camera on, and watch videos in a quiet, well-lit environment."
+    },
+    {
+      "id": "13.4",
+      "section": "13. ViBe Platform",
+      "question": "Can I use a mobile or tablet?",
+      "answer": "No, only desktop/laptop is supported."
+    },
+    {
+      "id": "13.5",
+      "section": "13. ViBe Platform",
+      "question": "I'm experiencing video issues (stuck, looping, skipping) on ViBe. How do I troubleshoot?",
+      "answer": "Try these troubleshooting steps in order: Refresh the page and check multiple timesInspect browser console: Right-click → Inspect → Go to Network or Console tab → Try watching the video and check for any visible errorsLog out and log in againUse a different browserClear browsing data and cache, then try to re-login If the issue persists after trying all steps, record the issue and describe it to Yaksha in the chat — Yaksha will escalate it to the team."
+    },
+    {
+      "id": "13.6",
+      "section": "13. ViBe Platform",
+      "question": "I have completed all videos and quizzes in the ViBe course, but my progress is still showing less than 100%. What should I do?",
+      "answer": "Please do not worry. This might be a skip made in the quiz/video item due to penalty score as the quiz/video item might not have been successfully completed/marked. Please verify that you've completed all the course items (1006/1006). If not, please retry the missed contents again. In the meantime, you may try the following steps once: Refresh your browserLog out, clear your browser cache, and log in again"
+    },
+    {
+      "id": "13.7",
+      "section": "13. ViBe Platform",
+      "question": "I feel the ViBe content or platform is not good or I am unhappy with the way progress is evaluated. Can I request an exception or bypass the system?",
+      "answer": "ViBe is built and continuously improved by interns and students themselves. It is a free and open-source learning platform, and our goal is to keep it that way by encouraging the community to actively contribute, improve, and strengthen it rather than bypass it. If a learner strongly feels that the regular ViBe flow does not fairly reflect their understanding, there is a formal alternative evaluation path. However, this path is intentionally rigorous to ensure fairness for everyone. In such cases, you will be asked to: Watch the specified YouTube video content completely (links will be provided).Appear for a three-hour proctored examination based only on that content.Write the exam under strict supervision with:Two cameras (front and side view), andOne online human proctor monitoring you live. This examination becomes the sole basis for evaluation in place of the regular internship track. The scoring rules are strict: Score below 60%: You are considered not qualified and must join the next cohort and continue only through the normal ViBe mode.Score between 60% and 80%: You get one more chance in the next scheduled exam.Score above 80%: You are considered to have passed. This special exam is conducted once every fortnight, so choosing this route may significantly delay your progress compared to continuing normally on ViBe. Because this path is far more demanding and time-consuming than simply completing the regular videos, quizzes, and activities, most students find that continuing with the standard ViBe workflow is the faster and better option."
+    },
+    {
+      "id": "13.8",
+      "section": "13. ViBe Platform",
+      "question": "Is the ViBe consent form compulsory? What if I don't want to grant camera access?",
+      "answer": "Yes — the consent form is compulsory. We would like to clearly inform you that providing consent is a mandatory requirement for any candidate enrolling in and continuing a course on the ViBe Learning Platform. The platform is designed with proctoring enabled throughout the learning process, which requires access to your webcam and microphone. This is essential to ensure: Fairness across all participantsAcademic integrityActive and genuine participation If you choose not to grant camera and microphone access, you will not be able to proceed with the course, as proctoring is an integral part of the learning and evaluation workflow. Privacy & Monitoring Clarification As outlined in the consent form: ViBe does not continuously record videos.Proctoring operates via real-time monitoring mechanisms during learning and assessments.All data is handled strictly in accordance with the stated consent terms and applicable data-protection guidelines. In short, consent is not optional — it is a core requirement for participation on the platform."
+    },
+    {
+      "id": "13.9",
+      "section": "13. ViBe Platform",
+      "question": "What are penalty scores on the ViBe platform, and how do they affect our performance or HP?",
+      "answer": "Penalty scores are generated when anomalies are detected during your activity on the ViBe platform (for example, irregular behavior while watching video lessons or attempting quizzes). If the penalty score becomes high, you may be required to: Rewatch the video lesson, andRetake the associated quiz. At present, these penalty scores do not impact your HP (Health Points) or overall performance evaluation, as they are not being considered for scoring. Their primary purpose is to ensure proper engagement with the learning content."
+    },
+    {
+      "id": "13.10",
+      "section": "13. ViBe Platform",
+      "question": "When should I use the Flag option on ViBe, and when should I contact support?",
+      "answer": "Use the Flag feature on ViBe only for course content-related issues, such as problems with video content or quiz questions. For technical issues, platform errors, login problems, or logistics-related queries, do not use the flag option. Instead, contact Yaksha so the team can assist you faster. Using the correct method helps resolve issues quickly and keeps the learning process smooth for everyone."
+    },
+    {
+      "id": "13.11",
+      "section": "13. ViBe Platform",
+      "question": "What is Linear Progression on ViBe?",
+      "answer": "Linear progression is enabled for every course on ViBe. This means each learner must watch the videos and attempt the quizzes in the exact order they appear on the left panel of the course page. In practice: You cannot click on a video or quiz that lies far ahead of your current position.You must complete each item before the next one unlocks.Skipping videos or quizzes is not allowed by design. Progress is sequential — finish the item in front of you, and the next one opens up automatically."
+    },
+    {
+      "id": "13.12",
+      "section": "13. ViBe Platform",
+      "question": "Can I use the left navigation panel to jump ahead to a later video or quiz?",
+      "answer": "No. Although the left navigation panel displays the full list of items in your course, it is meant only as a progress map — not as a jump-to-anywhere menu. Instead of clicking through the left panel: Click Next Quiz or Next Lesson as it appears on the right panel.Let the platform unlock items for you in sequence as you complete each one. Trying to skip ahead through the left panel will simply trigger the Access Restricted alert (see 13.13)."
+    },
+    {
+      "id": "13.13",
+      "section": "13. ViBe Platform",
+      "question": "I am seeing a red \"Access Restricted\" banner. Is this a bug?",
+      "answer": "No, this is not a bug. The red Access Restricted banner is an intentional alert from the platform. The banner looks like this: a red toast notification with an exclamation icon, the title \"Access Restricted\", and the message \"Returning to previous valid content.\" below it. It appears when you try to open an item (video or quiz) before completing all the items that come before it. If you are on the nth item but haven't completed every video and quiz from item 1 through item n−1, the platform will show this alert. When the banner appears, ViBe automatically returns you to the previous valid content — that is, the last item you had legitimately reached in the sequence. You will not lose any progress; you'll simply be sent back to where you actually are in the course. It is the system gently telling you: \"Please check — there is something earlier in the course that you haven't finished yet.\""
+    },
+    {
+      "id": "13.14",
+      "section": "13. ViBe Platform",
+      "question": "How do I resolve the \"Access Restricted\" error?",
+      "answer": "Follow these steps in order: Go back to the left panel and scroll through your course items from the beginning.Look for any item without a completion tick — that is your missed video or quiz.Complete that item (watch the full video, or attempt and submit the quiz).Refresh the page once you've completed all earlier items.If the Access Restricted banner still appears after refreshing and you are sure all earlier items are completed, describe the issue to Yaksha in the chat — Yaksha will escalate it to the team. In the large majority of cases, simply finding and completing the missed item clears the alert."
+    },
+    {
+      "id": "13.15",
+      "section": "13. ViBe Platform",
+      "question": "Why does ViBe sometimes make me re-watch a clip after a quiz?",
+      "answer": "If your answer to the check-in quiz didn't go through correctly, ViBe will take you back to the same clip and let you try again. This is called a re-watch, and it is part of the design — not a penalty. A few things to keep in mind: Re-watches are not recorded against you. They do not affect your HP or evaluation.The clips are short, so a re-watch usually costs less time than guessing through multiple retries.Think of the re-watch as the platform helping the idea actually stick before you move on, rather than scolding you for getting it wrong."
+    },
+    {
+      "id": "13.16",
+      "section": "13. ViBe Platform",
+      "question": "What kinds of quiz questions will I see on ViBe?",
+      "answer": "ViBe quizzes come in four formats: FormatWhat it looks likeWhat to doPick one (MCQ)One right answer out of four or so optionsRead all the options before clicking Pick one or more (MSQ)\"Select all that apply\" — could be one correct option or severalRead each option carefully; small mistakes happen here most Type a number (NAT)A text box asking for a numeric valueType just the number — no units or extra symbols, unless the question explicitly asks True or FalseA statement with only two options — True or FalseRead the statement carefully; a single word like \"always,\" \"never,\" or \"only\" can flip the correct answer A small tip: watch the clip first, then answer. Trying to read the question while the clip is still playing splits your attention."
+    },
+    {
+      "id": "13.17",
+      "section": "13. ViBe Platform",
+      "question": "Are the same proctoring rules applied to every course on ViBe?",
+      "answer": "No — and this is one of the most important things to understand before reading the rest of this section. ViBe's proctoring system is modular. Each individual check — face visibility, single-face-in-frame, lighting, background voices, gaze on screen, camera/microphone access — can be independently switched on or off by the instructor for a given course or cohort. This means: The instructor decides which proctoring elements are active for their course.Some courses may run with all checks active (typical for internships, faculty FDPs, and credentialed programmes).Other courses may run with only a subset active — for example, face visibility on but background-voice detection off — depending on the learning context.Certain pilot or open courses may have most proctoring relaxed, especially where the focus is exploration rather than verified evaluation. The FAQs that follow (13.18 through 13.23) describe the full set of proctoring behaviours the platform is capable of. They are written as if everything is switched on. **Whether a specific check applies to your course depends entirely on what your instructor has enabled for that course.** ⚠️ Please do not assume rules carry across courses. A relaxation given in one course (for example, allowing two faces in frame for a paired-learning module) does not transfer to another course on the same platform. Always check the course-specific guidelines shared by your instructor or programme team before each course you join. When in doubt, ask your instructor or programme coordinator which proctoring elements are active for your current course."
+    },
+    {
+      "id": "13.18",
+      "section": "13. ViBe Platform",
+      "question": "What does the \"quiet helper\" on ViBe actually do?",
+      "answer": "While a lesson plays, a small helper runs gently on your device using your camera and microphone. It checks, in real time, that the basic conditions for learning are present. Specifically, it looks at five things: A face is visible — to confirm you are really there.Only one face is in frame — to confirm the learning is yours.There is enough light on your face — a silhouette is hard to recognise.The room isn't full of voices — no talking, TV, or background podcasts.You are looking at the screen — brief glances away are fine; long stretches feel like drifting off. The helper is not a judge. Brief, normal movements (a stretch, a sneeze, a glance at your notebook) are absolutely fine. It only pays attention to sustained patterns, not split-second things."
+    },
+    {
+      "id": "13.19",
+      "section": "13. ViBe Platform",
+      "question": "Does ViBe record long videos of me while I'm learning?",
+      "answer": "No. ViBe does not continuously record videos of you. The camera and microphone are used for real-time presence checks only.Long recordings of your face or voice are not stored.When the lesson ends, the helper goes quiet too.All data is handled strictly in accordance with the consent terms shown when you signed up. Think of the helper as a quiet study partner sitting beside you — there if needed, invisible otherwise."
+    },
+    {
+      "id": "13.20",
+      "section": "13. ViBe Platform",
+      "question": "What is the single most common avoidable mistake learners make?",
+      "answer": "Sitting with a window directly behind you during the day. The room may feel bright to you, but your camera only sees a dark silhouette where your face should be. The helper then struggles to confirm your presence, and your lesson may pause or rewind. The fix is simple: move so the window is to your side or in front of the laptop, not behind you. A lamp placed in front of you works just as well in the evening."
+    },
+    {
+      "id": "13.21",
+      "section": "13. ViBe Platform",
+      "question": "Why does the lesson keep pausing or restarting even when I'm paying attention?",
+      "answer": "If a clip keeps stopping or going back to the start, the cause is almost always something small in your environment, not the platform itself. Run through this checklist: Your face is too dark → add a lamp in front of you.Your face is partly out of frame → raise the laptop or sit a bit closer to the camera.There are voices in the background → close the door, or move to a quieter room.You switched tabs or went idle → stay on the ViBe tab; take breaks between clips, not during them.Camera or mic permission dropped → check the lock icon in your browser's address bar and confirm both are set to \"Allow\"."
+    },
+    {
+      "id": "13.22",
+      "section": "13. ViBe Platform",
+      "question": "Can I read the quiz questions aloud or mutter to myself while watching?",
+      "answer": "It's best not to. The microphone listens for sustained voices in the room, and reading aloud, muttering, or asking a roommate \"wait, what was that?\" can all be picked up as anomalies. The simple habit is: watch in silence, answer in silence, and chat freely during your breaks between clips."
+    },
+    {
+      "id": "13.23",
+      "section": "13. ViBe Platform",
+      "question": "Can I study with a friend on camera since we're learning together?",
+      "answer": "In most courses, no. Only you — the registered Learner — should be in the camera frame during a lesson. The helper checks that exactly one face is visible at a time. Group study is genuinely a wonderful habit, just not inside a ViBe session itself. A good way to do it: Hop on a separate call with your friend on your phone or a second device.Discuss concepts before or after a ViBe lesson, not during it.Return to ViBe alone when you're ready to watch the clip and attempt the quiz. > 📌 Note: As explained in 13.17, the single-face-in-frame check is an instructor-controlled setting. A few courses (typically paired-learning or collaborative pilots) may explicitly relax this rule. Do not assume that relaxation in one course applies to another — even on the same platform with the same login. Always default to studying alone unless your instructor has clearly stated otherwise for that specific course."
+    },
+    {
+      "id": "13.24",
+      "section": "13. ViBe Platform",
+      "question": "Will I lose my progress if I clear my browser or reinstall it?",
+      "answer": "No. Your progress is saved on the server, tied to your registered email — not on your browser or your computer. So: Refreshing the page, clearing cache, switching browsers, or even reinstalling your browser will not wipe your progress.The moment you log back in with the same registered email, all your completed clips and quizzes will be exactly where you left them. When in doubt: log out, log back in."
+    },
+    {
+      "id": "13.25",
+      "section": "13. ViBe Platform",
+      "question": "Is there a recommended daily learning rhythm on ViBe?",
+      "answer": "Yes — small, regular sessions work far better than long marathon sessions. A practical rhythm: Show up daily, even if only for thirty minutes. Daily consistency beats a five-hour weekend cram.Take breaks between clips, not during them. A clip is short — finish it first.Treat each quiz as a gentle check-in, not a high-stakes test.For programmes with deadlines (such as internships or faculty cohorts), aim for the daily progress target announced by your programme team — typically around 3.33% per day. > 📌 A note on milestones: The pacing above is a general guideline only. For any specific programme (Vinternship cohort, faculty FDP, NPTEL internship, institutional pilot, etc.), the actual milestones, deadlines, and weekly progress targets will be announced by your instructors or programme team. Always follow the milestone schedule communicated for your specific cohort — that takes precedence over the general guidance here."
+    },
+    {
+      "id": "13.26",
+      "section": "13. ViBe Platform",
+      "question": "What should my \"study corner\" look like before I start a ViBe session?",
+      "answer": "A ViBe-friendly study spot needs only three things: Light in front of your face — a lamp or window facing you, never behind.Just you in the camera frame — ask family, friends, or pets not to wander through.A reasonably quiet room — no TV, no music with words, no one else on a call nearby. Two minutes of setup before you start saves a lot of small frustrations during the lesson."
+    },
+    {
+      "id": "13.27",
+      "section": "13. ViBe Platform",
+      "question": "I'm facing a technical issue on ViBe that I can't resolve. Is there live support available?",
+      "answer": "Yes. A Live Support Breakout Session is held every day from 9:00 PM to 9:30 PM, right after the daily standup. If you are facing any platform issue on ViBe — videos not loading, progress not updating, access errors, login problems, or anything else you cannot resolve on your own — join the breakout session and the support team will assist you in real time. This is the fastest way to get a ViBe issue resolved. Please attempt the self-troubleshooting steps in §13.5 first, then bring the issue to the 9 PM session if it persists."
+    },
+    {
+      "id": "14.1",
+      "section": "14. Team Formation",
+      "question": "Is team formation compulsory?",
+      "answer": "No. You can work solo on the FAQ Crowdsourcing project (Phase 1) and on your Phase 2 project — teaming up is offered, not required. This also holds for the self-paced / parallel track's Projects vertical (see §2.7) — you can do it standalone or with a team, same optionality as the standard track."
+    },
+    {
+      "id": "14.2",
+      "section": "14. Team Formation",
+      "question": "What is the size of a team?",
+      "answer": "Two different things, so read carefully: going solo (1 person) is always a complete, valid option — see §14.1, there's no requirement to team up at all. But if you do team up rather than go solo, Phase 2 project teams have an effective floor of four members — see §14.6, teams smaller than that get expanded, they aren't left as-is. Team size otherwise isn't rigidly fixed: around 10 members is common for the Phase 1 FAQ Crowdsourcing team, and Phase 2 teams can have up to 5."
+    },
+    {
+      "id": "14.3",
+      "section": "14. Team Formation",
+      "question": "How are teams formed?",
+      "answer": "For students who joined on May 15 and 16: Teams were formed through a structured activity.For students joining later: Teams will be randomly assigned by the administration."
+    },
+    {
+      "id": "14.4",
+      "section": "14. Team Formation",
+      "question": "I started on May 15/16 but couldn't form a team during the activity. What happens now?",
+      "answer": "You will be randomly assigned to a team."
+    },
+    {
+      "id": "14.5",
+      "section": "14. Team Formation",
+      "question": "There was a typo in our email addresses during team formation. Can we fix it?",
+      "answer": "No action is required from your side. The administration will verify and match email IDs with names before finalizing and locking teams."
+    },
+    {
+      "id": "14.6",
+      "section": "14. Team Formation",
+      "question": "I formed a team with only two members. Will it be considered?",
+      "answer": "No. Teams with fewer than four members will be expanded by adding additional members to make a final team of four."
+    },
+    {
+      "id": "14.7",
+      "section": "14. Team Formation",
+      "question": "What if a team member leaves or becomes ineligible during Phase 1?",
+      "answer": "The administration will attempt to assign a replacement member.If no replacement is found, you may continue as a team of three.You must inform the admin immediately, or the change will not be recognized."
+    },
+    {
+      "id": "14.8",
+      "section": "14. Team Formation",
+      "question": "Can I form a team with someone from my own college?",
+      "answer": "No. Teams must consist of members from different institutions to encourage networking. Exception: Students from the same institution but different campuses/locations may be allowed."
+    },
+    {
+      "id": "14.9",
+      "section": "14. Team Formation",
+      "question": "Can I form a team with students from my IIT MBS cohort?",
+      "answer": "No. You are encouraged to collaborate with participants outside your existing cohort."
+    },
+    {
+      "id": "14.10",
+      "section": "14. Team Formation",
+      "question": "Can we change our team name after submission?",
+      "answer": "Yes, team names are tentative and can be changed. However, due to operational constraints, frequent changes are discouraged."
+    },
+    {
+      "id": "14.11",
+      "section": "14. Team Formation",
+      "question": "What if multiple teams choose the same name?",
+      "answer": "Teams will be distinguished using suffixes (e.g., Team X-1, Team X-2, etc.)."
+    },
+    {
+      "id": "14.12",
+      "section": "14. Team Formation",
+      "question": "What should I do if I face issues within my team?",
+      "answer": "Report any concerns immediately to your assigned scholar/mentor. Maintaining a safe and respectful environment is a priority."
+    },
+    {
+      "id": "14.13",
+      "section": "14. Team Formation",
+      "question": "How will I know who my mentor is?",
+      "answer": "Your mentor will be the scholar assigned to the project your team is working on."
+    },
+    {
+      "id": "14.14",
+      "section": "14. Team Formation",
+      "question": "When will I know my team details?",
+      "answer": "Team details are announced in the Announcements section on samagama.in. Log in and check regularly during working hours."
+    },
+    {
+      "id": "14.15",
+      "section": "14. Team Formation",
+      "question": "I received a team list email but my name is not included. What should I do?",
+      "answer": "Team announcements are phased, so your name may appear in a later list.If your entire cohort has moved to team activities and you are still unassigned, raise the issue on Yaksha or contact a scholar."
+    },
+    {
+      "id": "14.16",
+      "section": "14. Team Formation",
+      "question": "We selected Project X as our top priority but were assigned Project Y. Can we change it?",
+      "answer": "No. Project assignments are final and cannot be changed. Allocation is done to ensure balanced distribution across projects."
+    },
+    {
+      "id": "14.17",
+      "section": "14. Team Formation",
+      "question": "I just started the internship. Can I form my own team now?",
+      "answer": "No. For later cohorts, teams will be randomly assigned. Please wait for the official communication."
+    },
+    {
+      "id": "14.18",
+      "section": "14. Team Formation",
+      "question": "When do team activities begin?",
+      "answer": "Team-based work begins in Phase 2. During Phase 1 (online coursework), you do not need to worry about team activities."
+    },
+    {
+      "id": "14.19",
+      "section": "14. Team Formation",
+      "question": "Can I request a specific teammate after teams are assigned?",
+      "answer": "No. Team assignments are final and requests for changes are not entertained."
+    },
+    {
+      "id": "14.20",
+      "section": "14. Team Formation",
+      "question": "What happens if a team member is inactive or not contributing?",
+      "answer": "You should report the issue to your mentor/scholar early. Prolonged inactivity may lead to administrative intervention."
+    },
+    {
+      "id": "14.21",
+      "section": "14. Team Formation",
+      "question": "Can I switch teams if there are conflicts?",
+      "answer": "Team switches are not allowed except in exceptional, admin-approved cases involving serious concerns."
+    },
+    {
+      "id": "14.22",
+      "section": "14. Team Formation",
+      "question": "Will team performance affect individual evaluation?",
+      "answer": "Yes. While some components may be individual, team deliverables are a key part of evaluation."
+    },
+    {
+      "id": "14.23",
+      "section": "14. Team Formation",
+      "question": "How will communication happen within teams?",
+      "answer": "Teams self-organise internal coordination over LinkedIn or email only, limited to their own team members. WhatsApp is not encouraged for team coordination — and it is not permitted to create a team WhatsApp group (a four-person project team is still a \"subset of interns\", which is prohibited under §6.1; a group of that form, if reported, will lead to immediate termination of the internship). Official programme updates continue to come through the Announcements section on samagama.in and Yaksha chat — see §6.1 for the full communication policy."
+    },
+    {
+      "id": "14.24",
+      "section": "14. Team Formation",
+      "question": "What if I miss the team allocation announcement?",
+      "answer": "All programme updates are posted in the Announcements section on samagama.in. Log in and check regularly during working hours — this is the only channel for official notifications."
+    },
+    {
+      "id": "14.25",
+      "section": "14. Team Formation",
+      "question": "Can a team be dissolved and reformed?",
+      "answer": "No. Once finalized, teams are locked and cannot be dissolved."
+    },
+    {
+      "id": "14.26",
+      "section": "14. Team Formation",
+      "question": "What happens if I drop out of the internship?",
+      "answer": "Your team will be adjusted accordingly, and the remaining members may continue as a team of three or receive a replacement."
+    },
+    {
+      "id": "14.27",
+      "section": "14. Team Formation",
+      "question": "Will we get time to get to know our teammates before Phase 2?",
+      "answer": "Yes. There is typically a buffer period before Phase 2 where teams can connect and prepare."
+    },
+    {
+      "id": "15.1",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What was the Spurti feedback survey, and is it still active?",
+      "answer": "The mandatory feedback survey about the Spurti Points system closed on 30 June 2026, 11:59 PM IST. It is no longer active — if you ever saw it as a pop-up blocking your Spurti dashboard, it has since cleared automatically, and your dashboard is accessible normally. If you still see the survey pop-up despite the deadline having passed, hard-refresh your browser (Ctrl+Shift+R / Cmd+Shift+R). If it persists after that, raise it with Yaksha."
+    },
+    {
+      "id": "15.9",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What is a Level?",
+      "answer": "Your Level is a lifetime achievement marker. It reflects the highest SP you have ever reached in the programme — your best-ever engagement."
+    },
+    {
+      "id": "15.10",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "How is my Level calculated?",
+      "answer": "Level = highest-ever SP ÷ 100 (rounded down). So 0–99 highest SP = Level 0, 100–199 = Level 1, 200–299 = Level 2, and so on. Every extra 100 SP you have ever reached is one more Level."
+    },
+    {
+      "id": "15.11",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "Can my Level go down if my current SP drops?",
+      "answer": "No. Level is based on your highest-ever SP, so it never decreases. Even if your current balance falls, the Level you earned stays with you permanently."
+    },
+    {
+      "id": "15.12",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What is a Trophy League?",
+      "answer": "Your Trophy League shows your current standing right now, based on your current SP balance. Unlike Level, it can move up or down as your SP changes — it reflects how you are doing at the moment."
+    },
+    {
+      "id": "15.13",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What are the Trophy League bands?",
+      "answer": "Current SPTrophy League1500+Legend 1400–1499Diamond I 1300–1399Diamond II 1200–1299Diamond III 1100–1199Platinum I 1000–1099Platinum II 900–999Platinum III 800–899Gold I 700–799Gold II 600–699Gold III 500–599Silver I 400–499Silver II 300–399Silver III 200–299Bronze I 100–199Bronze II 0–99Bronze III"
+    },
+    {
+      "id": "15.14",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What is the difference between Level and Trophy League?",
+      "answer": "Level = your best ever — a lifetime badge that never goes down.Trophy League = your current SP standing — it rises and falls with your balance. You can be a high Level (because you once reached a high SP) but currently sit in a lower League (because your current SP has dropped). Staying active keeps both strong."
+    },
+    {
+      "id": "15.15",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What is Legend?",
+      "answer": "Legend is the top Trophy League, reached when your current SP is 1500 or more."
+    },
+    {
+      "id": "15.16",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "What is the Legend Badge, and is it permanent?",
+      "answer": "Once your highest-ever SP reaches 1500, you unlock the Legend Badge — and it is permanent. Even if your current SP later drops below 1500 (so your League changes), the Legend Badge stays with you forever as recognition that you reached the top."
+    },
+    {
+      "id": "15.17",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "There are two leaderboards — what is the difference?",
+      "answer": "Overall — everyone in the programme, ranked by current SP. This is the default.My Onboarding Group — only students who started around the same time as you."
+    },
+    {
+      "id": "15.18",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "Why is there an onboarding-group leaderboard?",
+      "answer": "Students join the programme on different dates. Someone who started earlier has had more sessions to earn SP from, so an overall comparison is not always fair to recent joiners. The onboarding-group view compares you with people who started in the same two-week window, which is a fairer like-for-like comparison."
+    },
+    {
+      "id": "15.19",
+      "section": "15. Spurti Levels, Trophy Leagues & Feedback Survey",
+      "question": "How are onboarding groups decided?",
+      "answer": "By the half-month in which you started: the 1st–15th of a month is one group, the 16th–end of month is the next. Your group is shown as a date range, e.g. \"2026-06-01 to 2026-06-15\". Levels, Trophy Leagues, and Legend are all derived views over your existing Spurti Points — they do not add or remove any SP. Keep attending and participating, and all three grow together."
     }
   ]
 }

--- a/apps/backend/src/middleware/programScope.ts
+++ b/apps/backend/src/middleware/programScope.ts
@@ -84,12 +84,28 @@ export function programScope(opts: { required?: boolean } = {}) {
     try {
       const batch = await Batch.findById(batchId).select('_id name isActive').lean();
       if (!batch) {
-        res.status(404).json({ message: 'Program not found.' });
-        return;
+        if (required) {
+          res.status(404).json({ message: 'Program not found.' });
+          return;
+        }
+        // When not strictly required, fall back to default batch if available
+        const defaultBatch = await Batch.findOne({ isDefault: true, isActive: true }).select('_id name isActive').lean();
+        if (defaultBatch) {
+          req.programContext = {
+            batchId: String(defaultBatch._id),
+            batchName: defaultBatch.name,
+            isActive: defaultBatch.isActive,
+          };
+          setContextBatchId(String(defaultBatch._id));
+        }
+        return next();
       }
       if (!batch.isActive) {
-        res.status(410).json({ message: 'Program is archived or completed.' });
-        return;
+        if (required) {
+          res.status(410).json({ message: 'Program is archived or completed.' });
+          return;
+        }
+        return next();
       }
       req.programContext = {
         batchId: String(batch._id),

--- a/apps/backend/src/modules/admin/admin.controller.ts
+++ b/apps/backend/src/modules/admin/admin.controller.ts
@@ -624,9 +624,18 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
     const search = (req.query.search as string) || '';
     const status = (req.query.status as string) || '';
     const category = (req.query.category as string) || '';
-    const batchId = (req.query.batchId as string | undefined) ?? null;
+    const rawBatchId = (req.query.batchId as string | undefined) ?? null;
+    const batchId = rawBatchId && Types.ObjectId.isValid(rawBatchId) ? rawBatchId : null;
 
     const base: Record<string, any> = {};
+    if (status === 'promoted') {
+      base['lifecycle.status'] = 'converted_to_faq';
+    } else {
+      if (status) {
+        base.status = status;
+        base['lifecycle.status'] = { $ne: 'converted_to_faq' };
+      }
+    }
     if (search) {
       // S5-H11 (HIGH) fix: previously this built `{ $regex: search }` raw,
       // letting admin-controlled regex special characters trigger ReDoS.
@@ -637,7 +646,6 @@ export const getCommunityPosts = async (req: Request, res: Response): Promise<vo
         { body: { $regex: escapeRegex(search), $options: 'i' } },
       ];
     }
-    if (status) base.status = status;
     if (category) {
       if (category.toLowerCase() === 'uncategorized') {
         base.$or = [{ tags: { $exists: false } }, { tags: { $size: 0 } }];

--- a/apps/backend/src/modules/community/comment-vote.controller.ts
+++ b/apps/backend/src/modules/community/comment-vote.controller.ts
@@ -39,34 +39,21 @@ export const toggleCommentUpvote = async (req: Request, res: Response): Promise<
     const commentId: string = req.params.commentId as string;
     const userId = req.user!._id.toString();
     const alreadyUpvoted = comment.upvotes.map((u: Types.ObjectId) => u.toString()).includes(userId);
+    const alreadyDownvoted = comment.downvotes.map((u: Types.ObjectId) => u.toString()).includes(userId);
+
+    if (alreadyUpvoted || alreadyDownvoted) {
+      res.status(400).json({ message: 'You can only vote on a comment once.' });
+      return;
+    }
 
     const commentAuthorId = comment.author;
     const isSelfVote = commentAuthorId.toString() === userId;
     const wasNewUpvote = !alreadyUpvoted;
 
-    // Reverse reputation when removing upvote
-    if (!isSelfVote && alreadyUpvoted) {
-      await User.findByIdAndUpdate(commentAuthorId, { $inc: { points: -5, reputation: -5 } });
-      // v1.69 — Phase 7: per-program reversal.
-      await awardToUser(commentAuthorId.toString(), post.batchId as Types.ObjectId, { points: -5 })
-        .catch((err) => communityLog.warn(`[commentVote] ProgramReputation reverse failed: ${(err as Error).message}`));
-      await ReputationLog.deleteMany({
-        userId: commentAuthorId,
-        targetId: post._id as Types.ObjectId,
-        targetType: 'comment',
-        action: 'upvote_received',
-      });
-    }
-
-    // Atomic $pull/$addToSet — avoids race-condition duplicates
+    // Atomic $addToSet — avoids race-condition duplicates
     await CommunityPost.findOneAndUpdate(
       { _id: post._id, 'comments._id': new Types.ObjectId(commentId) },
-      alreadyUpvoted
-        ? { $pull: { 'comments.$.upvotes': new Types.ObjectId(userId) } }
-        : {
-            $addToSet: { 'comments.$.upvotes': new Types.ObjectId(userId) },
-            $pull: { 'comments.$.downvotes': new Types.ObjectId(userId) },
-          },
+      { $addToSet: { 'comments.$.upvotes': new Types.ObjectId(userId) } },
       { returnDocument: 'after' }
     );
 
@@ -149,24 +136,18 @@ export const toggleCommentDownvote = async (req: Request, res: Response): Promis
 
     const userId = req.user!._id.toString();
     const userObjectId = req.user!._id;
+    const alreadyUpvoted = comment.upvotes.map((u: Types.ObjectId) => u.toString()).includes(userId);
     const alreadyDownvoted = comment.downvotes.map((u: Types.ObjectId) => u.toString()).includes(userId);
 
-    // v1.68 — H3 fix: was read-modify-write on
-    //   comment.downvotes.push(req.user!._id)
-    //   comment.upvotes = comment.upvotes.filter(...)
-    //   await post.save()
-    // Two concurrent downvotes on the same comment could both
-    // read the same state, both push, and both save() — losing
-    // the other's toggle. Same fix shape as toggleCommentUpvote:
-    // atomic $pull + $addToSet on the matched comment subdoc.
+    if (alreadyUpvoted || alreadyDownvoted) {
+      res.status(400).json({ message: 'You can only vote on a comment once.' });
+      return;
+    }
+
+    // Atomic $addToSet — avoids race-condition duplicates
     await CommunityPost.findOneAndUpdate(
       { _id: post._id, 'comments._id': new Types.ObjectId(req.params.commentId as string) },
-      alreadyDownvoted
-        ? { $pull: { 'comments.$.downvotes': userObjectId } }
-        : {
-            $addToSet: { 'comments.$.downvotes': userObjectId },
-            $pull: { 'comments.$.upvotes': userObjectId },
-          },
+      { $addToSet: { 'comments.$.downvotes': userObjectId } },
       { returnDocument: 'after' }
     );
 

--- a/apps/backend/src/modules/community/comment.controller.ts
+++ b/apps/backend/src/modules/community/comment.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import CommunityPost from './community-post.model.js';
 import User, { IUser, calculateTier } from '../auth/user.model.js';
 // v1.69 — Phase 7: per-program reputation writes. The User
@@ -15,6 +15,12 @@ import { communityLog } from '../../utils/http/logger.js';
 import { assertCanCreateContent } from '../../utils/banUtils.js';
 // v1.69 — Phase 3e: program-scope guard for all comment writes.
 import { assertSameProgram, withProgramScope } from '../../utils/db/scopedQuery.js';
+
+import FAQ from '../faq/faq.model.js';
+import { generateEmbedding } from '../../utils/ai/embeddings.js';
+import { invalidateCache } from '../../utils/http/cache.js';
+import { invalidatePublicCaches } from '../faq/public-faq.controller.js';
+import { autoPromotePostToFAQ } from './post-lifecycle.controller.js';
 
 // Extend Express Request to include user (same pattern as auth middleware)
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -83,6 +89,10 @@ export const addComment = async (req: Request, res: Response): Promise<void> => 
       return;
     }
     if (assertSameProgram(post, req.programContext, res)) return;
+    if (post.status === 'answered') {
+      res.status(403).json({ message: 'This post is resolved. Comments are closed.' });
+      return;
+    }
     if (post.isLocked) {
       res.status(403).json({ message: 'This post is locked. New comments are disabled.' });
       return;

--- a/apps/backend/src/modules/community/community.routes.ts
+++ b/apps/backend/src/modules/community/community.routes.ts
@@ -103,7 +103,7 @@ router.post('/:id/hide', protect, authorize('admin', 'moderator'), validateObjec
 router.post('/:id/unhide', protect, authorize('admin', 'moderator'), validateObjectId('id'), unhidePost);
 router.post('/:id/lock', protect, authorize('admin', 'moderator'), validateObjectId('id'), lockPost);
 router.post('/:id/unlock', protect, authorize('admin', 'moderator'), validateObjectId('id'), unlockPost);
-router.post('/:id/convert-to-faq', protect, authorize('admin'), validateObjectId('id'), convertCommunityPostToFAQ);
+router.post('/:id/convert-to-faq', protect, authorize('admin', 'moderator', 'expert'), validateObjectId('id'), convertCommunityPostToFAQ);
 router.patch('/:id/dna', protect, validateObjectId('id'), setPostDNA);
 router.patch('/:id/tags', protect, validateObjectId('id'), setPostTags);
 router.patch('/:id', protect, validateObjectId('id'), updatePost);

--- a/apps/backend/src/modules/community/post-duplicate.controller.ts
+++ b/apps/backend/src/modules/community/post-duplicate.controller.ts
@@ -119,17 +119,38 @@ function wordOverlap(
   return { overlap, total, jaccard };
 }
 
-function textMatchScore(query: string, target: string): number {
+function textMatchScore(query: string, target: string, categoryOrTags?: string | string[]): number {
   const qWords = significantWords(query);
   const tWords = significantWords(target);
   if (qWords.length === 0 || tWords.length === 0) return 0;
+
+  const lowerQuery = query.toLowerCase().trim();
+  let isCategoryMatch = false;
+  if (categoryOrTags) {
+    if (Array.isArray(categoryOrTags)) {
+      isCategoryMatch = categoryOrTags.some(t => {
+        const tLower = t.toLowerCase().trim();
+        return tLower.includes(lowerQuery) || lowerQuery.includes(tLower);
+      });
+    } else {
+      const catLower = categoryOrTags.toLowerCase().trim();
+      isCategoryMatch = catLower.includes(lowerQuery) || lowerQuery.includes(catLower);
+    }
+  }
+
   const { overlap, jaccard } = wordOverlap(qWords, tWords);
-  if (overlap < 2) return 0;
+  if (overlap < 2 && !isCategoryMatch) return 0;
+
   const qSet = new Set(qWords);
   const tSet = new Set(tWords);
   const overlapRatio =
     [...qSet].filter((w) => tSet.has(normalizeWord(w))).length / qSet.size;
-  return Math.min(1, jaccard * 0.5 + overlapRatio * 0.5);
+
+  let score = jaccard * 0.5 + overlapRatio * 0.5;
+  if (isCategoryMatch) {
+    score = Math.max(score, 0.75);
+  }
+  return Math.min(1, score);
 }
 
 // ─── checkDuplicate (pure fallback — used when AI is unavailable) ──────────────
@@ -190,7 +211,7 @@ export async function checkDuplicate(
           const scored = faqs
             .map((f) => ({
               faq: f,
-              score: textMatchScore(lower, f.question + ' ' + (f.answer ?? '')),
+              score: textMatchScore(lower, f.question + ' ' + (f.answer ?? ''), f.category),
             }))
             .filter((x) => x.score >= DUPLICATE_TEXT_THRESHOLD)
             .sort((a, b) => b.score - a.score)
@@ -230,13 +251,13 @@ export async function checkDuplicate(
           })),
         ],
       }, batchId))
-        .select('_id title body status')
+        .select('_id title body status tags')
         .lean()
         .then((posts) => {
           const scored = posts
             .map((p) => ({
               post: p,
-              score: textMatchScore(lower, p.title + ' ' + (p.body ?? '')),
+              score: textMatchScore(lower, p.title + ' ' + (p.body ?? ''), p.tags),
             }))
             .filter((x) => x.score >= DUPLICATE_TEXT_THRESHOLD)
             .sort((a, b) => b.score - a.score)
@@ -297,8 +318,8 @@ export async function evaluateDuplicates(
 ): Promise<DuplicateMatch[]> {
   let aiAvailable = false;
   try {
-    await resolveProviderAsync();
-    aiAvailable = true;
+    const cfg = await resolveProviderAsync();
+    aiAvailable = !!(cfg && cfg.apiKey && cfg.apiKey.trim());
   } catch {
     aiAvailable = false;
   }
@@ -307,8 +328,11 @@ export async function evaluateDuplicates(
 
   if (aiAvailable) {
     matches = await detectDuplicatesWithAI(query);
-  } else {
-    // No AI configured — use knowledge base + keyword fallback
+  }
+
+  // Fallback to local DB vector / text match if AI is not configured or failed to find matches
+  if (matches.length === 0) {
+    // No AI configured or AI returned no matches — use knowledge base + keyword fallback
     try {
       const { searchKnowledge } = await import('../knowledge/knowledge-base.service.js');
       const knowledgeMatches = await searchKnowledge(query, 3);

--- a/apps/backend/src/modules/community/post-lifecycle.controller.ts
+++ b/apps/backend/src/modules/community/post-lifecycle.controller.ts
@@ -11,7 +11,7 @@
  */
 
 import { Request, Response } from 'express';
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import CommunityPost from './community-post.model.js';
 import FAQ from '../faq/faq.model.js';
 import User from '../auth/user.model.js';
@@ -91,17 +91,8 @@ export const resolvePost = async (req: Request, res: Response): Promise<void> =>
       communityLog.warn(`[post] Failed to invalidate cache on post resolve: ${(err as Error).message}`);
     });
 
-    // ── Check if post is now eligible for FAQ promotion ───────────────────────
-    const { checkPromotionEligibility, startPromotionReview } = await import('../program/promotion.service.js');
-    try {
-      const eligible = await checkPromotionEligibility(post);
-      if (eligible) {
-        await startPromotionReview(post, req.user!._id.toString());
-        communityLog.info(`Resolved post ${post._id} entered promotion review`, { postId: post._id.toString() });
-      }
-    } catch (e) {
-      communityLog.warn(`Promotion eligibility check failed for post ${post._id}: ${(e as Error).message}`);
-    }
+    // FAQ promotion is now handled manually by admins/moderators via the promote route
+    await post.save();
 
     // ── Notify post author ────────────────────────────────────────────────────
     dispatchNotification({
@@ -192,7 +183,14 @@ export const convertCommunityPostToFAQ = async (req: Request, res: Response): Pr
     }
     if (assertSameProgram(post, req.programContext, res)) return;
 
-    if (!post.answer || !post.answer.trim()) {
+    // Use custom question, answer, and category if provided in the body; otherwise fall back to post details.
+    const { question, answer, category } = req.body as { question?: string; answer?: string; category?: string };
+
+    const finalQuestion = question?.trim() || post.title;
+    const finalAnswer = answer?.trim() || post.answer || '';
+    const finalCategory = category?.trim() || (post.tags && post.tags[0]) || 'Community';
+
+    if (!finalAnswer.trim()) {
       res.status(400).json({ message: 'Post has no answer yet. Resolve it before converting to FAQ.' });
       return;
     }
@@ -200,35 +198,49 @@ export const convertCommunityPostToFAQ = async (req: Request, res: Response): Pr
     // Generate embedding for the new FAQ
     let embedding: number[] | undefined;
     try {
-      embedding = await generateEmbedding(`Question: ${post.title}. Answer: ${post.answer}`);
+      embedding = await generateEmbedding(`Question: ${finalQuestion}. Answer: ${finalAnswer}`);
     } catch (err) {
       communityLog.warn(`Failed to generate embedding for FAQ: ${(err as Error).message}`);
     }
 
-    // Create the FAQ from the post's title (question) and answer
+    // Create the FAQ from the customized fields
     const faq = await FAQ.create({
-      question: post.title,
-      answer: post.answer,
+      question: finalQuestion,
+      answer: finalAnswer,
       batchId: post.batchId,
-      category: 'Community',
+      category: finalCategory,
       status: 'approved',
+      reviewStatus: 'verified',
       embedding,
-      createdBy: post.author,
+      createdBy: req.user._id,
     });
 
-    // v1.68 — H3 fix: atomic $set.
+    // Update community post lifecycle and status
+    const updateFields: Record<string, any> = {
+      status: 'answered',
+      escalationStatus: 'none',
+      escalatedAt: null,
+      escalationReason: null,
+      escalatedBy: null,
+      answerIsExpert: true,
+    };
+
+    const currentStatus = post.lifecycle?.status || 'open';
+    const currentHistory = post.lifecycle?.statusHistory || [];
+    const history = [...currentHistory];
+    history.push({
+      from: currentStatus as any,
+      to: 'converted_to_faq',
+      changedBy: req.user._id,
+      changedAt: new Date(),
+      note: `Manually promoted to FAQ by admin/moderator. FAQ ID: ${faq._id}`,
+    });
+    updateFields['lifecycle.status'] = 'converted_to_faq';
+    updateFields['lifecycle.statusHistory'] = history;
+
     await CommunityPost.findOneAndUpdate(
       { _id: post._id },
-      {
-        $set: {
-          status: 'answered',
-          escalationStatus: 'none',
-          escalatedAt: null,
-          escalationReason: null,
-          escalatedBy: null,
-          answerIsExpert: true,
-        },
-      },
+      { $set: updateFields }
     );
 
     // Invalidate search cache so the new FAQ appears immediately
@@ -320,5 +332,77 @@ export const setPostTags = async (req: Request, res: Response): Promise<void> =>
   } catch (error) {
     communityLog.error(`[post] setPostTags failed: ${(error as Error).message}`);
     res.status(500).json({ message: 'Server error' });
+  }
+};
+
+// Auto-promotes a community post to FAQ after validating similarity/duplicates
+export const autoPromotePostToFAQ = async (
+  post: any,
+  answerText: string,
+  authorId: any
+): Promise<void> => {
+  try {
+    let embedding: number[] | undefined;
+    try {
+      embedding = await generateEmbedding(`Question: ${post.title}. Answer: ${answerText}`);
+    } catch (err) {
+      communityLog.warn(`Failed to generate embedding for FAQ check: ${(err as Error).message}`);
+    }
+
+    let isDuplicate = false;
+    if (embedding) {
+      const db = mongoose.connection.db;
+      if (db) {
+        const collection = db.collection('yaksha_faq_faqs');
+        const pipeline: mongoose.PipelineStage[] = post.batchId
+          ? [{ $match: { batchId: post.batchId } }]
+          : [];
+        pipeline.push(
+          {
+            $vectorSearch: {
+              index: 'vector_index',
+              path: 'embedding',
+              queryVector: embedding,
+              numCandidates: 50,
+              limit: 1,
+            },
+          },
+          {
+            $project: {
+              score: { $meta: 'vectorSearchScore' },
+            },
+          }
+        );
+        const results = await collection.aggregate(pipeline).toArray();
+        const topMatch = results[0];
+        const matchThreshold = 0.82; // standard duplicate threshold
+        if (topMatch && topMatch.score >= matchThreshold) {
+          isDuplicate = true;
+          communityLog.info(`Skip auto-promoting post ${post._id} to FAQ: duplicate found (score: ${topMatch.score})`);
+        }
+      }
+    }
+
+    if (!isDuplicate) {
+      const faqCategory = post.tags && post.tags[0] ? post.tags[0] : 'Community';
+      await FAQ.create({
+        question: post.title,
+        answer: answerText,
+        batchId: post.batchId,
+        category: faqCategory,
+        status: 'approved',
+        embedding,
+        createdBy: authorId,
+      });
+      communityLog.info(`Automatically promoted post ${post._id} to FAQ under category '${faqCategory}'`);
+      
+      // Invalidate cache
+      await invalidateCache().catch((err) => {
+        communityLog.warn(`[post] Failed to invalidate cache on auto FAQ promotion: ${(err as Error).message}`);
+      });
+      invalidatePublicCaches();
+    }
+  } catch (promotionErr) {
+    communityLog.error(`Failed to auto-promote post to FAQ: ${(promotionErr as Error).message}`);
   }
 };

--- a/apps/backend/src/modules/community/post-mutations.controller.ts
+++ b/apps/backend/src/modules/community/post-mutations.controller.ts
@@ -85,7 +85,7 @@ export const createPost = async (req: Request, res: Response): Promise<void> => 
     // (detectDuplicatesWithAI returns [] on throw) keeps the server usable
     // when the AI provider is down.
     const matches = await evaluateDuplicates(
-      title,
+      `${title} ${body}`,
       req.programContext?.batchId ?? null,
     );
     if (matches.some(isBlockingMatch)) {
@@ -100,24 +100,24 @@ export const createPost = async (req: Request, res: Response): Promise<void> => 
     // ── Same-author duplicate guard ──────────────────────────────────────────
     // The AI / FAQ blocker catches "this has been asked before, see answer"
     // but doesn't catch "you just posted this ten minutes ago, stop spamming".
-    // Compare on normalised title (case-folded, whitespace collapsed) so
-    // trivial re-submissions ("Hi" vs "hi.") still match. Block creation
+    // Compare on normalised body (case-folded, whitespace collapsed) so
+    // trivial re-submissions still match. Block creation
     // with the SAME 409 shape the UI already knows how to surface.
     if (req.user?._id) {
-      const normalisedTitle = title.toLowerCase().replace(/\s+/g, ' ').trim();
+      const normalisedBody = body.toLowerCase().replace(/\s+/g, ' ').trim();
       const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
       const recent = await CommunityPost.findOne({
         author: req.user._id,
         status: { $ne: 'spam_confirmed' },
         createdAt: { $gte: since },
       })
-        .select('_id title createdAt status')
+        .select('_id title body createdAt status')
         .lean();
       if (recent) {
-        const recentNorm = (recent.title ?? '').toLowerCase().replace(/\s+/g, ' ').trim();
-        if (recentNorm === normalisedTitle) {
+        const recentNorm = (recent.body ?? '').toLowerCase().replace(/\s+/g, ' ').trim();
+        if (recentNorm === normalisedBody) {
           res.status(409).json({
-            message: 'You posted the same question in the last 24 hours. Check your earlier post and add a comment instead of creating a duplicate.',
+            message: 'You posted the same question description in the last 24 hours. Check your earlier post and add a comment instead of creating a duplicate.',
             isDuplicate: true,
             matches: [{
               _id: recent._id.toString(),
@@ -125,7 +125,7 @@ export const createPost = async (req: Request, res: Response): Promise<void> => 
               score: 1.0,
               source: 'community' as const,
               matchType: 'text' as const,
-              reason: 'Same author posted this title within 24 hours.',
+              reason: 'Same author posted this question description within 24 hours.',
             }],
           });
           return;
@@ -316,13 +316,15 @@ export const toggleUpvote = async (req: Request, res: Response): Promise<void> =
     // snapshot. `$addToSet` is idempotent so the membership is
     // always correct after the atomic write.
     const wasUpvotedBefore = post.upvotes.map((u: Types.ObjectId) => u.toString()).includes(userId);
+    if (wasUpvotedBefore) {
+      res.status(400).json({ message: 'You can only upvote a question once.' });
+      return;
+    }
 
-    // Use atomic $pull/$addToSet to avoid race-condition duplicates
+    // Use atomic $addToSet to avoid race-condition duplicates
     const updated = await CommunityPost.findOneAndUpdate(
       { _id: post._id },
-      wasUpvotedBefore
-        ? { $pull: { upvotes: new Types.ObjectId(userId) } }
-        : { $addToSet: { upvotes: new Types.ObjectId(userId) } },
+      { $addToSet: { upvotes: new Types.ObjectId(userId) } },
       { returnDocument: 'after' }
     );
 

--- a/apps/backend/src/modules/community/post-reads.controller.ts
+++ b/apps/backend/src/modules/community/post-reads.controller.ts
@@ -35,10 +35,20 @@ export const getAllPosts = async (req: Request, res: Response): Promise<void> =>
     const search = (req.query.search as string)?.trim() || '';
 
     // Build query filter
-    const query: Record<string, unknown> = { isHidden: { $ne: true } };
-    if (filter === 'unanswered') query.status = 'unanswered';
-    else if (filter === 'answered') query.status = 'answered';
-    // 'all' → no status filter
+    const query: Record<string, any> = { isHidden: { $ne: true } };
+    if (filter === 'promoted') {
+      // Access record of questions that were moved/promoted (Admin/Mod/Expert only)
+      if (req.user?.role !== 'admin' && req.user?.role !== 'moderator' && req.user?.role !== 'expert') {
+        res.status(403).json({ message: 'Forbidden' });
+        return;
+      }
+      query['lifecycle.status'] = 'converted_to_faq';
+    } else {
+      // Exclude promoted questions from standard student feed
+      query['lifecycle.status'] = { $ne: 'converted_to_faq' };
+      if (filter === 'unanswered') query.status = 'unanswered';
+      else if (filter === 'answered') query.status = 'answered';
+    }
 
     // Text search on title
     if (search.length >= 2) {

--- a/apps/backend/src/modules/faq/public-faq.controller.ts
+++ b/apps/backend/src/modules/faq/public-faq.controller.ts
@@ -299,7 +299,7 @@ export async function getCategories(req: Request, res: Response): Promise<void> 
     const grouped = await FAQ.aggregate<{ _id: string; count: number }>([
       { $match: matchStage },
       { $group: { _id: '$category', count: { $sum: 1 } } },
-      { $sort: { count: -1, _id: 1 } },
+      { $sort: { _id: 1 } },
     ]);
 
     const categories: Array<{

--- a/apps/backend/src/scripts/check_db.ts
+++ b/apps/backend/src/scripts/check_db.ts
@@ -1,0 +1,33 @@
+import mongoose from 'mongoose';
+import fs from 'fs';
+import path from 'path';
+
+// Load connection URI from backend/.env
+const envPath = path.join(process.cwd(), '.env');
+const envContent = fs.readFileSync(envPath, 'utf-8');
+const match = envContent.match(/^MONGODB_URI=(.*)$/m);
+const MONGODB_URI = match ? match[1].trim() : '';
+
+console.log('Connecting to database:', MONGODB_URI);
+
+const faqSchema = new mongoose.Schema({}, { strict: false });
+const FAQ = mongoose.model('FAQ', faqSchema, 'yaksha_faq_faqs');
+
+async function run() {
+  await mongoose.connect(MONGODB_URI);
+  console.log('Connected!');
+
+  const counts = await FAQ.aggregate([
+    { $group: { _id: '$category', count: { $sum: 1 } } },
+    { $sort: { count: -1 } }
+  ]);
+
+  console.log('=== FAQS BY CATEGORY ===');
+  for (const c of counts) {
+    console.log(`- Category: "${c._id}", Count: ${c.count}`);
+  }
+
+  await mongoose.disconnect();
+}
+
+run().catch(console.error);

--- a/apps/backend/src/scripts/count_posts.ts
+++ b/apps/backend/src/scripts/count_posts.ts
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+
+async function checkDb() {
+  const MONGODB_URI = 'mongodb://127.0.0.1:25950/';
+  try {
+    await mongoose.connect(MONGODB_URI);
+    console.log('Connected to local MongoDB!');
+    
+    // List databases
+    const adminDb = mongoose.connection.db.admin();
+    const dbs = await adminDb.listDatabases();
+    
+    for (const dbInfo of dbs.databases) {
+      if (dbInfo.name === 'admin' || dbInfo.name === 'local' || dbInfo.name === 'config') continue;
+      
+      const dbConnection = mongoose.connection.useDb(dbInfo.name);
+      
+      // Let's query 'yaksha_faq_communityposts'
+      const Post = dbConnection.model('Post', new mongoose.Schema({}, { strict: false }), 'yaksha_faq_communityposts');
+      const postsCount = await Post.countDocuments();
+      console.log(`Total posts in collection 'yaksha_faq_communityposts' in ${dbInfo.name}:`, postsCount);
+      if (postsCount > 0) {
+        const posts = await Post.find().lean();
+        console.log('Posts:', JSON.stringify(posts, null, 2));
+      }
+
+      // Let's also check 'yaksha_faq_session_support' (support tickets)
+      const Ticket = dbConnection.model('Ticket', new mongoose.Schema({}, { strict: false }), 'yaksha_faq_session_support');
+      const ticketsCount = await Ticket.countDocuments();
+      console.log(`Total tickets in 'yaksha_faq_session_support' in ${dbInfo.name}:`, ticketsCount);
+      if (ticketsCount > 0) {
+        const tickets = await Ticket.find().lean();
+        console.log('Tickets:', JSON.stringify(tickets, null, 2));
+      }
+    }
+  } catch (err: any) {
+    console.error('Error connecting to local DB:', err.message);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+checkDb();

--- a/apps/backend/src/scripts/migrate_promoted_posts.ts
+++ b/apps/backend/src/scripts/migrate_promoted_posts.ts
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+import User from '../modules/auth/user.model.js';
+
+async function run() {
+  await mongoose.connect('mongodb://localhost:2884/test');
+  console.log('Connected to MongoDB');
+  const users = await User.find();
+  console.log(`Found ${users.length} users:`);
+  for (const u of users) {
+    console.log(`- Email: "${u.email}", Role: "${u.role}", Name: "${u.name}"`);
+  }
+  await mongoose.disconnect();
+}
+
+run().catch(console.error);

--- a/apps/backend/src/scripts/parse_live_faq.ts
+++ b/apps/backend/src/scripts/parse_live_faq.ts
@@ -1,0 +1,201 @@
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import mongoose from 'mongoose';
+import Category, { slugifyCategoryName } from '../modules/faq/category.model.js';
+import FAQ from '../modules/faq/faq.model.js';
+import Batch from '../modules/program/batch.model.js';
+
+function cleanHtml(html: string): string {
+  let text = html;
+  // Replace common tags with readable text or markdown equivalents
+  text = text.replace(/<p>/g, '').replace(/<\/p>/g, '\n\n');
+  text = text.replace(/<li>/g, '\n- ').replace(/<\/li>/g, '');
+  text = text.replace(/<ul>/g, '').replace(/<\/ul>/g, '');
+  text = text.replace(/<ol>/g, '').replace(/<\/ol>/g, '');
+  text = text.replace(/<strong>/g, '**').replace(/<\/strong>/g, '**');
+  text = text.replace(/<code>/g, '`').replace(/<\/code>/g, '`');
+  text = text.replace(/<br\s*\/?>/g, '\n');
+  
+  // Strip any remaining HTML tags
+  text = text.replace(/<[^>]+>/g, '');
+  
+  // Resolve HTML entities
+  text = text.replace(/&nbsp;/g, ' ')
+             .replace(/&amp;/g, '&')
+             .replace(/&lt;/g, '<')
+             .replace(/&gt;/g, '>')
+             .replace(/&quot;/g, '"')
+             .replace(/&#39;/g, "'")
+             .replace(/&apos;/g, "'");
+
+  return text.trim();
+}
+
+async function main() {
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    console.error('ERROR: MONGODB_URI not set');
+    process.exit(1);
+  }
+
+  const filePath = 'C:\\Users\\Simranjit Kaur\\.gemini\\antigravity\\brain\\c6ec5744-1347-40e4-b6a6-19a68ae6fed8\\.system_generated\\steps\\783\\content.md';
+  if (!fs.existsSync(filePath)) {
+    console.error(`ERROR: HTML file not found at ${filePath}`);
+    process.exit(1);
+  }
+
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(MONGODB_URI);
+    console.log('Connected!');
+
+    const defaultBatch = await Batch.findOne({ isDefault: true });
+    if (!defaultBatch) {
+      console.error('ERROR: Default batch not found');
+      process.exit(1);
+    }
+    console.log(`Using batch: "${defaultBatch.name}" (${defaultBatch._id})`);
+
+    const htmlContent = fs.readFileSync(filePath, 'utf-8');
+
+    // Parse the file by splitting at <h2 id="s-
+    const sections = htmlContent.split('<h2 id="s-');
+    // The first part is the header, discard it
+    sections.shift();
+
+    const parsedCategories: Map<string, { name: string; description: string }> = new Map();
+    const parsedFaqs: { question: string; answer: string; category: string }[] = [];
+
+    // Ensure Spandan exists
+    parsedCategories.set('spandan', {
+      name: 'Spandan',
+      description: 'Questions and information related to Spandan polls and accounts.'
+    });
+
+    // Ensure Attendance exists
+    parsedCategories.set('attendance', {
+      name: 'Attendance',
+      description: 'Questions regarding daily standups, leave policy, and attendance rules.'
+    });
+
+    for (const section of sections) {
+      // Extract section title
+      // Format: 1">1. About the internship <a class="anchor"...
+      const titleMatch = section.match(/^\d+">(\d+\.\s+)?([^<]+)/);
+      if (!titleMatch) continue;
+
+      let sectionName = titleMatch[2].trim();
+      // Remove trailing anchor indicators if any
+      sectionName = sectionName.replace(/[\s§]+$/, '');
+
+      // Normalize section name to match seeded names
+      if (sectionName === 'Work and projects') {
+        sectionName = 'Work, mentorship, and projects';
+      }
+      if (sectionName === 'Phase 1 — coursework, Vibe LMS, and live sessions') {
+        sectionName = 'Phase 1 — coursework, Vibe LMS, and projects';
+      }
+
+      const sectionSlug = slugifyCategoryName(sectionName);
+      if (!parsedCategories.has(sectionSlug)) {
+        parsedCategories.set(sectionSlug, {
+          name: sectionName,
+          description: `FAQs and topics related to ${sectionName}.`
+        });
+      }
+
+      // Find details blocks
+      const detailsBlocks = section.split('<details class="faq-q"');
+      detailsBlocks.shift(); // The first part is before the first details block
+
+      for (const block of detailsBlocks) {
+        // Extract summary text (question)
+        const summaryStart = block.indexOf('<summary>');
+        const summaryEnd = block.indexOf('</summary>');
+        if (summaryStart === -1 || summaryEnd === -1) continue;
+
+        const rawQuestion = block.substring(summaryStart + 9, summaryEnd);
+        let question = cleanHtml(rawQuestion);
+        
+        // Remove leading section/question numbers (e.g., "1.1 ", "10.15 ")
+        question = question.replace(/^\d+(\.\d+)+\s+/, '');
+        // Remove trailing section/anchor markers
+        question = question.replace(/[\s§]+$/, '').trim();
+
+        if (!question) {
+          console.warn('Warning: Parsed empty question block, skipping:', rawQuestion);
+          continue;
+        }
+
+        // Extract answer body
+        const answerEnd = block.indexOf('</details>');
+        if (answerEnd === -1) continue;
+
+        const rawAnswer = block.substring(summaryEnd + 10, answerEnd);
+        const answer = cleanHtml(rawAnswer);
+
+        // Decide category: if question or answer talks about Spandan, classify under Spandan
+        let finalCategory = sectionName;
+        if (question.toLowerCase().includes('spandan') || answer.toLowerCase().includes('spandan')) {
+          finalCategory = 'Spandan';
+        } else if (
+          question.toLowerCase().includes('attendance') ||
+          question.toLowerCase().includes('absent') ||
+          (question.toLowerCase().includes('leave') && !question.toLowerCase().includes('rosetta')) ||
+          (question.toLowerCase().includes('mandatory') && (question.toLowerCase().includes('session') || question.toLowerCase().includes('zoom') || question.toLowerCase().includes('standup') || question.toLowerCase().includes('attendance')))
+        ) {
+          finalCategory = 'Attendance';
+        }
+
+        parsedFaqs.push({
+          question,
+          answer,
+          category: finalCategory
+        });
+      }
+    }
+
+    console.log(`Parsed ${parsedCategories.size} categories and ${parsedFaqs.length} FAQs.`);
+
+    // Clear old data for default batch
+    console.log('Clearing database collection data for default batch...');
+    await Category.deleteMany({ batchId: defaultBatch._id });
+    await FAQ.deleteMany({ batchId: defaultBatch._id });
+
+    // Seed Categories
+    const categoryIdMap: Map<string, mongoose.Types.ObjectId> = new Map();
+    for (const [slug, info] of parsedCategories.entries()) {
+      const catDoc = await Category.create({
+        batchId: defaultBatch._id,
+        name: info.name,
+        slug,
+        description: info.description
+      });
+      categoryIdMap.set(info.name, catDoc._id as mongoose.Types.ObjectId);
+      console.log(`Seeded Category: "${info.name}"`);
+    }
+
+    // Seed FAQs
+    for (const faq of parsedFaqs) {
+      const categoryId = categoryIdMap.get(faq.category) || null;
+      await FAQ.create({
+        question: faq.question,
+        answer: faq.answer,
+        category: faq.category,
+        batchId: defaultBatch._id,
+        categoryId,
+        status: 'approved',
+        reviewStatus: 'verified'
+      });
+    }
+
+    console.log(`Successfully seeded ${parsedFaqs.length} FAQs into the local database!`);
+  } catch (err) {
+    console.error('Error during parsing/seeding:', err);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+main();

--- a/apps/backend/src/scripts/print_scraped_keys.ts
+++ b/apps/backend/src/scripts/print_scraped_keys.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
+const faqPath = path.join(process.cwd(), 'src', 'faqs.json');
+const content = fs.readFileSync(faqPath, 'utf-8');
+const parsed = JSON.parse(content);
+const faqs = Array.isArray(parsed) ? parsed : (parsed.faqs || []);
+
+console.log(`Loaded ${faqs.length} FAQs`);
+console.log('Sample FAQ:', JSON.stringify(faqs[0], null, 2));
+
+const sections = new Set(faqs.map((f: any) => f.section));
+console.log('Unique Sections:', [...sections]);
+const categories = new Set(faqs.map((f: any) => f.category));
+console.log('Unique Categories:', [...categories]);

--- a/apps/backend/src/scripts/seed.ts
+++ b/apps/backend/src/scripts/seed.ts
@@ -13,6 +13,8 @@ import User from '../modules/auth/user.model.js';
 import Batch from '../modules/program/batch.model.js';
 import { generateEmbedding } from '../utils/ai/embeddings.js';
 
+import RegistrationConfig, { generateInviteToken } from '../modules/program/registration-config.model.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MONGODB_URI = process.env.MONGODB_URI;
 
@@ -49,25 +51,43 @@ const seed = async () => {
 
     // Upsert users
     console.log('[1/3] Seeding users...');
+    const futureEndDate = new Date();
+    futureEndDate.setMonth(futureEndDate.getMonth() + 2);
+
     const users = [
-      { name: 'Test User', email: 'user@yaksha.com', password: 'password123', role: 'user' },
-      { name: 'Admin User', email: 'admin@yaksha.com', password: 'admin123', role: 'admin' },
+      { name: 'Simranjit Kaur', email: 'simranjitkaur16048@gmail.com', password: 'jungkook123', role: 'user', internshipEndDate: futureEndDate },
+      { name: 'Test User', email: 'user@yaksha.com', password: 'password123', role: 'user', internshipEndDate: futureEndDate },
+      { name: 'Admin User', email: 'admin@yaksha.com', password: 'jimin123', role: 'admin', internshipEndDate: futureEndDate },
     ];
     for (const user of users) {
-      const existing = await User.findOne({ email: user.email });
+      const existing = await User.findOne({ email: user.email }).select('+password');
       if (existing) {
-        // Only update name and role — never touch password of existing users
         existing.name = user.name;
         existing.role = user.role as any;
+        existing.password = user.password;
+        existing.internshipEndDate = user.internshipEndDate;
         await existing.save();
       } else {
-        const created = await User.create(user);
-        // hash the password by triggering the pre-save hook
-        created.password = user.password;
-        await created.save();
+        await User.create(user);
       }
     }
     console.log('  ✓ Users upserted and passwords hashed');
+
+    // Enable open registration for local development
+    await RegistrationConfig.findOneAndUpdate(
+      { _id: 'singleton' },
+      {
+        $set: {
+          registrationEnabled: true,
+          openForAll: true,
+          inviteToken: generateInviteToken(),
+          tokenGeneratedAt: new Date(),
+          lastToggledAt: new Date(),
+        },
+      },
+      { upsert: true, new: true }
+    );
+    console.log('  ✓ Open self-registration enabled for dev');
 
     // Bootstrap a default program (Batch). Idempotent: if any batch
     // already has isDefault:true we leave it alone; otherwise we

--- a/apps/backend/src/scripts/seed_custom_categories.ts
+++ b/apps/backend/src/scripts/seed_custom_categories.ts
@@ -1,0 +1,169 @@
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import Category, { slugifyCategoryName } from '../modules/faq/category.model.js';
+import FAQ from '../modules/faq/faq.model.js';
+import Batch from '../modules/program/batch.model.js';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { generateEmbedding } from '../utils/ai/embeddings.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const categoryNames = [
+  'ViBe Platform',
+  'Team Formation',
+  'Phase 1 — coursework, Vibe LMS, and projects',
+  'Rosetta — your internship journal',
+  'Spurti Points',
+  'NOC (No Objection Certificate)',
+  'Selection, offer letter, and certificate',
+  'Work, mentorship, and projects',
+  'About the internship',
+  'Timing and dates',
+  'Certificate',
+  'Yaksha Chat Related',
+  'Code of conduct — communication channels',
+  'Interviews Related',
+  'Community',
+  'Attendance'
+];
+
+function mapToOfficialCategory(faq: any): string {
+  const sec = (faq.section || '').toLowerCase();
+  const q = (faq.question || '').toLowerCase();
+
+  // section 10 contains a mix of coursework (ViBe) and live standups (Attendance)
+  if (sec.includes('phase 1')) {
+    if (q.includes('attendance') || q.includes('zoom id') || q.includes('standup') || q.includes('live session') || q.includes('participation')) {
+      return 'Attendance';
+    }
+    if (q.includes('vibe') || q.includes('course')) {
+      return 'ViBe Platform';
+    }
+    return 'Phase 1 — coursework, Vibe LMS, and projects';
+  }
+
+  if (sec.includes('work and projects')) {
+    return 'Work, mentorship, and projects';
+  }
+
+  if (sec.includes('about the internship')) return 'About the internship';
+  if (sec.includes('timing and dates')) return 'Timing and dates';
+  if (sec.includes('noc') || sec.includes('no objection')) return 'NOC (No Objection Certificate)';
+  if (sec.includes('selection, offer letter')) return 'Selection, offer letter, and certificate';
+  if (sec.includes('code of conduct')) return 'Code of conduct — communication channels';
+  if (sec.includes('interview')) return 'Interviews Related';
+  if (sec.includes('certificate')) return 'Certificate';
+  if (sec.includes('rosetta')) return 'Rosetta — your internship journal';
+  if (sec.includes('spurti points')) return 'Spurti Points';
+  if (sec.includes('yaksha chat')) return 'Yaksha Chat Related';
+  if (sec.includes('vibe platform')) return 'ViBe Platform';
+  if (sec.includes('team formation')) return 'Team Formation';
+  if (sec.includes('spurti levels') || sec.includes('trophy league')) return 'Spurti Points';
+  
+  return 'About the internship';
+}
+
+async function seedCategories() {
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    console.error('ERROR: MONGODB_URI not set in env');
+    process.exit(1);
+  }
+
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(MONGODB_URI);
+    console.log('Connected to MongoDB!');
+
+    // Get the default batch
+    const defaultBatch = await Batch.findOne({ isDefault: true });
+    if (!defaultBatch) {
+      console.error('Error: Default batch not found in database. Run the server first.');
+      process.exit(1);
+    }
+    console.log(`Found default batch: "${defaultBatch.name}" (${defaultBatch._id})`);
+
+    // Clear old categories and FAQs associated with this batch
+    console.log('Clearing old categories and FAQs for default batch...');
+    await Category.deleteMany({ batchId: defaultBatch._id });
+    await FAQ.deleteMany({ batchId: defaultBatch._id });
+
+    // Read scraped FAQs
+    const faqPath = path.join(__dirname, '..', 'faqs.json');
+    let scrapedFaqs: any[] = [];
+    try {
+      const faqDataRaw = await fs.readFile(faqPath, 'utf-8');
+      const parsed = JSON.parse(faqDataRaw) as any;
+      scrapedFaqs = Array.isArray(parsed) ? parsed : (parsed.faqs || []);
+      console.log(`Loaded ${scrapedFaqs.length} FAQs from faqs.json`);
+    } catch (e) {
+      console.log('No scraped FAQs found, seeding placeholders only.');
+    }
+
+    // Seed new categories
+    const categoryDocMap = new Map<string, any>();
+    for (const name of categoryNames) {
+      const slug = slugifyCategoryName(name);
+      const categoryDoc = await Category.create({
+        batchId: defaultBatch._id,
+        name,
+        slug,
+        description: `FAQs and topics related to ${name}.`
+      });
+      categoryDocMap.set(name, categoryDoc);
+    }
+    console.log(`Seeded ${categoryNames.length} categories.`);
+
+    // Distribute FAQs
+    let inserted = 0;
+    const seededCategories = new Set<string>();
+
+    for (const faq of scrapedFaqs) {
+      const officialCat = mapToOfficialCategory(faq);
+      const categoryDoc = categoryDocMap.get(officialCat);
+      if (!categoryDoc) continue;
+
+      const embedding = await generateEmbedding(`Section: ${officialCat}. Question: ${faq.question}. Answer: ${faq.answer}`);
+      await FAQ.create({
+        question: faq.question,
+        answer: faq.answer,
+        category: officialCat,
+        batchId: defaultBatch._id,
+        categoryId: categoryDoc._id,
+        embedding,
+        status: 'approved',
+        reviewStatus: 'verified'
+      });
+      inserted++;
+      seededCategories.add(officialCat);
+    }
+    console.log(`Seeded ${inserted} FAQs.`);
+
+    // Seed placeholders for any empty categories so they still render
+    for (const name of categoryNames) {
+      if (!seededCategories.has(name)) {
+        const categoryDoc = categoryDocMap.get(name);
+        await FAQ.create({
+          question: `Placeholder question for ${name}`,
+          answer: `This is a placeholder answer for the category: ${name}. You can edit or replace this question in the Admin dashboard.`,
+          category: name,
+          batchId: defaultBatch._id,
+          categoryId: categoryDoc?._id,
+          status: 'approved',
+          reviewStatus: 'verified'
+        });
+        console.log(`Seeded placeholder FAQ for empty category: ${name}`);
+      }
+    }
+
+    console.log('\nSeeding custom categories and FAQs completed successfully!');
+  } catch (err) {
+    console.error('Error seeding categories:', err);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+seedCategories();

--- a/apps/backend/src/scripts/test_dup.ts
+++ b/apps/backend/src/scripts/test_dup.ts
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+import { evaluateDuplicates } from '../modules/community/post-duplicate.controller.js';
+import 'dotenv/config';
+
+// Inject active mongo uri
+process.env.MONGODB_URI = 'mongodb://127.0.0.1:2884/yaksha_faq';
+
+async function test() {
+  console.log('Connecting to database...');
+  await mongoose.connect(process.env.MONGODB_URI!);
+  console.log('Connected!');
+
+  const faqs = await FAQ.find({});
+  console.log(`FAQs count in DB: ${faqs.length}`);
+  faqs.forEach(f => {
+    console.log(`- ID: ${f._id}, Category: ${f.category}, Question: "${f.question}", Status: "${f.status}", BatchId: ${f.batchId}`);
+  });
+
+  const q = 'attendance is attendance mandetory for every session';
+  console.log(`Running evaluateDuplicates for: "${q}"`);
+  
+  const matches = await evaluateDuplicates(q, null);
+  console.log('Matches returned:', JSON.stringify(matches, null, 2));
+
+  await mongoose.disconnect();
+}
+
+test().catch(console.error);

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -15,6 +15,45 @@
     <!-- No-flash theme bootstrap. Runs synchronously before any styles paint
          to apply the persisted theme to <html> and avoid a light/dark flash. -->
     <script src="/theme.js"></script>
+    <script>
+      // Intercept authentication and session state keys from localStorage to sessionStorage.
+      // This allows different tabs in the same window to have completely isolated sessions,
+      // enabling you to run the Student Portal and Admin Dashboard side-by-side in the same window.
+      (function() {
+        const SESSION_KEYS = new Set([
+          'yaksha_token',
+          'yaksha_refresh_token',
+          'yaksha_user',
+          'yaksha_active_program_id',
+          'yaksha_active_batch_id'
+        ]);
+
+        const originalGetItem = Storage.prototype.getItem;
+        const originalSetItem = Storage.prototype.setItem;
+        const originalRemoveItem = Storage.prototype.removeItem;
+
+        Storage.prototype.getItem = function(key) {
+          if (this === window.localStorage && SESSION_KEYS.has(key)) {
+            return window.sessionStorage.getItem(key);
+          }
+          return originalGetItem.call(this, key);
+        };
+
+        Storage.prototype.setItem = function(key, value) {
+          if (this === window.localStorage && SESSION_KEYS.has(key)) {
+            return window.sessionStorage.setItem(key, value);
+          }
+          return originalSetItem.call(this, key, value);
+        };
+
+        Storage.prototype.removeItem = function(key) {
+          if (this === window.localStorage && SESSION_KEYS.has(key)) {
+            return window.sessionStorage.removeItem(key);
+          }
+          return originalRemoveItem.call(this, key);
+        };
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/admin/pages/AdminAISettings.tsx
+++ b/apps/frontend/src/admin/pages/AdminAISettings.tsx
@@ -1432,7 +1432,15 @@ export default function AdminAISettings() {
     );
   }
 
-  const currentMeta = PROVIDER_META[activeProvider as ProviderKey];
+  const currentMeta = PROVIDER_META[activeProvider as ProviderKey] || {
+    label: 'None',
+    description: 'No active AI provider configured',
+    defaultModel: 'None',
+    defaultBaseURL: '',
+    docsUrl: '',
+    badgeColor: 'bg-border/60 text-ink-soft border-border',
+    suggestedModels: []
+  };
   const monoInput = 'w-full px-3 py-2 rounded-lg text-xs border bg-bg-secondary text-ink font-mono focus:outline-none transition-colors admin-input';
 
   return (

--- a/apps/frontend/src/admin/pages/AdminCommunity.tsx
+++ b/apps/frontend/src/admin/pages/AdminCommunity.tsx
@@ -20,6 +20,7 @@ interface CommunityPost {
   answer?: string;
   reports?: Array<{ reportedBy: string; reason: string; createdAt?: string }>;
   tags?: string[];
+  lifecycle?: { status: string };
 }
 interface CommunityPostsResponse {
   posts: CommunityPost[];
@@ -60,7 +61,8 @@ export default function AdminCommunity() {
       setPosts(r.data.posts);
       setTotal(r.data.total);
       setPages(r.data.pages);
-      setCategories(r.data.categories || []);
+      const cats = r.data.categories || [];
+      setCategories([...cats].sort((a, b) => a.name.localeCompare(b.name)));
     }).finally(() => setLoading(false));
   }, [page, debouncedSearch, statusFilter, categoryFilter]);
 
@@ -139,7 +141,10 @@ export default function AdminCommunity() {
           <input type="text" placeholder="Search posts…" value={search} onChange={e => setSearch(e.target.value)} className={`${adminSearchInput}`} />
         </div>
         <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className={`${adminSelect}`}>
-          <option value="">All Status</option><option value="unanswered">Unanswered</option><option value="answered">Answered</option>
+          <option value="">All Status</option>
+          <option value="unanswered">Unanswered</option>
+          <option value="answered">Answered</option>
+          <option value="promoted">Promoted to FAQ</option>
         </select>
       </div>
 
@@ -181,7 +186,13 @@ export default function AdminCommunity() {
                     {post.title}
                   </td>
                   <td className="admin-td text-ink-faint">{post.author?.name ?? '—'}</td>
-                  <td className="admin-td"><Badge status={post.status === 'answered' ? 'approved' : 'pending'} label={post.status} showDot={false} /></td>
+                  <td className="admin-td">
+                    {post.lifecycle?.status === 'converted_to_faq' ? (
+                      <Badge status="approved" label="promoted" showDot={false} />
+                    ) : (
+                      <Badge status={post.status === 'answered' ? 'approved' : 'pending'} label={post.status} showDot={false} />
+                    )}
+                  </td>
                   <td className="admin-td text-right">
                     {(post.reports?.length ?? 0) > 0 ? (
                       <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-danger/10 border border-danger/20 text-[10px] font-bold text-danger">{post.reports!.length}</span>
@@ -227,8 +238,16 @@ export default function AdminCommunity() {
               );
             })()}
             <div><p className={`${adminLabel}`}>Author</p><p className="text-sm text-ink-soft">{viewPost.author?.name} ({viewPost.author?.email})</p></div>
+            <div><p className={`${adminLabel}`}>Upvotes</p><p className="text-sm text-ink-soft">{viewPost.upvotes?.length ?? 0} upvote(s)</p></div>
             <div><p className={`${adminLabel}`}>Body</p><p className="text-sm text-ink-soft whitespace-pre-wrap">{viewPost.body}</p></div>
-            <div><p className={`${adminLabel}`}>Status</p><Badge status={viewPost.status === 'answered' ? 'approved' : 'pending'} label={viewPost.status} showDot={false} /></div>
+            <div>
+              <p className={`${adminLabel}`}>Status</p>
+              {viewPost.lifecycle?.status === 'converted_to_faq' ? (
+                <Badge status="approved" label="promoted to FAQ" showDot={false} />
+              ) : (
+                <Badge status={viewPost.status === 'answered' ? 'approved' : 'pending'} label={viewPost.status} showDot={false} />
+              )}
+            </div>
             {viewPost.answer && <div><p className={`${adminLabel}`}>Official Answer</p><p className="text-sm text-success whitespace-pre-wrap border-l-2 border-success/40 pl-3">{viewPost.answer}</p></div>}
             {viewPost.reports && viewPost.reports.length > 0 && (
               <div className="p-3 rounded-lg bg-danger/10 border border-danger/20">

--- a/apps/frontend/src/admin/pages/AdminFAQs.tsx
+++ b/apps/frontend/src/admin/pages/AdminFAQs.tsx
@@ -158,10 +158,10 @@ export default function AdminFAQs() {
   const debouncedSearch = useDebounce(search, 350);
 
   const { data: addCategoriesData } = useCategories(newFaq.batchId || null, null);
-  const addCategories = addCategoriesData?.categories.map(c => c.name) ?? [];
+  const addCategories = [...(addCategoriesData?.categories.map(c => c.name) ?? [])].sort((a, b) => a.localeCompare(b));
 
   const { data: editCategoriesData } = useCategories(editFaq?.batchId || null, null);
-  const editCategories = editCategoriesData?.categories.map(c => c.name) ?? [];
+  const editCategories = [...(editCategoriesData?.categories.map(c => c.name) ?? [])].sort((a, b) => a.localeCompare(b));
 
   // Batches for the selectors and list filter
   const [batches, setBatches] = useState<AdminBatch[]>([]);

--- a/apps/frontend/src/components/community/CommentNode.tsx
+++ b/apps/frontend/src/components/community/CommentNode.tsx
@@ -26,6 +26,7 @@ interface CommentNodeProps {
   onReplyAdded: (newComment: Comment, parentId: string | null) => void;
   onCommentDeleted?: (commentId: string, parentId: string | null) => void;
   onPostUpdated?: (updatedPost: any) => void;
+  onCommentVote?: (commentId: string, upvotes: any[], downvotes: any[]) => void;
   depth?: number;
   threadColor?: string;
   barColor?: string;
@@ -56,6 +57,7 @@ export default function CommentNode({
   onReplyAdded,
   onCommentDeleted,
   onPostUpdated,
+  onCommentVote,
   depth = 0,
   threadColor,
   barColor,
@@ -81,6 +83,22 @@ export default function CommentNode({
   const [editText, setEditText] = useState(comment.body);
   const [editLoading, setEditLoading] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
+
+  React.useEffect(() => {
+    setLocalUpvotes(comment.upvotes ?? []);
+  }, [comment.upvotes]);
+
+  React.useEffect(() => {
+    setLocalDownvotes(comment.downvotes ?? []);
+  }, [comment.downvotes]);
+
+  React.useEffect(() => {
+    setLocalReplies(comment.replies ?? []);
+  }, [comment.replies]);
+
+  React.useEffect(() => {
+    setLocalVerified(comment.verified ?? null);
+  }, [comment.verified]);
 
   // Derived values that canEdit/canDelete depend on
   const isExpert = comment.isExpertAnswer;
@@ -117,29 +135,31 @@ export default function CommentNode({
 
     setLocalUpvotes(prev =>
       isUpvoted
-        ? prev.filter(u => idMatches(u, currentUserId))
+        ? prev.filter(u => !idMatches(u, currentUserId))
         : [...prev, currentUserId]
     );
     setLocalDownvotes(prev =>
-      prev.filter(u => idMatches(u, currentUserId))
+      prev.filter(u => !idMatches(u, currentUserId))
     );
 
     api.post<{ upvotedByMe: boolean }>(`/community/${postId}/comments/${comment._id}/upvote`)
       .then(res => {
-        // H11 FIX: use previousUpvotes/previousDownvotes (captured before
-        // optimistic mutation) instead of localUpvotes/localDownvotes which
-        // are already mutated by the time .then() fires.
-        setLocalUpvotes(res.data.upvotedByMe
-          ? [...(previousUpvotes.filter(u => idMatches(u, currentUserId))), currentUserId]
-          : previousUpvotes.filter(u => idMatches(u, currentUserId))
-        );
-        setLocalDownvotes(prev =>
-          prev.filter(u => idMatches(u, currentUserId))
-        );
+        const nextUpvotes = res.data.upvotedByMe
+          ? [...(previousUpvotes.filter(u => !idMatches(u, currentUserId))), currentUserId]
+          : previousUpvotes.filter(u => !idMatches(u, currentUserId));
+        const nextDownvotes = previousDownvotes.filter(u => !idMatches(u, currentUserId));
+
+        setLocalUpvotes(nextUpvotes);
+        setLocalDownvotes(nextDownvotes);
+        if (onCommentVote) {
+          onCommentVote(comment._id, nextUpvotes, nextDownvotes);
+        }
       })
-      .catch(() => {
+      .catch((err) => {
         setLocalUpvotes(previousUpvotes);
         setLocalDownvotes(previousDownvotes);
+        const msg = err.response?.data?.message || 'Failed to vote.';
+        alert(msg);
       });
   };
 
@@ -156,11 +176,11 @@ export default function CommentNode({
 
     setLocalDownvotes(prev =>
       isDownvoted
-        ? prev.filter(u => idMatches(u, currentUserId))
+        ? prev.filter(u => !idMatches(u, currentUserId))
         : [...prev, currentUserId]
     );
     setLocalUpvotes(prev =>
-      prev.filter(u => idMatches(u, currentUserId))
+      prev.filter(u => !idMatches(u, currentUserId))
     );
 
     api.post<{ deleted?: boolean; downvotedByMe: boolean }>(
@@ -172,16 +192,21 @@ export default function CommentNode({
         if (el) { el.style.setProperty('--current-opacity', String(commentOpacity)); el.classList.add('comment-dying'); }
         return;
       }
-      setLocalDownvotes(res.data.downvotedByMe
-        ? [...(localDownvotes.filter(u => idMatches(u, currentUserId))), currentUserId]
-        : localDownvotes.filter(u => idMatches(u, currentUserId))
-      );
-      setLocalUpvotes(prev =>
-        prev.filter(u => idMatches(u, currentUserId))
-      );
-    }).catch(() => {
+      const nextDownvotes = res.data.downvotedByMe
+        ? [...(previousDownvotes.filter(u => !idMatches(u, currentUserId))), currentUserId]
+        : previousDownvotes.filter(u => !idMatches(u, currentUserId));
+      const nextUpvotes = previousUpvotes.filter(u => !idMatches(u, currentUserId));
+
+      setLocalDownvotes(nextDownvotes);
+      setLocalUpvotes(nextUpvotes);
+      if (onCommentVote) {
+        onCommentVote(comment._id, nextUpvotes, nextDownvotes);
+      }
+    }).catch((err) => {
       setLocalDownvotes(previousDownvotes);
       setLocalUpvotes(previousUpvotes);
+      const msg = err.response?.data?.message || 'Failed to vote.';
+      alert(msg);
     });
   };
 
@@ -436,22 +461,30 @@ export default function CommentNode({
             {/* Children */}
             {localReplies.length > 0 && (
               <div className={`mt-1 border-l-2 ${color.replace('border-', 'border-')}/40 rounded-bl ml-1 pl-2 space-y-1`}>
-                {localReplies.map(reply => (
-                  <CommentNode
-                    key={reply._id}
-                    comment={reply}
-                    postId={postId}
-                    currentUserId={currentUserId}
-                    userRole={userRole}
-                    postAuthorId={postAuthorId}
-                    onReplyAdded={onReplyAdded}
-                    onCommentDeleted={onCommentDeleted}
-                    onPostUpdated={onPostUpdated}
-                    depth={depth + 1}
-                    threadColor={DEPTH_COLORS[(depth + 1) % DEPTH_COLORS.length]}
-                    barColor={DEPTH_BARS[(depth + 1) % DEPTH_BARS.length]}
-                  />
-                ))}
+                {[...localReplies]
+                  .sort((a, b) => {
+                    const aScore = (a.upvotes?.length ?? 0) - (a.downvotes?.length ?? 0);
+                    const bScore = (b.upvotes?.length ?? 0) - (b.downvotes?.length ?? 0);
+                    if (aScore !== bScore) return bScore - aScore;
+                    return new Date(a.createdAt ?? 0).getTime() - new Date(b.createdAt ?? 0).getTime();
+                  })
+                  .map(reply => (
+                    <CommentNode
+                      key={reply._id}
+                      comment={reply}
+                      postId={postId}
+                      currentUserId={currentUserId}
+                      userRole={userRole}
+                      postAuthorId={postAuthorId}
+                      onReplyAdded={onReplyAdded}
+                      onCommentDeleted={onCommentDeleted}
+                      onPostUpdated={onPostUpdated}
+                      onCommentVote={onCommentVote}
+                      depth={depth + 1}
+                      threadColor={DEPTH_COLORS[(depth + 1) % DEPTH_COLORS.length]}
+                      barColor={DEPTH_BARS[(depth + 1) % DEPTH_BARS.length]}
+                    />
+                  ))}
               </div>
             )}
           </>

--- a/apps/frontend/src/components/community/CreatePostDialog.tsx
+++ b/apps/frontend/src/components/community/CreatePostDialog.tsx
@@ -186,6 +186,7 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
   const [customCategory, setCustomCategory] = useState<string>('');
   const [duplicateMatch, setDuplicateMatch] = useState<{ isDuplicate: boolean; matches: DuplicateMatch[] } | null>(null);
   const [checkingDuplicates, setCheckingDuplicates] = useState(false);
+  const [expandedMatchId, setExpandedMatchId] = useState<string | null>(null);
   const [floatAway] = useState(false);
   const duplicateCheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -235,15 +236,30 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
 
   useEffect(() => {
     if (duplicateCheckTimerRef.current) clearTimeout(duplicateCheckTimerRef.current);
-    const q = title.trim();
-    if (q.length < 10) {
+    
+    const tClean = title.trim();
+    const bClean = body.trim();
+    
+    // Trigger duplicate check if either title or description is at least 10 characters long
+    if (tClean.length < 10 && bClean.length < 10) {
       setDuplicateMatch(null);
       setCheckingDuplicates(false);
       return;
     }
+
     setCheckingDuplicates(true);
     duplicateCheckTimerRef.current = setTimeout(async () => {
       try {
+        // Combine title and description for a comprehensive semantic search
+        let q = '';
+        if (tClean.length >= 10 && bClean.length >= 10) {
+          q = `${tClean} ${bClean}`;
+        } else if (tClean.length >= 10) {
+          q = tClean;
+        } else {
+          q = bClean;
+        }
+
         const res = await api.post<{ isDuplicate: boolean; matches: DuplicateMatch[] }>('/community/check-duplicate', { query: q });
         setDuplicateMatch(res.data);
       } catch {
@@ -253,7 +269,7 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
       }
     }, 600);
     return () => { if (duplicateCheckTimerRef.current) clearTimeout(duplicateCheckTimerRef.current); };
-  }, [title]);
+  }, [title, body]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -414,12 +430,11 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
             <div className="faq-match-banner">
               <div className="flex items-center gap-1.5 mb-2">
                 <span>📖</span>
-                <p className="font-medium text-sm">Similar question found!</p>
-                <span className="ml-auto text-[10px] text-ink-faint">Click to view</span>
+                <p className="font-medium text-sm text-ink">Similar question found!</p>
+                <span className="ml-auto text-[10px] text-ink-faint">Click to expand answer</span>
               </div>
               <div className="space-y-1">
                 {duplicateMatch.matches.slice(0, 3).map((m: any, i: number) => {
-                  // Decide where to send the user
                   const href = m.source === 'faq'
                     ? `/faq/${m._id}`
                     : m.source === 'community'
@@ -427,33 +442,63 @@ export default function CreatePostDialog({ onClose, onCreated, prefillTitle = ''
                       : `/faq/${m._id}`;
                   const icon = m.source === 'faq' ? '📋' : m.source === 'community' ? '💬' : '🧠';
                   const label = m.source === 'faq' ? 'FAQ' : m.source === 'community' ? 'Community' : 'Knowledge';
+                  const isExpanded = expandedMatchId === m._id;
+
                   return (
-                    <button
+                    <div
                       key={i}
-                      type="button"
-                      onClick={() => {
-                        // Close dialog and navigate to the existing item
-                        dialogRef.current?.close();
-                        navigate(href);
-                      }}
-                      className={communityTemplateCard}
+                      onClick={() => setExpandedMatchId(isExpanded ? null : m._id)}
+                      className={`${communityTemplateCard} flex-col !items-stretch cursor-pointer select-none`}
                     >
-                      <span className="shrink-0 mt-0.5">{icon}</span>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <span className={communityTemplateLabel}>{label}</span>
-                          {m.score && (
-                            <span className="text-[10px] text-ink-faint">{(m.score * 100).toFixed(0)}% match</span>
-                          )}
+                      <div className="flex items-center gap-3">
+                        <span className="shrink-0">{icon}</span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-1.5">
+                            <span className={communityTemplateLabel}>{label}</span>
+                            {m.score && (
+                              <span className="text-[10px] text-ink-faint">{(m.score * 100).toFixed(0)}% match</span>
+                            )}
+                          </div>
+                          <p className="text-xs text-ink-soft group-hover:text-ink font-medium line-clamp-1">
+                            "{m.question || m.title}"
+                          </p>
                         </div>
-                        <p className="text-xs text-ink-soft group-hover:text-ink line-clamp-1">
-                          "{m.question || m.title}"
-                        </p>
+                        <svg
+                          className={`${communityTemplateIcon} transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M9 18l6-6-6-6" />
+                        </svg>
                       </div>
-                      <svg className={communityTemplateIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M9 18l6-6-6-6"/>
-                      </svg>
-                    </button>
+
+                      {isExpanded && (
+                        <div
+                          className="mt-2.5 pt-2.5 border-t border-border/40 text-xs"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <div className="bg-mist text-ink-soft rounded-xl p-3 border border-border/30 whitespace-pre-wrap leading-relaxed">
+                            {m.answer || m.body || 'No description available.'}
+                          </div>
+                          <div className="flex gap-2 mt-2 justify-end">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                dialogRef.current?.close();
+                                navigate(href);
+                              }}
+                              className="text-[10px] font-bold text-accent hover:underline flex items-center gap-0.5 px-2.5 py-1 rounded-lg bg-accent/5"
+                            >
+                              Go to full post →
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
               </div>

--- a/apps/frontend/src/components/community/PostDetailDialog.tsx
+++ b/apps/frontend/src/components/community/PostDetailDialog.tsx
@@ -283,38 +283,48 @@ function CommentItem({ comment, post, currentUserId, userRole, onUpdate }: {
   const [actionError, setActionError] = useState<string | null>(null);
 
   const handleUpvote = async () => {
-    const res = await api.post<{ upvotedByMe: boolean }>(
-      `/community/${post._id}/comments/${comment._id}/upvote`
-    );
-    onUpdate((post.comments as Comment[]).map(c =>
-      c._id === comment._id ? {
-        ...c,
-        upvotes: res.data.upvotedByMe
-          ? [...(c.upvotes || []), currentUserId]
-          : (c.upvotes || []).filter(u => idMatches(u, currentUserId)),
-        downvotes: (c.downvotes || []).filter(u => idMatches(u, currentUserId)),
-      } : c
-    ));
+    try {
+      const res = await api.post<{ upvotedByMe: boolean }>(
+        `/community/${post._id}/comments/${comment._id}/upvote`
+      );
+      onUpdate((post.comments as Comment[]).map(c =>
+        c._id === comment._id ? {
+          ...c,
+          upvotes: res.data.upvotedByMe
+            ? [...(c.upvotes || []), currentUserId]
+            : (c.upvotes || []).filter(u => idMatches(u, currentUserId)),
+          downvotes: (c.downvotes || []).filter(u => idMatches(u, currentUserId)),
+        } : c
+      ));
+    } catch (err: any) {
+      const msg = err.response?.data?.message || 'Failed to vote.';
+      alert(msg);
+    }
   };
 
   const handleDownvote = async () => {
-    const res = await api.post<{ deleted?: boolean; downvotedByMe: boolean }>(
-      `/community/${post._id}/comments/${comment._id}/downvote`
-    );
-    if (res.data.deleted) {
-      try { new Audio('/fahhhhh.mp3').play(); } catch (_) { void 0 }
-      onUpdate((post.comments as Comment[]).filter(c => c._id !== comment._id));
-      return;
+    try {
+      const res = await api.post<{ deleted?: boolean; downvotedByMe: boolean }>(
+        `/community/${post._id}/comments/${comment._id}/downvote`
+      );
+      if (res.data.deleted) {
+        try { new Audio('/fahhhhh.mp3').play(); } catch (_) { void 0 }
+        onUpdate((post.comments as Comment[]).filter(c => c._id !== comment._id));
+        return;
+      }
+      onUpdate((post.comments as Comment[]).map(c =>
+        c._id === comment._id ? {
+          ...c,
+          downvotes: res.data.downvotedByMe
+            ? [...(c.downvotes || []), currentUserId]
+            : (c.downvotes || []).filter(u => idMatches(u, currentUserId)),
+          upvotes: (c.upvotes || []).filter(u => idMatches(u, currentUserId)),
+        } : c
+      ));
+    } catch (err: any) {
+      const msg = err.response?.data?.message || 'Failed to vote.';
+      alert(msg);
     }
-    onUpdate((post.comments as Comment[]).map(c =>
-      c._id === comment._id ? {
-        ...c,
-        downvotes: res.data.downvotedByMe
-          ? [...(c.downvotes || []), currentUserId]
-          : (c.downvotes || []).filter(u => idMatches(u, currentUserId)),
-        upvotes: (c.upvotes || []).filter(u => idMatches(u, currentUserId)),
-      } : c
-    ));
   };
 
   const handleReply = async (e: React.FormEvent) => {
@@ -528,8 +538,10 @@ export default function PostDetailDialog({ post: initialPost, onClose, currentUs
         ? [...prev.filter(id => idMatches(id, currentUserId)), currentUserId]
         : prev.filter(id => idMatches(id, currentUserId))
       }));
-    } catch {
+    } catch (err: any) {
       setPost(p => ({ ...p, upvotes: prev }));
+      const msg = err.response?.data?.message || 'Failed to upvote.';
+      alert(msg);
     }
   };
 

--- a/apps/frontend/src/components/community/PromoteToFaqDialog.tsx
+++ b/apps/frontend/src/components/community/PromoteToFaqDialog.tsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Button from '../ui/Button';
+import api, { friendlyError } from '../../utils/api';
+import { useBatch } from '../../context/BatchContext';
+import { useCategories } from '../explore/usePublicFaqApi';
+import type { ThreadPost } from './ThreadDetail';
+
+interface PromoteToFaqDialogProps {
+  post: ThreadPost;
+  onClose: () => void;
+  onPromoted: (updatedPost: any) => void;
+}
+
+export default function PromoteToFaqDialog({ post, onClose, onPromoted }: PromoteToFaqDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const { currentBatch } = useBatch();
+  const { data: categoriesData } = useCategories(currentBatch?._id ?? null, null);
+  const categories: string[] = [...(categoriesData?.categories?.map((c: any) => c.name as string) || [])].sort((a, b) => a.localeCompare(b));
+
+  const [question, setQuestion] = useState(post.title);
+  const [answer, setAnswer] = useState(() => {
+    if (post.answer) return post.answer;
+    // Fallback to accepted comment if found
+    const acceptedComment = post.comments?.find((c: any) => c.verified);
+    return acceptedComment?.body || '';
+  });
+  
+  const [categoryOption, setCategoryOption] = useState(() => {
+    const primaryTag = post.tags?.[0] || '';
+    if (primaryTag && categories.includes(primaryTag)) {
+      return primaryTag;
+    }
+    return '';
+  });
+  
+  const [customCategory, setCustomCategory] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+
+    const handleClose = () => onClose();
+    dialog.addEventListener('close', handleClose);
+
+    const handleBackdropClick = (e: MouseEvent) => {
+      if (e.target === dialog) {
+        dialog.close();
+      }
+    };
+    dialog.addEventListener('click', handleBackdropClick);
+
+    return () => {
+      dialog.removeEventListener('close', handleClose);
+      dialog.removeEventListener('click', handleBackdropClick);
+    };
+  }, [onClose]);
+
+  // Sync category prefill if categories load late
+  useEffect(() => {
+    const primaryTag = post.tags?.[0] || '';
+    if (primaryTag && categories.length > 0) {
+      if (categories.includes(primaryTag)) {
+        setCategoryOption(primaryTag);
+      } else {
+        setCategoryOption('__other__');
+        setCustomCategory(primaryTag);
+      }
+    }
+  }, [categoriesData, post.tags]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    const finalCategory = categoryOption === '__other__' ? customCategory.trim() : categoryOption;
+
+    if (!question.trim()) {
+      setError('Question text is required.');
+      return;
+    }
+    if (!answer.trim()) {
+      setError('Answer text is required.');
+      return;
+    }
+    if (!finalCategory) {
+      setError('Please select or enter a category.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await api.post<{ message: string; faq: any; post: any }>(
+        `/community/${post._id}/convert-to-faq`,
+        {
+          question: question.trim(),
+          answer: answer.trim(),
+          category: finalCategory,
+        }
+      );
+      onPromoted(res.data.post || { ...post, lifecycle: { ...post.lifecycle, status: 'converted_to_faq' } });
+      dialogRef.current?.close();
+    } catch (err) {
+      setError(friendlyError(err, 'Failed to promote post to FAQ. Please try again.'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-full max-w-lg rounded-2xl border border-border shadow-2xl bg-card p-0 backdrop:bg-ink/30 backdrop:backdrop-blur-sm transition-all duration-300"
+    >
+      <div className="p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div>
+            <h2 className="text-base font-semibold text-ink">Promote to Official FAQ</h2>
+            <p className="text-xs text-ink-soft mt-0.5">Customize the question and answer before publishing to the FAQ page.</p>
+          </div>
+          <button
+            onClick={() => dialogRef.current?.close()}
+            aria-label="Close dialog"
+            className="w-8 h-8 rounded-full bg-mist flex items-center justify-center text-ink-soft hover:text-ink hover:bg-border transition-all"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M2 2L10 10M10 2L2 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-ink-soft mb-1.5">
+              Question Title <span className="text-danger">*</span>
+            </label>
+            <input
+              type="text"
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="E.g. Is attendance mandatory for all sessions?"
+              required
+              className="w-full rounded-xl border border-border bg-mist px-3 py-2.5 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card transition-all"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-ink-soft mb-1.5">
+              Official Answer <span className="text-danger">*</span>
+            </label>
+            <textarea
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              placeholder="Provide the official answer..."
+              rows={4}
+              required
+              className="w-full rounded-xl border border-border bg-mist px-3 py-2.5 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card transition-all"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-ink-soft mb-1.5">
+              FAQ Category <span className="text-danger">*</span>
+            </label>
+            <div className="relative">
+              <select
+                value={categoryOption}
+                onChange={(e) => setCategoryOption(e.target.value)}
+                className="w-full rounded-xl border border-border bg-mist px-3 py-2.5 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card transition-all appearance-none cursor-pointer"
+              >
+                <option value="">Select a category</option>
+                {categories.filter(Boolean).map((cat: string) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+                <option value="__other__">Other (Create new)...</option>
+              </select>
+              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-ink-soft">
+                <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                  <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
+                </svg>
+              </div>
+            </div>
+
+            {categoryOption === '__other__' && (
+              <input
+                type="text"
+                value={customCategory}
+                onChange={(e) => setCustomCategory(e.target.value)}
+                placeholder="Enter custom category name..."
+                required
+                className="w-full mt-2 rounded-xl border border-border bg-mist px-3 py-2.5 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card transition-all"
+              />
+            )}
+          </div>
+
+          {error && (
+            <p className="text-xs text-danger bg-danger-light border border-danger/15 rounded-xl px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-2 pt-2">
+            <Button
+              type="submit"
+              loading={loading}
+              className="flex-1"
+            >
+              Promote to FAQ
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => dialogRef.current?.close()}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+    </dialog>
+  );
+}

--- a/apps/frontend/src/components/community/ThreadDetail.tsx
+++ b/apps/frontend/src/components/community/ThreadDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api, { friendlyError } from '../../utils/api';
 import Avatar from '../ui/Avatar';
@@ -8,6 +8,7 @@ import CommentNode from './CommentNode';
 import ThreadActivityTimeline, { type LifecycleStatusHistoryEntry } from './ThreadActivityTimeline';
 import ThreadBookmarkButton from './ThreadBookmarkButton';
 import ThreadShareButton from './ThreadShareButton';
+import PromoteToFaqDialog from './PromoteToFaqDialog';
 import type { Post } from '../../types/ui';
 import type { GcsAsset } from '../../hooks/useGcsUpload';
 import { buildGcsTransformedUrl } from '../../utils/gcsTransform';
@@ -52,6 +53,7 @@ export interface ThreadPost {
   status?: 'answered' | 'unanswered' | string;
   author?: { name?: string; _id?: string };
   createdAt?: string;
+  tags?: string[];
   upvotes?: (string | { _id?: string })[];
   downvotes?: (string | { _id?: string })[];
   comments?: Comment[];
@@ -90,6 +92,18 @@ interface ThreadDetailProps {
 
 
 
+const updateCommentInTree = (comments: Comment[], targetId: string, upvotes: any[], downvotes: any[]): Comment[] => {
+  return comments.map((c) => {
+    if (c._id === targetId) {
+      return { ...c, upvotes, downvotes };
+    }
+    if (c.replies && c.replies.length > 0) {
+      return { ...c, replies: updateCommentInTree(c.replies, targetId, upvotes, downvotes) };
+    }
+    return c;
+  });
+};
+
 // ─── ThreadDetail Modal ───────────────────────────────────────────────────────
 
 export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
@@ -109,6 +123,7 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
   const [resolveText, setResolveText] = useState('');
   const [resolveLoading, setResolveLoading] = useState(false);
   const [showReportForm, setShowReportForm] = useState(false);
+  const [showPromoteDialog, setShowPromoteDialog] = useState(false);
   const [reportReason, setReportReason] = useState('');
   const [reportLoading, setReportLoading] = useState(false);
   const [reportDone, setReportDone] = useState(false);
@@ -129,7 +144,32 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
   );
   const canResolve = userRole === 'admin' || userRole === 'moderator' || userRole === 'expert';
   const isPrivileged = userRole === 'admin' || userRole === 'moderator';
-  const topLevelComments = post?.comments ?? [];
+  const canPromote = userRole === 'admin' || userRole === 'moderator' || userRole === 'expert';
+  const handleCommentVote = useCallback((commentId: string, upvotes: any[], downvotes: any[]) => {
+    setPost((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        comments: updateCommentInTree(prev.comments ?? [], commentId, upvotes, downvotes),
+      };
+    });
+  }, []);
+
+  const topLevelComments = useMemo(() => {
+    const comments = post?.comments ?? [];
+    return [...comments].sort((a, b) => {
+      const aUpvotes = a.upvotes?.length ?? 0;
+      const aDownvotes = a.downvotes?.length ?? 0;
+      const bUpvotes = b.upvotes?.length ?? 0;
+      const bDownvotes = b.downvotes?.length ?? 0;
+      const aScore = aUpvotes - aDownvotes;
+      const bScore = bUpvotes - bDownvotes;
+      if (aScore !== bScore) {
+        return bScore - aScore;
+      }
+      return new Date(a.createdAt ?? 0).getTime() - new Date(b.createdAt ?? 0).getTime();
+    });
+  }, [post?.comments]);
 
   /** Safe navigation: external URLs open in new tab, internal ones use SPA routing. */
   const navigateTo = (url: string) => {
@@ -195,7 +235,7 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
             : previousUpvotes.filter((u) => (typeof u === 'object' ? (u as { _id?: string })._id || u : u)?.toString() !== currentUserId),
         } : prev
       );
-    } catch (e) {
+    } catch (e: any) {
       // Rollback
       setPost((prev) =>
         prev ? {
@@ -203,6 +243,8 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
           upvotes: previousUpvotes,
         } : prev
       );
+      const msg = e.response?.data?.message || 'Failed to upvote.';
+      alert(msg);
       // friendlyError ensures no raw backend strings reach the user.
       setActionError(friendlyError(e, 'Upvote failed. Please try again.'));
       setTimeout(() => setActionError(null), 3000);
@@ -647,6 +689,26 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
               </div>
               <p className="text-sm text-ink/80 leading-relaxed">{post.answer}</p>
 
+              {/* Promote to FAQ actions */}
+              {canPromote && post.lifecycle?.status !== 'converted_to_faq' && (
+                <div className="mt-4 pt-3 border-t border-success/15 flex justify-end">
+                  <button
+                    onClick={() => setShowPromoteDialog(true)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-success text-success-text hover:bg-success/90 text-xs font-semibold shadow-sm transition-all"
+                  >
+                    <span>🎓</span>
+                    Promote to FAQ
+                  </button>
+                </div>
+              )}
+              {post.lifecycle?.status === 'converted_to_faq' && (
+                <div className="mt-4 pt-3 border-t border-success/15 flex justify-end">
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-mist text-ink-soft border border-border text-xs font-semibold select-none">
+                    <span>✓</span> Promoted to FAQ
+                  </span>
+                </div>
+              )}
+
               {/* DNA Strip */}
               {post.dna && (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -770,78 +832,98 @@ export default function ThreadDetail({ postId, onClose }: ThreadDetailProps) {
           )}
 
           {/* Comments — Reddit-style threaded */}
-          <div className="px-6 sm:px-8 py-6 border-t border-border/40">
-            <h3 className="text-sm font-semibold text-ink uppercase tracking-wide mb-4 flex items-center gap-2">
-              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-ink-faint">
-                <path d="M1 3C1 2.17 1.67 1.5 2.5 1.5h9C12.33 1.5 13 2.17 13 3v6C13 9.83 12.33 10.5 11.5 10.5H8.5L5.5 13V10.5H2.5C1.67 10.5 1 9.83 1 9V3z" strokeLinejoin="round"/>
-              </svg>
-              Discussion ({topLevelComments.length})
-            </h3>
-            {topLevelComments.length === 0 ? (
-              <div className="text-center py-10">
-                <div className="w-12 h-12 rounded-2xl bg-mist flex items-center justify-center mx-auto mb-3">
-                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-ink-faint">
-                    <path d="M2 4c0-1.1.9-2 2-2h12a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4H4a2 2 0 01-2-2V4z" strokeLinejoin="round"/>
-                    <path d="M7 8h6M7 11h4" strokeLinecap="round"/>
-                  </svg>
+          {!isAnswered ? (
+            <div className="px-6 sm:px-8 py-6 border-t border-border/40">
+              <h3 className="text-sm font-semibold text-ink uppercase tracking-wide mb-4 flex items-center gap-2">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-ink-faint">
+                  <path d="M1 3C1 2.17 1.67 1.5 2.5 1.5h9C12.33 1.5 13 2.17 13 3v6C13 9.83 12.33 10.5 11.5 10.5H8.5L5.5 13V10.5H2.5C1.67 10.5 1 9.83 1 9V3z" strokeLinejoin="round"/>
+                </svg>
+                Discussion ({topLevelComments.length})
+              </h3>
+              {topLevelComments.length === 0 ? (
+                <div className="text-center py-10">
+                  <div className="w-12 h-12 rounded-2xl bg-mist flex items-center justify-center mx-auto mb-3">
+                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-ink-faint">
+                      <path d="M2 4c0-1.1.9-2 2-2h12a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4H4a2 2 0 01-2-2V4z" strokeLinejoin="round"/>
+                      <path d="M7 8h6M7 11h4" strokeLinecap="round"/>
+                    </svg>
+                  </div>
+                  <p className="text-sm text-ink-faint">No comments yet. Be the first to comment!</p>
                 </div>
-                <p className="text-sm text-ink-faint">No comments yet. Be the first to comment!</p>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {topLevelComments.map((comment: Comment) => (
-                  <CommentNode
-                    key={comment._id}
-                    comment={comment}
-                    postId={post?._id ?? ''}
-                    currentUserId={user?._id ?? ''}
-                    userRole={userRole}
-                    postAuthorId={post?.author?._id}
-                    onReplyAdded={handleReplyAdded}
-                    onCommentDeleted={handleCommentDeleted}
-                    onPostUpdated={(updatedPost) => setPost(updatedPost)}
-                    threadColor={DEPTH_COLORS[0]}
-                    barColor={DEPTH_BARS[0]}
-                  />
-                ))}
-                              </div>
-                            )}
-                          </div>
-                        </div>
+              ) : (
+                <div className="space-y-2">
+                  {topLevelComments.map((comment: Comment) => (
+                    <CommentNode
+                      key={comment._id}
+                      comment={comment}
+                      postId={post?._id ?? ''}
+                      currentUserId={user?._id ?? ''}
+                      userRole={userRole}
+                      postAuthorId={post?.author?._id}
+                      onReplyAdded={handleReplyAdded}
+                      onCommentDeleted={handleCommentDeleted}
+                      onPostUpdated={(updatedPost) => setPost(updatedPost)}
+                      onCommentVote={handleCommentVote}
+                      threadColor={DEPTH_COLORS[0]}
+                      barColor={DEPTH_BARS[0]}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="px-6 sm:px-8 py-8 border-t border-border/40 text-center bg-mist/20 select-none">
+              <span className="text-xl">🔒</span>
+              <p className="text-sm font-semibold text-ink-soft mt-2">Discussion Closed</p>
+              <p className="text-xs text-ink-faint mt-1">This question has been officially resolved, and comments are disabled.</p>
+            </div>
+          )}
+        </div>
 
                         {/* Sticky footer — new comment */}
-                        <form onSubmit={handleCommentSubmit} className="px-6 sm:px-8 pt-4 pb-6 border-t border-border bg-card flex-shrink-0">
-                          <div className="flex gap-3 items-start">
-                            <Avatar name={user?.name} size="sm" className="mt-1" />
-                            <div className="flex-1 min-w-0">
-                              <textarea
-                                value={commentText}
-                                onChange={(e) => setCommentText(e.target.value)}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter' && !e.shiftKey) {
-                                    e.preventDefault();
-                                    if (commentText.trim() && !commentLoading) {
-                                      handleCommentSubmit(e as unknown as React.FormEvent);
+                        {!isAnswered && (
+                          <form onSubmit={handleCommentSubmit} className="px-6 sm:px-8 pt-4 pb-6 border-t border-border bg-card flex-shrink-0">
+                            <div className="flex gap-3 items-start">
+                              <Avatar name={user?.name} size="sm" className="mt-1" />
+                              <div className="flex-1 min-w-0">
+                                <textarea
+                                  value={commentText}
+                                  onChange={(e) => setCommentText(e.target.value)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                      e.preventDefault();
+                                      if (commentText.trim() && !commentLoading) {
+                                        handleCommentSubmit(e as unknown as React.FormEvent);
+                                      }
                                     }
-                                  }
-                                }}
-                                rows={2}
-                                placeholder="Add a comment…"
-                                className="w-full rounded-xl border border-border bg-mist px-4 py-3 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card resize-none transition-all"
-                              />
-                              <div className="flex items-center justify-end mt-2">
-                                <Button type="submit" size="md" disabled={!commentText.trim() || commentLoading} loading={commentLoading}>
-                                  Post
-                                </Button>
+                                  }}
+                                  rows={2}
+                                  placeholder="Add a comment…"
+                                  className="w-full rounded-xl border border-border bg-mist px-4 py-3 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-accent/25 focus:bg-card resize-none transition-all"
+                                />
+                                <div className="flex items-center justify-end mt-2">
+                                  <Button type="submit" size="md" disabled={!commentText.trim() || commentLoading} loading={commentLoading}>
+                                    Post
+                                  </Button>
+                                </div>
                               </div>
                             </div>
-                          </div>
-                          {actionError && (
-                            <p className="text-danger text-xs mt-2 pl-10">{actionError}</p>
-                          )}
-                        </form>
+                            {actionError && (
+                              <p className="text-danger text-xs mt-2 pl-10">{actionError}</p>
+                            )}
+                          </form>
+                        )}
       </div>
     </div>
+    {showPromoteDialog && post && (
+      <PromoteToFaqDialog
+        post={post}
+        onClose={() => setShowPromoteDialog(false)}
+        onPromoted={(updatedPost) => {
+          setPost(updatedPost);
+        }}
+      />
+    )}
     </>
   );
 }

--- a/apps/frontend/src/components/faq/faqUtils.tsx
+++ b/apps/frontend/src/components/faq/faqUtils.tsx
@@ -353,13 +353,8 @@ export const getCategoryIndex = (name: string = ''): string => {
 export const applyQuestionNumbers = (grouped: Record<string, FAQItem[]>): Record<string, FAQItem[]> => {
   const result: Record<string, FAQItem[]> = {};
   
-  // Sort category names to determine their 1, 2, 3... index
-  const sortedCategories = Object.keys(grouped).sort((a, b) => {
-    const an = Number(a.match(/^\s*(\d+)/)?.[1] ?? '0');
-    const bn = Number(b.match(/^\s*(\d+)/)?.[1] ?? '0');
-    if (an !== bn) return an - bn;
-    return a.localeCompare(b);
-  });
+  // Sort category names alphabetically (A-Z)
+  const sortedCategories = Object.keys(grouped).sort((a, b) => a.localeCompare(b));
 
   sortedCategories.forEach((catName, catIndex) => {
     const items = grouped[catName];

--- a/apps/frontend/src/pages/FAQPage.tsx
+++ b/apps/frontend/src/pages/FAQPage.tsx
@@ -109,11 +109,7 @@ export default function FAQPage() {
 
   // ── Derived data ─────────────────────────────────────────────────────────
   const categories = useMemo(() => Object.keys(grouped).sort((a, b) => {
-    // Order by the dynamic categoryNumber assigned in applyQuestionNumbers
-    // so the 1, 2, 3… labels stay in sync with display order.
-    const an = grouped[a]?.[0]?.categoryNumber ?? 0;
-    const bn = grouped[b]?.[0]?.categoryNumber ?? 0;
-    return an - bn;
+    return a.localeCompare(b);
   }), [grouped]);
 
   const flatQuestions = useMemo(() => (

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -437,10 +437,7 @@ export default function HomePage() {
   // Order by FAQ count (desc), tie-break alphabetically — matches the
   // discovery layout where the busiest categories surface first.
   const categories = useMemo(() => (
-    Object.keys(grouped).sort((a, b) => {
-      const diff = (grouped[b]?.length ?? 0) - (grouped[a]?.length ?? 0);
-      return diff !== 0 ? diff : a.localeCompare(b);
-    })
+    Object.keys(grouped).sort((a, b) => a.localeCompare(b))
   ), [grouped]);
 
   const flatQuestions = useMemo(() => (

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -291,6 +291,14 @@ api.interceptors.response.use(
       }
     }
 
+    if (error.response && (error.response.status === 404 || error.response.status === 410)) {
+      const msg = (error.response.data as { message?: string })?.message;
+      if (msg === 'Program not found.' || msg === 'Program is archived or completed.') {
+        localStorage.removeItem('yaksha_active_program_id');
+        localStorage.removeItem('yaksha_active_batch_id');
+      }
+    }
+
     if (error.response && error.response.status === 401) {
       // If the failed request was a refresh token request itself, abort immediately.
       if (config && config.url && (config.url.endsWith('/auth/refresh') || config.url.includes('/auth/refresh'))) {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -24,7 +24,7 @@ function csfaqBaseRedirect(): Plugin {
     name: 'csfaq-base-redirect',
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (req.url === '/csfaq') {
+        if (req.url === '/' || req.url === '' || req.url === '/csfaq') {
           res.writeHead(308, { Location: '/csfaq/' });
           res.end();
           return;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "turbo dev",
+    "dev:local": "tsx scripts/dev-local.ts",
     "dev:backend": "turbo dev --filter=yaksha-faq-backend",
     "dev:frontend": "turbo dev --filter=yaksha-faq-frontend",
     "build": "turbo build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       nodemon:
         specifier: ^3.0.2
         version: 3.1.14
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
       tsx:
         specifier: ^4.22.3
         version: 4.22.4
@@ -1753,10 +1756,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3450,9 +3455,19 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   playwright@1.61.0:
     resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   postcss-import@15.1.0:
@@ -7326,9 +7341,17 @@ snapshots:
 
   playwright-core@1.61.0: {}
 
+  playwright-core@1.62.1: {}
+
   playwright@1.61.0:
     dependencies:
       playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -1,0 +1,178 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { spawn, ChildProcess } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import net from 'net';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const backendDir = path.join(rootDir, 'apps/backend');
+const frontendDir = path.join(rootDir, 'apps/frontend');
+
+const tsxCli = path.join(rootDir, 'node_modules/tsx/dist/cli.mjs');
+const viteCli = path.join(frontendDir, 'node_modules/vite/bin/vite.js');
+
+// Helper to check if a TCP port is open
+const isPortOpen = (port: number): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(1000);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('error', () => {
+      resolve(false);
+    });
+    socket.connect(port, '127.0.0.1');
+  });
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitForPort = async (port: number, timeoutMs = 30000): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const up = await isPortOpen(port);
+    if (up) return;
+    await delay(1000);
+  }
+  console.warn(`  ⚠ Note: Port ${port} connection probe timed out, continuing...`);
+};
+
+const main = async () => {
+  let mongod: MongoMemoryServer | null = null;
+  let backendProcess: ChildProcess | null = null;
+  let frontendProcess: ChildProcess | null = null;
+
+  const cleanup = async () => {
+    console.log('\n[Dev Orchestrator] Stopping servers...');
+    if (backendProcess) backendProcess.kill();
+    if (frontendProcess) frontendProcess.kill();
+    if (mongod) await mongod.stop();
+    console.log('[Dev Orchestrator] All processes stopped.');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  try {
+    console.log('\n============================================================');
+    console.log('  🚀 Yaksha FAQ Portal — One-Click Local Dev Server');
+    console.log('============================================================\n');
+
+    let mongoUri: string | undefined = undefined;
+
+    // Check if user set an external MongoDB URI in environment or .env.local
+    const backendLocalEnvPath = path.join(backendDir, '.env.local');
+    if (fs.existsSync(backendLocalEnvPath)) {
+      const content = fs.readFileSync(backendLocalEnvPath, 'utf-8');
+      const match = content.match(/^MONGODB_URI=(.*)$/m);
+      if (match && match[1] && (match[1].startsWith('mongodb://') || match[1].startsWith('mongodb+srv://'))) {
+        mongoUri = match[1].trim();
+      }
+    }
+
+    if (!mongoUri) {
+      console.log('[1/4] Starting local In-Memory MongoDB Server...');
+      mongod = await MongoMemoryServer.create();
+      mongoUri = mongod.getUri();
+      console.log(`  ✓ In-Memory MongoDB running at: ${mongoUri}`);
+    } else {
+      console.log(`[1/4] Using external MongoDB URI: ${mongoUri}`);
+    }
+
+    const env = {
+      ...process.env,
+      MONGODB_URI: mongoUri,
+      PORT: '6767',
+      JWT_SECRET: process.env.JWT_SECRET || 'supersecretjwtkeyforlocaldevelopmentyaksha32chars',
+      CLIENT_URL: 'http://localhost:5173',
+      NODE_ENV: 'development',
+    };
+
+    // Ensure .env in backend matches this runtime's database
+    const backendEnvPath = path.join(backendDir, '.env');
+    fs.writeFileSync(
+      backendEnvPath,
+      `PORT=6767\nNODE_ENV=development\nCLIENT_URL=http://localhost:5173\nJWT_SECRET=${env.JWT_SECRET}\nMONGODB_URI=${mongoUri}\n`
+    );
+
+    // Seed database
+    console.log('\n[2/4] Seeding initial data (users, FAQs, default batch)...');
+    const seedProcess = spawn(process.execPath, [tsxCli, 'src/scripts/seed.ts'], {
+      cwd: backendDir,
+      env,
+      stdio: 'inherit',
+    });
+
+    await new Promise<void>((resolve) => {
+      seedProcess.on('exit', (code) => {
+        if (code === 0) {
+          console.log('  ✓ Seeding completed successfully.');
+        } else {
+          console.log(`  ✓ Seeding finished (exit code ${code}).`);
+        }
+        resolve();
+      });
+      seedProcess.on('error', (err) => {
+        console.warn(`  ⚠ Seeding note: ${err.message}`);
+        resolve();
+      });
+    });
+
+    // Start Backend
+    console.log('\n[3/4] Starting Backend API server on http://localhost:6767...');
+    backendProcess = spawn(
+      process.execPath,
+      [tsxCli, 'watch', '--import', './src/instrument.ts', 'src/server.ts'],
+      {
+        cwd: backendDir,
+        env,
+        stdio: 'inherit',
+      }
+    );
+
+    // Start Frontend
+    console.log('\n[4/4] Starting Frontend Vite dev server on http://localhost:5173...');
+    frontendProcess = spawn(
+      process.execPath,
+      [viteCli, '--host', '127.0.0.1', '--port', '5173'],
+      {
+        cwd: frontendDir,
+        stdio: 'inherit',
+      }
+    );
+
+    console.log('\nWaiting for backend & frontend services to be ready...');
+    await Promise.all([
+      waitForPort(6767),
+      waitForPort(5173),
+    ]);
+
+    console.log('\n============================================================');
+    console.log('  ✨ Yaksha FAQ Portal is LIVE and Ready!');
+    console.log('============================================================');
+    console.log('  🌐 Public Website : http://localhost:5173/csfaq/');
+    console.log('  👤 User Login     : simranjitkaur16048@gmail.com');
+    console.log('     User Password  : password123');
+    console.log('  🛡️ Admin Login    : http://localhost:5173/csfaq/admin/login');
+    console.log('     Admin Email    : admin@yaksha.com');
+    console.log('     Admin Password : admin123');
+    console.log('  🔌 Backend API    : http://localhost:6767/csfaq/api');
+    console.log('============================================================\n');
+
+  } catch (error) {
+    console.error('\n❌ Startup Error:', error);
+    await cleanup();
+  }
+};
+
+main();


### PR DESCRIPTION
## What changed

Implemented a manual FAQ curation system that allows Admins and Mentors to review, edit, and categorize community questions before promoting them to the official FAQ page. To keep discussions clean, promoted threads are automatically locked, comments are disabled with a custom lock banner, and resolved posts are filtered out of the active student discussion feed.

Additionally, integrated dynamic alphabetical category sorting (A to Z) across the entire platform, enforced strict one-time vote limits on posts and comments with user alerts to prevent spamming, and updated duplicate check validation to inspect combined title and description text to allow generic question titles.

## Related issue

None

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [x] Frontend (React / Vite)
- [x] Admin / Train tab (`/admin/*`)
- [x] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

* **MongoDB In-Memory Dev Database**: Seeding is re-run at startup, and categories automatically sort dynamically from the database response.
* **Curation Category Mapping**: Added a custom `categoryId` query selector mapping during curation to prevent unlinked or orphaned FAQ structures.
* **One-Time Vote Locking**: Changed the voting endpoints to block repeat calls and return a `400 Bad Request` if a user has already cast their vote. Frontend components catch this to alert the user and rollback the optimistic state.