### PR TITLE
fix(admin): persist FAQ content edits in updateFAQ

### DIFF
--- a/apps/backend/src/modules/admin/admin.controller.ts
+++ b/apps/backend/src/modules/admin/admin.controller.ts
@@ -388,24 +388,31 @@ export const updateFAQ = async (req: Request, res: Response): Promise<void> => {
       }
     }
 
+    // Build the $set payload with the content fields that were modified above
+    const setPayload: Record<string, unknown> = {
+      reports: [],
+    };
+    if (question) setPayload.question = faq.question;
+    if (answer) setPayload.answer = faq.answer;
+    if (category) setPayload.category = faq.category;
+    if (status) setPayload.status = faq.status;
+    if (tags) setPayload.tags = faq.tags;
+    if (faq.embedding) setPayload.embedding = faq.embedding;
+
     // Admin edit while under review = re-verification
     if (faq.reviewStatus === 'pending_review' || faq.reviewStatus === 'update_requested') {
-      // v1.68 — H3 fix: in-memory mutate + save() is racy.
-      // Wrap as a single atomic $set on the fields the
-      // pending-review branch touches. (reports=[] is set
-      // whether verify is true or not — the original "else"
-      // branch handled the !verify case by just clearing reports.)
       const newCycle = faq.reviewCycle + 1;
-      await FAQ.findOneAndUpdate(
-        { _id: faq._id },
-        { $set: { reports: [], lastVerifiedDate: new Date(), flaggedAt: null, flagType: null, flagReason: null, flaggedBy: null, reviewCycle: newCycle } },
-      );
+      setPayload.lastVerifiedDate = new Date();
+      setPayload.flaggedAt = null;
+      setPayload.flagType = null;
+      setPayload.flagReason = null;
+      setPayload.flaggedBy = null;
+      setPayload.reviewCycle = newCycle;
+      setPayload.reviewStatus = 'verified';
+      await FAQ.findOneAndUpdate({ _id: faq._id }, { $set: setPayload });
       await FreshReviewVote.deleteMany({ faqId: faq._id });
     } else {
-      await FAQ.findOneAndUpdate(
-        { _id: faq._id },
-        { $set: { reports: [] } },
-      );
+      await FAQ.findOneAndUpdate({ _id: faq._id }, { $set: setPayload });
     }
     await logAction(req.user!._id.toString(), 'edit_faq', faq._id.toString(), 'faq', faq.question);
 


### PR DESCRIPTION
## Summary

Fixes the admin FAQ update endpoint (`PUT /admin/faq/:id`) so that content edits are **actually persisted**.

## Problem

In `apps/backend/src/modules/admin/admin.controller.ts`, the `updateFAQ` handler mutated FAQ fields in memory (`question`, `answer`, `category`, `status`, `tags`, `embedding`), but the subsequent `findOneAndUpdate` only set `reports: []`. All content changes were silently dropped — the API returned a 200 with the in-memory mutated doc, but MongoDB was never updated.

## Fix

Build a `$set` payload including **all** modified content fields:

- `question`, `answer`, `category`, `status`, `tags`, `embedding`
- when under review: also `lastVerifiedDate`, `flaggedAt`, `flagType`, `flagReason`, `flaggedBy`, `reviewCycle`, `reviewStatus`
- always `reports: []`

The `pending_review`/`update_requested` branch and the plain-edit branch now both use this single payload in one atomic `findOneAndUpdate`.

## Why it matters

During a related bulk FAQ upload task, admins observed that `PUT /admin/faq/:id` returned success but edits did not persist. This was traced to the missing fields in the `$set` — delete+recreate had to be used as a workaround. This PR removes the need for that workaround.

## Testing

- Verified against the code path: normal edit persists content fields; review-branch edit clears reports and bumps the review cycle.
- Existing test suites (backend vitest) unaffected by the change.