### PR TITLE
fix(admin): scope FAQ review queue to active program

### DIFF
--- a/apps/backend/src/modules/program/promotion.service.ts
+++ b/apps/backend/src/modules/program/promotion.service.ts
@@ -632,11 +632,20 @@ export async function getPromotionQueue(req: Request, res: Response): Promise<vo
     const page = Math.max(1, parseInt(String(req.query.page ?? '1')));
     const limit = Math.min(50, Math.max(1, parseInt(String(req.query.limit ?? '20'))));
 
+    // The review actions on this queue (verify / promote / merge) all gate on
+    // assertSameProgram, so listing cross-program items just yields a 404 on
+    // click. Scope the queue to the active program only.
+    const batchId = req.programContext?.batchId;
+    const scopedByBatch = (filter: Record<string, unknown>): Record<string, unknown> =>
+      batchId ? { ...filter, batchId } : filter;
+
     // 1. Fetch eligible community posts
-    const posts = await CommunityPost.find({
-      'lifecycle.status': { $in: ['ai_validated', 'community_accepted'] },
-      'lifecycle.communityAcceptedAt': { $ne: null },
-    })
+    const posts = await CommunityPost.find(
+      scopedByBatch({
+        'lifecycle.status': { $in: ['ai_validated', 'community_accepted'] },
+        'lifecycle.communityAcceptedAt': { $ne: null },
+      }),
+    )
       .populate('author', 'name')
       .select('-embedding');
 
@@ -664,9 +673,11 @@ export async function getPromotionQueue(req: Request, res: Response): Promise<vo
     });
 
     // 2. Fetch reported/flagged FAQs that need review
-    const reportedFaqs = await FAQ.find({
-      reviewStatus: { $in: ['pending_review', 'update_requested'] },
-    })
+    const reportedFaqs = await FAQ.find(
+      scopedByBatch({
+        reviewStatus: { $in: ['pending_review', 'update_requested'] },
+      }),
+    )
       .populate('createdBy', 'name')
       .select('-embedding')
       .lean();


### PR DESCRIPTION
## Problem

Verifying a reported/pending FAQ on the admin review page (\/admin/faqs/review\) fails with \404 Not Found\ on \PUT /api/admin/faq/:id\.

The button calls \updateFAQ\ (\pps/backend/src/modules/admin/admin.controller.ts:346\) which returns 404 when \ssertSameProgram\ (\pps/backend/src/utils/db/scopedQuery.ts:95\) finds the FAQ's \atchId\ differs from the active program in \?batchId\ / \x-program-id\.

## Root cause

\getPromotionQueue\ (\pps/backend/src/modules/program/promotion.service.ts:630\) builds the review queue **without any program filter** — it lists every \pending_review\ / \update_requested\ FAQ and eligible community post across *all* batches. The queue is meant to be per-program, but cross-program items appear. Clicking Verify then 404s because the item isn't part of the program you're scoped to.

## Fix

Scope the two queue queries in \getPromotionQueue\ to \eq.programContext.batchId\ (attached by the existing \programScope\ middleware from \?batchId\ or the \x-program-id\ header). Only items belonging to the active program are listed, so every verified/promoted/merged item passes \ssertSameProgram\.

## Verification

- \pnpm --filter yaksha-faq-backend typecheck\ passes
- \eslint apps/backend/src/modules/program/promotion.service.ts\ has no errors