### PR TITLE
Queue/shedulerarea fix

### DIFF
--- a/apps/backend/src/queue/__tests__/queue.service.test.ts
+++ b/apps/backend/src/queue/__tests__/queue.service.test.ts
@@ -111,6 +111,33 @@ describe('queue.service — stale lease recovery', () => {
     expect(String(nowClaimable!._id)).toBe(String(claimed!._id));
     expect(nowClaimable!.attempts).toBe(2);
   });
+
+  it('terminates a stale job instead of requeueing once maxAttempts is exhausted (poison-pill regression)', async () => {
+    // maxAttempts: 1 — the very first claim already uses the last attempt.
+    await enqueue('document-processing', { crashesWorker: true }, { maxAttempts: 1 });
+
+    // Simulate a worker that crashed hard (no caught error, so fail()
+    // never ran) by claiming the job then pushing its lease into the past.
+    const claimed = await claimNextJob('document-processing', 'crash-prone-worker');
+    expect(claimed).toBeTruthy();
+    expect(claimed!.attempts).toBe(1); // == maxAttempts already
+    await mongoose.connection.db!.collection('yaksha_faq_jobs').updateOne(
+      { _id: claimed!._id },
+      { $set: { lockedUntil: new Date(Date.now() - 60_000) } },
+    );
+
+    const touched = await recoverStaleLeases();
+    expect(touched).toBe(1);
+
+    // Before the fix, this job would have been silently reset to
+    // 'queued' and could be claimed — and crash a worker — forever.
+    const final = await mongoose.connection.db!.collection('yaksha_faq_jobs').findOne({ _id: claimed!._id });
+    expect(final?.status).toBe('failed');
+    expect(final?.error).toMatch(/max attempts/i);
+
+    const claimAfterRecovery = await claimNextJob('document-processing', 'another-worker');
+    expect(claimAfterRecovery).toBeNull();
+  });
 });
 
 describe('queue.service — concurrency safety', () => {

--- a/apps/backend/src/queue/job.model.ts
+++ b/apps/backend/src/queue/job.model.ts
@@ -8,9 +8,17 @@
  * State machine:
  *   queued ──claimNextJob──> processing ──complete──> completed
  *      │                          │
- *      │                          └─fail──> queued (if attempts < max)
- *      │                                  └─fail──> failed
+ *      │                          ├─fail──> queued (if attempts < max)
+ *      │                          │      └─> failed
+ *      │                          └─lease expiry (recoverStaleLeases)──> queued (if attempts < max)
+ *      │                                                              └─> failed (if attempts >= max)
  *      └─cancel──> cancelled
+ *
+ * A stale lease means the worker holding the job stopped renewing it —
+ * usually a hard crash rather than a caught error, so `fail()` (which
+ * enforces `maxAttempts`) never ran. `recoverStaleLeases()` enforces the
+ * same cap on that path so a payload that repeatedly crashes a worker
+ * can't loop forever.
  *
  * Lease / heartbeat:
  *   - `lockedUntil` is set on claim; another worker can claim after

--- a/apps/backend/src/queue/queue.service.ts
+++ b/apps/backend/src/queue/queue.service.ts
@@ -285,13 +285,48 @@ export async function getStats(type?: JobType): Promise<{
 
 /**
  * Recover jobs whose lease expired while a worker was alive but wedged.
- * Returns the number of jobs that were reset to queued. Safe to call
- * periodically (e.g. every minute from a setInterval).
+ * Returns the number of jobs that were touched (requeued + terminated).
+ * Safe to call periodically (e.g. every minute from a setInterval).
+ *
+ * Bug fix: this previously reset EVERY stale `processing` job straight
+ * back to `queued`, with no check against `maxAttempts`. `fail()` is the
+ * only other place that enforces the attempts cap, but `fail()` only
+ * runs when the worker *catches* an error. A payload that crashes the
+ * worker outright (uncaught exception, OOM, `kill -9`) never reaches
+ * `fail()` — the stale lease is the only signal left, and this sweeper
+ * was putting such jobs back in the queue unconditionally. That let a
+ * single "poison pill" job crash a worker, get reclaimed, crash another
+ * worker, and repeat indefinitely — silently bypassing `maxAttempts`.
+ * Jobs that already used their last attempt are now terminated here
+ * instead, matching the same cap `fail()` enforces on the normal path.
  */
 export async function recoverStaleLeases(): Promise<number> {
   const now = new Date();
-  const res = await Job.updateMany(
-    { status: 'processing', lockedUntil: { $lte: now } },
+
+  const exhausted = await Job.updateMany(
+    {
+      status: 'processing',
+      lockedUntil: { $lte: now },
+      $expr: { $gte: ['$attempts', '$maxAttempts'] },
+    },
+    {
+      $set: {
+        status: 'failed',
+        completedAt: now,
+        lockedUntil: null,
+        workerId: null,
+        error: 'lease expired after max attempts — worker likely crashed without a graceful failure',
+        updatedAt: now,
+      },
+    },
+  );
+
+  const requeued = await Job.updateMany(
+    {
+      status: 'processing',
+      lockedUntil: { $lte: now },
+      $expr: { $lt: ['$attempts', '$maxAttempts'] },
+    },
     {
       $set: {
         status: 'queued',
@@ -301,10 +336,14 @@ export async function recoverStaleLeases(): Promise<number> {
       },
     },
   );
-  if (res.modifiedCount > 0) {
-    logger.warn(`[queue] recovered ${res.modifiedCount} stale-lease job(s)`);
+
+  if (exhausted.modifiedCount > 0) {
+    logger.error(`[queue] ${exhausted.modifiedCount} stale-lease job(s) exhausted max attempts — marked failed instead of requeued`);
   }
-  return res.modifiedCount;
+  if (requeued.modifiedCount > 0) {
+    logger.warn(`[queue] recovered ${requeued.modifiedCount} stale-lease job(s)`);
+  }
+  return exhausted.modifiedCount + requeued.modifiedCount;
 }
 
 /**

--- a/docs/queue-fix.md
+++ b/docs/queue-fix.md
@@ -1,0 +1,147 @@
+# Queue Fix: Stale-Lease Recovery Bypassed `maxAttempts`
+
+**File changed:** `apps/backend/src/queue/queue.service.ts`
+**Also touched:** `apps/backend/src/queue/job.model.ts` (docs only), `apps/backend/src/queue/__tests__/queue.service.test.ts` (new regression test)
+**Area:** Backend / Queue infra
+**Type:** Bug fix
+
+---
+
+## The Problem
+
+The queue's documented state machine (in `job.model.ts`) says a job can
+only go from `processing` back to `queued` a bounded number of times —
+`fail()` enforces this by checking `attempts < maxAttempts` before
+requeueing, and marks the job `failed` once that cap is hit.
+
+But `fail()` only runs when the worker **catches** an error. If a job's
+payload crashes the worker outright — an uncaught exception, an OOM, the
+process getting killed — `fail()` never executes. The only backstop for
+that case is `recoverStaleLeases()`, a sweeper that runs every 60 seconds
+and resets any `processing` job whose lease expired (meaning nobody is
+still renewing it — the worker is gone).
+
+That sweeper had no `maxAttempts` check at all:
+
+```ts
+export async function recoverStaleLeases(): Promise<number> {
+  const now = new Date();
+  const res = await Job.updateMany(
+    { status: 'processing', lockedUntil: { $lte: now } },
+    { $set: { status: 'queued', workerId: null, updatedAt: now, runAfter: now } },
+  );
+  ...
+}
+```
+
+**Consequence:** a single "poison pill" job — one whose payload reliably
+crashes whatever worker processes it — could crash a worker, get
+reclaimed by the sweeper, get claimed by a fresh worker, crash it too,
+and repeat **indefinitely**. The `maxAttempts` cap that's supposed to
+stop retry storms was silently bypassed on this specific failure path.
+
+---
+
+## The Fix
+
+`recoverStaleLeases()` now splits stale jobs into two groups using a
+`$expr` comparison between `attempts` and `maxAttempts` (both fields on
+the same document):
+
+```ts
+export async function recoverStaleLeases(): Promise<number> {
+  const now = new Date();
+
+  const exhausted = await Job.updateMany(
+    {
+      status: 'processing',
+      lockedUntil: { $lte: now },
+      $expr: { $gte: ['$attempts', '$maxAttempts'] },
+    },
+    {
+      $set: {
+        status: 'failed',
+        completedAt: now,
+        lockedUntil: null,
+        workerId: null,
+        error: 'lease expired after max attempts — worker likely crashed without a graceful failure',
+        updatedAt: now,
+      },
+    },
+  );
+
+  const requeued = await Job.updateMany(
+    {
+      status: 'processing',
+      lockedUntil: { $lte: now },
+      $expr: { $lt: ['$attempts', '$maxAttempts'] },
+    },
+    { $set: { status: 'queued', workerId: null, updatedAt: now, runAfter: now } },
+  );
+
+  return exhausted.modifiedCount + requeued.modifiedCount;
+}
+```
+
+- Jobs that still have attempts remaining behave exactly as before —
+  requeued, immediately claimable.
+- Jobs that already used their last attempt are now marked `failed`
+  instead of going back to `queued`, with an error message explaining
+  why (so it's distinguishable from a normal `fail()`-terminated job in
+  logs/admin dashboard).
+
+Also updated the state-machine comment in `job.model.ts` to document
+the lease-expiry transition, which wasn't previously described at all.
+
+---
+
+## Why This Matters in Practice
+
+- **Before:** a bad payload could put a worker into a crash loop
+  forever, continuously consuming worker capacity and never surfacing
+  as a clearly "failed" job — it would just keep cycling through
+  `processing → (crash) → queued → processing → ...`.
+- **After:** the same payload fails at most `maxAttempts` times total
+  (matching the cap that already applies to every other failure path)
+  and then sits in `failed` where it's visible in the admin queue
+  dashboard (`GET /admin/queue/stats`, `GET /admin/queue/jobs/:id`) for
+  investigation.
+
+---
+
+## Verification
+
+- `tsc --noEmit` on the backend — clean, no new type errors.
+- Traced the existing "stale lease recovery" test by hand: it uses
+  default `maxAttempts: 3` with `attempts: 1` at time of lease expiry,
+  which falls into the "requeue" branch — unaffected by the fix,
+  `recovered === 1` still holds.
+- **Added a new regression test** (`poison-pill regression`, in
+  `queue.service.test.ts`) that enqueues a job with `maxAttempts: 1`,
+  claims it (using its only attempt), simulates a crashed worker by
+  expiring its lease, and asserts:
+  - `recoverStaleLeases()` marks it `failed`, not `queued`
+  - the error message mentions "max attempts"
+  - no worker can claim it afterward
+
+**Note:** I could not execute the test suite in this sandbox —
+`mongodb-memory-server` needs to download a real MongoDB binary from
+`fastdl.mongodb.org`, which isn't reachable from this environment. Please
+run it yourself before merging:
+
+```bash
+cd apps/backend
+npx vitest run src/queue/__tests__/queue.service.test.ts
+```
+
+All 7 existing test cases plus the 1 new one should pass. If anything
+fails, share the output and we'll fix it before you commit.
+
+---
+
+## Scope
+
+Three files touched, all inside the queue module:
+- `apps/backend/src/queue/queue.service.ts` — the actual fix
+- `apps/backend/src/queue/job.model.ts` — comment/documentation only, no behavior change
+- `apps/backend/src/queue/__tests__/queue.service.test.ts` — one new test added, nothing removed or changed


### PR DESCRIPTION
## What changed

Fixed a bug in recoverStaleLeases() (apps/backend/src/queue/queue.service.ts) where jobs whose worker lease expired were unconditionally reset to 'queued', with no check against maxAttempts. fail() enforces that cap, but only runs when a worker catches an error — a payload that crashes the worker outright (uncaught exception, OOM, kill) never reaches fail(), so recoverStaleLeases() was the only backstop, and it bypassed the cap entirely. A single "poison pill" job could crash a worker, get reclaimed, crash another worker, and repeat indefinitely.

recoverStaleLeases() now splits stale jobs into two groups using a $expr comparison between attempts and maxAttempts: jobs with attempts remaining are requeued as before, and jobs that already used their last attempt are now marked 'failed' with a clear error message, matching what fail() would have done.

Also updated the state-machine comment in job.model.ts to document the lease-expiry transition (previously undocumented), and added a regression test simulating the poison-pill scenario.

## Related issue

<!--
Closes #ISSUE-NUMBER
Refs #ISSUE-NUMBER (if partial)
-->

## Type of change

- [ ☑] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected

- [ ☑] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ☑] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [☑ ] Docs

## CI verification

- [ ] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [ ] `cd apps/frontend && npx tsc --noEmit` exits 0
- [ ] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [ ] Tested with a real API hit or browser interaction if behaviour changed
- [ ] Tests added or updated for the change
- [ ] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [ ] Rebased onto `main`, no merge commits

## Notes for reviewer

Regression test added specifically for this fix: "poison-pill regression" in queue.service.test.ts, simulating a worker that crashes (not a caught error) after using its last attempt. Could not run the test suite in my dev sandbox (no network access to mongodb-memory-server's binary download) — please confirm it passes in your environment before merging.
