### PR TITLE
fix(config): throw typed EnvValidationError from validateEnv instead of process.exit

### DIFF
--- a/apps/backend/src/__tests__/server-boot.test.ts
+++ b/apps/backend/src/__tests__/server-boot.test.ts
@@ -1,0 +1,80 @@
+/**
+ * server-boot.test.ts — M7 boot-boundary contract.
+ *
+ * validateEnv() no longer calls process.exit(1) itself; it throws a typed
+ * EnvValidationError that server.ts catches at the boot boundary. This
+ * smoke test proves the user-visible contract is preserved: booting the
+ * real server with an invalid environment still terminates the process
+ * with exit code 1 and logs every validation failure.
+ *
+ * Runs the actual entrypoint (src/server.ts) in a child process via tsx,
+ * so nothing about the boot path is mocked.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const BACKEND_ROOT = path.resolve(__dirname, '../..');
+const TSX_BIN = path.join(BACKEND_ROOT, 'node_modules', '.bin', 'tsx');
+const SERVER_ENTRY = path.join(BACKEND_ROOT, 'src', 'server.ts');
+
+interface BootResult {
+  code: number;
+  output: string;
+}
+
+function bootServer(env: NodeJS.ProcessEnv): Promise<BootResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      TSX_BIN,
+      [SERVER_ENTRY],
+      { env, cwd: BACKEND_ROOT, timeout: 30_000 },
+      (error, stdout, stderr) => {
+        const output = `${stdout}\n${stderr}`;
+        if (!error) {
+          resolve({ code: 0, output });
+          return;
+        }
+        // execFile reports any non-zero exit as an "error". Distinguish
+        // the outcomes we care about explicitly:
+        //  - killed/timeout → the boot never terminated: fail loudly.
+        //  - string code (e.g. 'ENOENT') → spawn failure, not an exit
+        //    code: fail loudly with the real cause.
+        //  - numeric code → the child exited; that's the value under test.
+        if (error.killed || error.signal) {
+          reject(new Error(`server boot timed out or was killed (signal: ${error.signal ?? 'none'})\n${output}`));
+          return;
+        }
+        if (typeof error.code !== 'number') {
+          reject(new Error(`failed to spawn server process (${String(error.code)}): ${error.message}`));
+          return;
+        }
+        resolve({ code: error.code, output });
+      },
+    );
+  });
+}
+
+describe('server boot boundary — invalid env still prevents startup (M7)', () => {
+  beforeAll(() => {
+    // Fail with a clear message if the tsx binary is missing, instead of
+    // a confusing output-assertion failure inside the test itself.
+    if (!existsSync(TSX_BIN)) {
+      throw new Error(`tsx binary not found at ${TSX_BIN} — run pnpm install first`);
+    }
+  });
+
+  it('exits with code 1 and logs each validation error when required vars are missing', async () => {
+    const env: NodeJS.ProcessEnv = { ...process.env, NODE_ENV: 'test' };
+    delete env.MONGODB_URI;
+    delete env.JWT_SECRET;
+
+    const { code, output } = await bootServer(env);
+
+    expect(code).toBe(1);
+    expect(output).toContain('Environment validation failed:');
+    expect(output).toContain('MONGODB_URI is required');
+    expect(output).toContain('JWT_SECRET is required');
+  }, 60_000);
+});

--- a/apps/backend/src/config/__tests__/envValidator.test.ts
+++ b/apps/backend/src/config/__tests__/envValidator.test.ts
@@ -1,0 +1,133 @@
+/**
+ * envValidator.ts — M7 fix tests.
+ *
+ * validateEnv() used to call process.exit(1) on failure, which made it
+ * untestable (a failing validation killed the test runner). It now throws
+ * a typed EnvValidationError carrying every individual failure message.
+ *
+ * Covers: missing/malformed MONGODB_URI, missing/short JWT_SECRET,
+ *         non-numeric PORT, multiple errors aggregated, valid env passes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { validateEnv, EnvValidationError } from '../envValidator.js';
+
+const MANAGED_KEYS = ['MONGODB_URI', 'JWT_SECRET', 'PORT', 'NODE_ENV'] as const;
+
+describe('validateEnv() — typed error instead of process.exit (M7)', () => {
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of MANAGED_KEYS) original[key] = process.env[key];
+
+    // Baseline valid environment. NODE_ENV stays non-production so the
+    // optional checks (GCS etc.) warn instead of erroring.
+    process.env.NODE_ENV = 'test';
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/csfaq-test';
+    process.env.JWT_SECRET = 'a-test-secret-that-is-at-least-32-chars!';
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    for (const key of MANAGED_KEYS) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  });
+
+  it('rejects a missing MONGODB_URI', () => {
+    delete process.env.MONGODB_URI;
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain('MONGODB_URI is required');
+    }
+  });
+
+  it('rejects a malformed MONGODB_URI', () => {
+    process.env.MONGODB_URI = 'postgres://not-a-mongo-url';
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain(
+        'MONGODB_URI must be a mongodb:// or mongodb+srv:// URL',
+      );
+    }
+  });
+
+  it('rejects a missing JWT_SECRET', () => {
+    delete process.env.JWT_SECRET;
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain('JWT_SECRET is required');
+    }
+  });
+
+  it('rejects a JWT_SECRET shorter than 32 characters', () => {
+    process.env.JWT_SECRET = 'too-short';
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain(
+        'JWT_SECRET must be at least 32 characters',
+      );
+    }
+  });
+
+  it('rejects a non-numeric PORT', () => {
+    process.env.PORT = 'eighty-eighty';
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain('PORT must be numeric');
+    }
+  });
+
+  it('aggregates every failure into one error', () => {
+    delete process.env.MONGODB_URI;
+    process.env.JWT_SECRET = 'short';
+    process.env.PORT = 'abc';
+
+    try {
+      validateEnv();
+      expect.unreachable('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      const { errors, message } = err as EnvValidationError;
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          'MONGODB_URI is required',
+          'JWT_SECRET must be at least 32 characters',
+          'PORT must be numeric',
+        ]),
+      );
+      // The message is a single readable summary of all failures.
+      expect(message).toContain('Environment validation failed');
+      expect(message).toContain('MONGODB_URI is required');
+    }
+  });
+
+  it('accepts a valid environment without throwing', () => {
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  it('accepts a numeric PORT', () => {
+    process.env.PORT = '6767';
+    expect(() => validateEnv()).not.toThrow();
+  });
+});

--- a/apps/backend/src/config/envValidator.ts
+++ b/apps/backend/src/config/envValidator.ts
@@ -1,6 +1,27 @@
 import { logger } from '../utils/http/logger.js';
 import { getGcsConfig } from '../integrations/gcs/gcs.js';
 
+/**
+ * EnvValidationError — thrown by validateEnv() when the environment is
+ * invalid (missing/malformed required variables).
+ *
+ * M7 fix: validateEnv() used to call process.exit(1) directly, which made
+ * it impossible to unit-test (a failing validation killed the test runner)
+ * and unsafe to call from any context other than process boot. The
+ * validator now reports failures through this typed error and the boot
+ * boundary (server.ts) decides whether to terminate the process.
+ */
+export class EnvValidationError extends Error {
+  /** Individual validation failure messages, one per problem found. */
+  public readonly errors: string[];
+
+  constructor(errors: string[]) {
+    super(`Environment validation failed: ${errors.join('; ')}`);
+    this.name = 'EnvValidationError';
+    this.errors = errors;
+  }
+}
+
 export function validateEnv(): void {
   const errors: string[] = [];
 
@@ -110,9 +131,10 @@ export function validateEnv(): void {
   }
 
   if (errors.length > 0) {
-    logger.error('Environment validation failed:');
-    errors.forEach(e => logger.error(`  - ${e}`));
-    process.exit(1);
+    // M7 fix: throw instead of process.exit(1). The caller at the boot
+    // boundary (server.ts) logs the errors and exits; everywhere else
+    // (tests, tooling) gets a catchable, inspectable error.
+    throw new EnvValidationError(errors);
   }
 
   // v1.71 — Soft warning when no Redis TCP URL is configured in prod.

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,5 +1,5 @@
 import './env.js';
-import { validateEnv } from './config/envValidator.js';
+import { validateEnv, EnvValidationError } from './config/envValidator.js';
 import { loadConfig } from './config/loader.js';
 import { createApp } from './bootstrap/app.js';
 import { startup, stopAllSchedulers } from './bootstrap/startup.js';
@@ -7,8 +7,21 @@ import { startupLog, shutdownLog, logger } from './utils/http/logger.js';
 import * as Sentry from '@sentry/node';
 import type { Server } from 'http';
 
-// Validate environment variables first
-validateEnv();
+// Validate environment variables first. validateEnv() throws a typed
+// EnvValidationError on failure (M7) — the decision to terminate the
+// process belongs here at the boot boundary, not inside the validator.
+try {
+  validateEnv();
+} catch (err) {
+  // The name check guards against dual module instances (ESM/CJS interop
+  // or bundler duplication), where `instanceof` can fail across copies.
+  if (err instanceof EnvValidationError || (err as Error)?.name === 'EnvValidationError') {
+    logger.error('Environment validation failed:');
+    ((err as EnvValidationError).errors ?? []).forEach((e) => logger.error(`  - ${e}`));
+    process.exit(1);
+  }
+  throw err;
+}
 
 const config = loadConfig();
 const app = createApp(config);


### PR DESCRIPTION
## What changed

`validateEnv()` no longer calls `process.exit(1)` inline on validation failure (finding **M7** in `docs/ISSUES.md`). It now throws a typed `EnvValidationError` carrying every individual failure message in an `errors: string[]` payload. The boot boundary in `server.ts` catches this error, logs each failure in the exact same format as before, and exits with code 1 so the decision to terminate the process is owned by the entrypoint, not by a validation helper. This makes the validator unit-testable (previously any failing test killed the test runner) and safe for future non-boot callers. Boot behaviour is unchanged and proven by a new smoke test that runs the real entrypoint with an invalid environment and asserts exit code 1.

## Related issue

Closes #227

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [x] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification

- [x] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` all tests pass *(6 pre-existing failures on `main`, unrelated details below)*
- [x] `cd apps/frontend && npx tsc --noEmit` exits 0
- [x] `cd apps/frontend && npx vitest run` all tests pass
- [ ] `pnpm run lint` 0 errors *(1 pre-existing error on `main`, unrelated details below)*
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed *(booted the real server with missing env vars: exits 1 with identical error output)*
- [x] Tests added or updated for the change
- [x] Single logical change unrelated fixes noted in description, not fixed here
- [x] Docs updated if route / API / env var / pipeline behaviour changed *(no route/API/env var behaviour changed)*
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer

**Behaviour contract (unchanged):** an invalid environment still prevents startup with exit code 1 and identical log output (`Environment validation failed:` + one `  - <error>` line each). This is verified end-to-end by `src/__tests__/server-boot.test.ts`, which spawns the real `src/server.ts` via tsx with `MONGODB_URI`/`JWT_SECRET` removed nothing mocked.

**API change (intentional):** any *future* caller of `validateEnv()` now receives a catchable `EnvValidationError` instead of having its process killed. `server.ts` is currently the only caller.

**Tests added (9):** `src/config/__tests__/envValidator.test.ts` - missing/malformed `MONGODB_URI`, missing/short `JWT_SECRET`, non-numeric `PORT`, multiple failures aggregated into one error, valid env passes (8 tests). `src/__tests__/server-boot.test.ts` — boot-boundary smoke test (1 test).

**Deliberately untested:** the two-line rethrow of non-`EnvValidationError` exceptions in `server.ts`. Covering it would require fault-injection hooks in the validator, which conflicts with keeping this a single minimal change.

**Pre-existing failures on `main` (not caused by this PR):**
- `src/__tests__/journey-tracks.test.ts` - 6 tests fail on a pristine clone of `main` (500 vs expected 200/404/400). Verified identical before/after this change.
- `pnpm run lint` 1 pre-existing error on `main` (`no-constant-condition` in `src/modules/ai/ai-client.service.ts:623`). The four files in this PR lint with 0 errors and 0 warnings.