### PR TITLE
fix: validateEnv() throws catchable EnvValidationError instead of process.exit(1)

### DIFF
--- a/apps/backend/src/config/__tests__/envValidator.test.ts
+++ b/apps/backend/src/config/__tests__/envValidator.test.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Tests for #232 — by Aswini Kumar Dhar
+//
+// WHAT THIS FILE PROVES: validateEnv() now throws a catchable
+// EnvValidationError instead of calling process.exit(1) directly, so it
+// can finally be unit-tested — which was impossible before this fix,
+// since calling validateEnv() with a broken environment used to kill the
+// entire Vitest process along with whatever else was running.
+// ─────────────────────────────────────────────────────────────────────────
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { validateEnv, EnvValidationError } from '../envValidator.js';
+import { logger } from '../../utils/http/logger.js';
+
+// validateEnv() reads process.env directly (no separate config-loading
+// step), so we snapshot and restore it around every test to avoid one
+// test's broken environment leaking into the next.
+const ORIGINAL_ENV = { ...process.env };
+
+describe('validateEnv (#232 — catchable EnvValidationError)', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    // Baseline valid environment — each test below breaks exactly one
+    // thing, so we know precisely which check fired.
+    process.env.MONGODB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/db';
+    process.env.JWT_SECRET = 'a'.repeat(32);
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when MONGODB_URI and JWT_SECRET are both valid', () => {
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  it('throws EnvValidationError (not process.exit) when MONGODB_URI is missing', () => {
+    delete process.env.MONGODB_URI;
+    expect(() => validateEnv()).toThrow(EnvValidationError);
+  });
+
+  it('includes the specific missing-var message in err.errors', () => {
+    delete process.env.MONGODB_URI;
+    try {
+      validateEnv();
+      expect.fail('validateEnv() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).errors).toContain('MONGODB_URI is required');
+    }
+  });
+
+  it('throws when JWT_SECRET is shorter than 32 characters', () => {
+    process.env.JWT_SECRET = 'too-short';
+    expect(() => validateEnv()).toThrow(EnvValidationError);
+  });
+
+  it('collects multiple errors in a single throw rather than failing fast', () => {
+    delete process.env.MONGODB_URI;
+    delete process.env.JWT_SECRET;
+    try {
+      validateEnv();
+      expect.fail('validateEnv() should have thrown');
+    } catch (err) {
+      const e = err as EnvValidationError;
+      expect(e.errors.length).toBeGreaterThanOrEqual(2);
+      expect(e.errors).toContain('MONGODB_URI is required');
+      expect(e.errors).toContain('JWT_SECRET is required');
+    }
+  });
+
+  // This is the exact scenario the issue was filed about: before this
+  // fix, this test would have killed the whole Vitest process instead of
+  // producing a clean pass/fail.
+  it('can be asserted with expect().toThrow() without killing the test runner', () => {
+    delete process.env.MONGODB_URI;
+    expect(() => validateEnv()).toThrow('MONGODB_URI is required');
+  });
+});
+
+// Mirrors the exact try/catch now living in server.ts, without importing
+// server.ts itself — server.ts has real side effects (app.listen(), a
+// live Mongo connection) at import time, which a unit test shouldn't
+// trigger just to check this one behavior.
+describe('boot-boundary behavior (mirrors server.ts)', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MONGODB_URI; // force a failure to exercise the catch path
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('logs each error line and exits with code 1 when validation fails', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      validateEnv();
+    } catch (err) {
+      if (err instanceof EnvValidationError) {
+        logger.error('Environment validation failed:');
+        err.errors.forEach((e) => logger.error(`  - ${e}`));
+        process.exit(1);
+      } else {
+        throw err;
+      }
+    }
+
+    expect(logger.error).toHaveBeenCalledWith('Environment validation failed:');
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('MONGODB_URI is required'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/backend/src/config/envValidator.ts
+++ b/apps/backend/src/config/envValidator.ts
@@ -1,6 +1,35 @@
 import { logger } from '../utils/http/logger.js';
 import { getGcsConfig } from '../integrations/gcs/gcs.js';
 
+// ─────────────────────────────────────────────────────────────────────────
+// Fix for #232 — by Aswini Kumar Dhar
+//
+// WHAT CHANGED: validateEnv() used to call process.exit(1) directly when
+// a required env var was missing/invalid. Now it throws this typed error
+// instead, and lets the caller decide what to do with it.
+//
+// WHY: process.exit(1) kills the entire process the instant it's called —
+// including the Vitest test runner, if a test tries to call validateEnv()
+// with a deliberately broken environment to check that it would fail.
+// There was no way to write a unit test for "does validateEnv() correctly
+// detect a missing MONGODB_URI" without the whole test suite dying along
+// with it. Throwing an error instead makes the failure catchable — tests
+// can assert on it normally with expect(...).toThrow(), and the real
+// server (server.ts) can still catch it and exit exactly as before.
+//
+// `errors` carries every individual problem found (e.g. both a missing
+// MONGODB_URI AND a too-short JWT_SECRET at once), so whoever catches this
+// can log each line separately, matching the old multi-line log output.
+// ─────────────────────────────────────────────────────────────────────────
+export class EnvValidationError extends Error {
+  public readonly errors: string[];
+  constructor(errors: string[]) {
+    super(`Environment validation failed:\n${errors.map((e) => `  - ${e}`).join('\n')}`);
+    this.name = 'EnvValidationError';
+    this.errors = errors;
+  }
+}
+
 export function validateEnv(): void {
   const errors: string[] = [];
 
@@ -109,10 +138,16 @@ export function validateEnv(): void {
     }
   }
 
+  // #232 — was: log every error here, then process.exit(1) right on the
+  // spot. 
+  // Now: just throw, and let server.ts (the actual process boot boundary)
+  // decide to log + exit. Same information either way — just
+  // handed off instead of acted on immediately.
   if (errors.length > 0) {
-    logger.error('Environment validation failed:');
-    errors.forEach(e => logger.error(`  - ${e}`));
-    process.exit(1);
+    // logger.error('Environment validation failed:');
+    // errors.forEach(e => logger.error(`  - ${e}`));
+    // process.exit(1);
+    throw new EnvValidationError(errors);
   }
 
   // v1.71 — Soft warning when no Redis TCP URL is configured in prod.

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,5 +1,5 @@
 import './env.js';
-import { validateEnv } from './config/envValidator.js';
+import { EnvValidationError, validateEnv } from './config/envValidator.js';
 import { loadConfig } from './config/loader.js';
 import { createApp } from './bootstrap/app.js';
 import { startup, stopAllSchedulers } from './bootstrap/startup.js';
@@ -7,8 +7,35 @@ import { startupLog, shutdownLog, logger } from './utils/http/logger.js';
 import * as Sentry from '@sentry/node';
 import type { Server } from 'http';
 
-// Validate environment variables first
-validateEnv();
+// ─────────────────────────────────────────────────────────────────────────
+// Fix for #232 — by Aswini Kumar Dhar
+//
+// WHAT CHANGED: validateEnv() no longer exits the process itself — it
+// throws EnvValidationError instead (see config/envValidator.ts). This
+// try/catch is the new home for the "log it, then exit(1)" behavior that
+// used to live inside validateEnv() directly.
+//
+// WHY HERE SPECIFICALLY: this is the real process boot boundary — the
+// point where, if the environment is broken, we actually want the whole
+// server process to stop. Putting the exit decision here (instead of
+// inside the validator) means validateEnv() can be called from anywhere
+// — including tests — without that call site accidentally taking down
+// the whole process.
+//
+// The log format and exit code (1) are unchanged from before this fix —
+// only *where* that logging happens has moved, not what it looks like.
+// ─────────────────────────────────────────────────────────────────────────
+
+try {
+  validateEnv();
+} catch (err) {
+  if (err instanceof EnvValidationError) {
+    logger.error('Environment validation failed:');
+    err.errors.forEach((e) => logger.error(`  - ${e}`));
+    process.exit(1);
+  }
+  throw err; // anything unexpected — don't swallow it silently
+}
 
 const config = loadConfig();
 const app = createApp(config);


### PR DESCRIPTION
## What changed
`validateEnv()` previously called `process.exit(1)` directly when required environment variables were missing or invalid. This made it impossible to unit-test the validator itself — calling it with a deliberately broken environment would kill the entire Vitest process instead of producing a normal pass/fail assertion.

- `validateEnv()` now throws a new `EnvValidationError` (with an `errors: string[]` field) instead of logging and exiting itself.
- `server.ts` — the actual process boot boundary — now wraps the call in a `try/catch`, logs each error line in the exact same format as before, and exits with code 1 there. End-user/production behavior is unchanged; only *where* the log-and-exit decision happens has moved.
- Adds `apps/backend/src/config/__tests__/envValidator.test.ts`, covering the missing-var cases, the multi-error case, and a boot-boundary test that mirrors `server.ts`'s catch logic.

## Related issue
Closes #232
Refs #227 (same underlying issue, reported separately)

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Docs / comments only
- [ ] CI / tooling

## Area affected
- [x] Backend (Express / Mongoose)
- [ ] Frontend (React / Vite)
- [ ] Admin / Train tab (`/admin/*`)
- [ ] Community (`/community` — posts, comments, auto-answer)
- [ ] Search (hybrid text retrieval, training stats)
- [ ] Auth / middleware / samagama.in bridge
- [ ] Crons / schedulers / embedding-warm
- [ ] Observability (Sentry / logging / Discord alerts)
- [ ] Docs

## CI verification
- [x] `cd apps/backend && npx tsc --noEmit` exits 0
- [ ] `cd apps/backend && npx vitest run` — all tests pass
- [x] `cd apps/frontend && npx tsc --noEmit` exits 0
- [x] `cd apps/frontend && npx vitest run` — all tests pass
- [ ] `pnpm run lint` — 0 errors (152 warnings is the baseline)
- [ ] GitHub Actions green on the merge commit (CI, CodeQL, Build & Deploy)
- [x] Tested with a real API hit or browser interaction if behaviour changed
- [x] Tests added or updated for the change
- [x] Single logical change — unrelated fixes noted in description, not fixed here
- [ ] Docs updated if route / API / env var / pipeline behaviour changed
- [x] Rebased onto `main`, no merge commits

## Notes for reviewer
This is purely an internal refactor of the boot-time validation path — no route, API contract, or env var *behavior* changed; only where the log-and-exit decision is made. Open to feedback on `EnvValidationError`'s shape (a class with an `errors: string[]` field) if there's a preferred convention elsewhere in the codebase.

Ran the full test/lint suite locally to check for regressions from this change specifically:

- `envValidator.test.ts` (this PR's new tests): 7/7 passing
- `backend.test.ts` (existing): 34/34 passing
- Frontend `tsc --noEmit`: clean, 0 errors
- Frontend `vitest run`: 132/132 passing
- Full backend `vitest run` did not complete cleanly in my local environment across two separate runs. One consistent, pre-existing failure: "Journey Tracks — user side" (6 tests) in `journey-tracks.test.ts`, unrelated to env validation. One intermittent failure in `golden-ticket-admin.reopen.test.ts` that passed clean on the second run (test-order-dependent, not a real regression). Both runs also ended in a Node segfault at a different point each time, always immediately after an `afterAll` hook — points to flaky async test teardown on Windows rather than anything in this diff. None of the affected tests touch `MONGODB_URI`, `JWT_SECRET`, `validateEnv`, or `server.ts`.
- `pnpm run lint`: 1 pre-existing error (`no-constant-condition`, `ai-client.service.ts`) and a warning count above the stated 152 baseline — both pre-existing on `main`, not introduced by this diff. None of this PR's 3 changed files appear anywhere in the lint output.